### PR TITLE
Fix get() in Red-Black and AVL trees.

### DIFF
--- a/drv/AVLTreeSet.drv
+++ b/drv/AVLTreeSet.drv
@@ -792,10 +792,10 @@ public class AVL_TREE_SET KEY_GENERIC extends ABSTRACT_SORTED_SET KEY_GENERIC im
 		return findKey( KEY_GENERIC_CAST k ) != null;
 	}
 
-#if #keysclass(Object)
+#if #keyclass(Object)
 	public K get( final KEY_TYPE k ) {
 		final Entry KEY_GENERIC entry = findKey( KEY_GENERIC_CAST k );
-		return entry == null ? null : entry.getKey();
+		return entry == null ? null : entry.key;
 	}
 #endif
 

--- a/drv/RBTreeSet.drv
+++ b/drv/RBTreeSet.drv
@@ -743,10 +743,10 @@ public class RB_TREE_SET KEY_GENERIC extends ABSTRACT_SORTED_SET KEY_GENERIC imp
 		return findKey( KEY_GENERIC_CAST k ) != null;
 	}
 
-#if #keysclass(Object)
+#if #keyclass(Object)
 	public K get( final KEY_TYPE k ) {
 		final Entry KEY_GENERIC entry = findKey( KEY_GENERIC_CAST k );
-		return entry == null ? null : entry.getKey();
+		return entry == null ? null : entry.key;
 	}
 #endif
 


### PR DESCRIPTION
Obvious typo s/keysclass/keyclass/ + getter does not exist, but is also not needed.