### PR TITLE
Add pop() operation to Set API, to pop elements from sets easily (UNTESTED).

### DIFF
--- a/drv/AVLTreeMap.drv
+++ b/drv/AVLTreeMap.drv
@@ -1319,6 +1319,14 @@ public class AVL_TREE_MAP KEY_VALUE_GENERIC extends ABSTRACT_SORTED_MAP  KEY_VAL
 					return f != null;
 				}
 
+				@SuppressWarnings("unchecked")
+				public MAP.Entry KEY_VALUE_GENERIC pop() {
+					if (lastEntry == null) { throw new NoSuchElementException(); }
+					BasicEntry KEY_VALUE_GENERIC e = new BasicEntry KEY_VALUE_GENERIC ( lastEntry.key, lastEntry.value );
+					AVL_TREE_MAP.this.REMOVE_VALUE( lastEntry.key );
+					return e;
+				}
+
 				public int size() { return count; }
 				public void clear() { AVL_TREE_MAP.this.clear(); }
 					 
@@ -1533,6 +1541,15 @@ public class AVL_TREE_MAP KEY_VALUE_GENERIC extends ABSTRACT_SORTED_MAP  KEY_VAL
 						final AVL_TREE_MAP.Entry KEY_VALUE_GENERIC f = findKey( KEY_CLASS2TYPE( e.getKey() ) );
 						if ( f != null && in( f.key ) ) Submap.this.REMOVE_VALUE( f.key );
 						return f != null;
+					}
+
+					@SuppressWarnings("unchecked")
+					public MAP.Entry KEY_VALUE_GENERIC pop() {
+						MAP.Entry KEY_VALUE_GENERIC l = lastEntry();
+						if (l == null) { throw new NoSuchElementException(); }
+						BasicEntry KEY_VALUE_GENERIC e = new BasicEntry KEY_VALUE_GENERIC ( l.ENTRY_GET_KEY(), l.ENTRY_GET_VALUE() );
+						AVL_TREE_MAP.this.REMOVE_VALUE( l.ENTRY_GET_KEY() );
+						return e;
 					}
 
 					public int size() {

--- a/drv/AVLTreeSet.drv
+++ b/drv/AVLTreeSet.drv
@@ -1052,6 +1052,12 @@ public class AVL_TREE_SET KEY_GENERIC extends ABSTRACT_SORTED_SET KEY_GENERIC im
 		return lastEntry.key;
 	}
 	 
+	public KEY_GENERIC_TYPE POP() {
+		if ( tree == null ) throw new NoSuchElementException();
+		KEY_GENERIC_TYPE k = lastEntry.key;
+		AVL_TREE_SET.this.remove( k );
+		return k;
+	}
 
 	/** An iterator on the whole range.
 	 *
@@ -1316,6 +1322,13 @@ public class AVL_TREE_SET KEY_GENERIC extends ABSTRACT_SORTED_SET KEY_GENERIC im
 			return e;
 		}
 
+		public KEY_GENERIC_TYPE POP() {
+			AVL_TREE_SET.Entry KEY_GENERIC e = lastEntry();
+			if ( e == null ) throw new NoSuchElementException();
+			KEY_GENERIC_TYPE k = e.key;
+			AVL_TREE_SET.this.remove( k );
+			return k;
+		}
 
 		public KEY_GENERIC_TYPE FIRST() {
 			AVL_TREE_SET.Entry KEY_GENERIC e = firstEntry();

--- a/drv/AbstractMap.drv
+++ b/drv/AbstractMap.drv
@@ -221,6 +221,12 @@ public abstract class ABSTRACT_MAP KEY_VALUE_GENERIC extends ABSTRACT_FUNCTION K
 							public boolean hasNext() { return i.hasNext(); }
 						};
 				}
+				public KEY_GENERIC_TYPE POP() {
+					final ObjectIterator<Map.Entry<KEY_GENERIC_CLASS,VALUE_GENERIC_CLASS>> i = entrySet().iterator();
+					KEY_GENERIC_CLASS k = ((MAP.Entry KEY_VALUE_GENERIC)i.next()).ENTRY_GET_KEY();
+					i.remove();
+					return k;
+				}
 			};
 	}
 

--- a/drv/AbstractSet.drv
+++ b/drv/AbstractSet.drv
@@ -78,5 +78,10 @@ public abstract class ABSTRACT_SET KEY_GENERIC extends ABSTRACT_COLLECTION KEY_G
 		return remove( KEY_OBJ2TYPE( o ) );
 	}
 
+	/** Delegates to the corresponding type-specific method. */
+	public KEY_GENERIC_CLASS pop() {
+		return KEY_CLASS.valueOf( POP() );
+	}
+
 #endif
 }

--- a/drv/AbstractSortedMap.drv
+++ b/drv/AbstractSortedMap.drv
@@ -111,6 +111,12 @@ public abstract class ABSTRACT_SORTED_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP
 		public KEY_BIDI_ITERATOR KEY_GENERIC iterator( final KEY_GENERIC_TYPE from ) { return new KeySetIterator KEY_VALUE_GENERIC( entrySet().iterator( new BasicEntry KEY_VALUE_GENERIC( from, VALUE_NULL ) ) ); }
 		public KEY_BIDI_ITERATOR KEY_GENERIC iterator() { return new KeySetIterator KEY_VALUE_GENERIC( entrySet().iterator() ); }
 
+		public KEY_GENERIC_TYPE POP() {
+			KEY_BIDI_ITERATOR i = new KeySetIterator KEY_VALUE_GENERIC( entrySet().iterator() );
+			KEY_GENERIC_TYPE k = KEY_GENERIC_CAST( i.NEXT_KEY() );
+			i.remove();
+			return k;
+		}
 
 	}
 	/** A wrapper exhibiting a map iterator as an iterator on keys.

--- a/drv/ArrayMap.drv
+++ b/drv/ArrayMap.drv
@@ -160,7 +160,12 @@ public class ARRAY_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENERIC 
 			final KEY_GENERIC_TYPE k = KEY_CLASS2TYPE( e.getKey() );
 			return ARRAY_MAP.this.containsKey( k ) && VALUE_EQUALS( ARRAY_MAP.this.GET_VALUE( k ), VALUE_CLASS2TYPE( e.getValue() ) );
 		}
-		
+
+		public MAP.Entry KEY_VALUE_GENERIC pop() {
+			if (size == 0) { throw new NoSuchElementException(); }
+			--size;
+			return new BasicEntry KEY_VALUE_GENERIC ( KEY_GENERIC_CAST key[ size ], VALUE_GENERIC_CAST value[ size ] );
+		}
 	}
 
 	public FastEntrySet KEY_VALUE_GENERIC ENTRYSET() {

--- a/drv/ArraySet.drv
+++ b/drv/ArraySet.drv
@@ -18,6 +18,7 @@
 package PACKAGE;
 
 import java.util.Collection;
+import java.util.NoSuchElementException;
 
 /** A simple, brute-force implementation of a set based on a backing array.
  *
@@ -132,6 +133,12 @@ public class ARRAY_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implements j
 		}
 		a[ size++ ] = k;
 		return true;
+	}
+
+	@Override
+	public KEY_GENERIC_TYPE POP() {
+		if (size == 0) { throw new NoSuchElementException(); }
+		return KEY_GENERIC_CAST(a[ --size ]);
 	}
 
 	@Override

--- a/drv/OpenHashBigSet.drv
+++ b/drv/OpenHashBigSet.drv
@@ -377,7 +377,29 @@ public class OPEN_HASH_BIG_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC impl
 			if ( KEY_EQUALS_NOT_NULL( curr, k ) ) return removeEntry( base, displ );
 		}
 	}
-	 
+
+	public KEY_GENERIC_TYPE POP() {
+		if ( containsNull ) {
+			removeNullEntry();
+			return KEY_NULL;
+		}
+		int base = key.length;
+		int displ = 0;
+		final KEY_GENERIC_TYPE key[][] = OPEN_HASH_BIG_SET.this.key;
+		for(;;) {
+			if ( displ == 0 && base <= 0 ) {
+				throw new NoSuchElementException();
+			}
+			if ( displ-- == 0 ) displ = key[ --base ].length - 1;
+
+			final KEY_GENERIC_TYPE k = key[ base ][ displ ];
+			if ( ! KEY_IS_NULL( k ) ) {
+				removeEntry( base, displ );
+				return k;
+			}
+		}
+	}
+
 	public boolean contains( final KEY_TYPE k ) {
 		if ( KEY_IS_NULL( k ) ) return containsNull;
 

--- a/drv/OpenHashMap.drv
+++ b/drv/OpenHashMap.drv
@@ -1806,7 +1806,27 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 				}
 			}
 		}
-			 
+
+		public MAP.Entry KEY_VALUE_GENERIC pop() {
+			if ( containsNullKey ) {
+				VALUE_GENERIC_TYPE v = removeNullEntry();
+				return new BasicEntry KEY_VALUE_GENERIC ( KEY_NULL, v );
+			}
+			int pos = n;
+			final KEY_GENERIC_TYPE key[] = OPEN_HASH_MAP.this.key;
+			for(;;) {
+				if ( --pos < 0 ) {
+					throw new NoSuchElementException();
+				}
+				KEY_GENERIC_TYPE k = key[ pos ];
+				if ( ! KEY_IS_NULL( k ) ) {
+					VALUE_GENERIC_TYPE v = value[ pos ];
+					removeEntry( pos );
+					return new BasicEntry KEY_VALUE_GENERIC ( k, v );
+				}
+			}
+		}
+
 		public int size() {
 			return size;
 		}
@@ -1919,6 +1939,24 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 			OPEN_HASH_MAP.this.clear();
 		}
 
+		public KEY_GENERIC_TYPE POP() {
+			if ( containsNullKey ) {
+				removeNullEntry();
+				return KEY_NULL;
+			}
+			int pos = n;
+			final KEY_GENERIC_TYPE key[] = OPEN_HASH_MAP.this.key;
+			for(;;) {
+				if ( --pos < 0 ) {
+					throw new NoSuchElementException();
+				}
+				KEY_GENERIC_TYPE k = key[ pos ];
+				if ( ! KEY_IS_NULL( k ) ) {
+					removeEntry( pos );
+					return k;
+				}
+			}
+		}
 
 #ifdef Linked
 		public KEY_GENERIC_TYPE FIRST() {

--- a/drv/OpenHashSet.drv
+++ b/drv/OpenHashSet.drv
@@ -712,6 +712,25 @@ public class OPEN_HASH_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implemen
 		}
 	}
 
+	public KEY_GENERIC_TYPE POP() {
+		if ( containsNull ) {
+			removeNullEntry();
+			return KEY_NULL;
+		}
+		final KEY_GENERIC_TYPE key[] = OPEN_HASH_SET.this.key;
+		int pos = n;
+		for(;;) {
+			if ( --pos < 0 ) {
+				throw new NoSuchElementException();
+			}
+			KEY_GENERIC_TYPE k = key[ pos ];
+			if ( ! KEY_IS_NULL( k ) ) {
+				removeEntry( pos );
+				return k;
+			}
+		}
+	}
+
 	SUPPRESS_WARNINGS_KEY_UNCHECKED
 	public boolean contains( final KEY_TYPE k ) {
 		if ( KEY_EQUALS_NULL( KEY_GENERIC_CAST k ) ) return containsNull;

--- a/drv/RBTreeMap.drv
+++ b/drv/RBTreeMap.drv
@@ -1248,7 +1248,7 @@ public class RB_TREE_MAP KEY_VALUE_GENERIC extends ABSTRACT_SORTED_MAP KEY_VALUE
 					final Map.Entry<KEY_GENERIC_CLASS, VALUE_GENERIC_CLASS> e = (Map.Entry<KEY_GENERIC_CLASS, VALUE_GENERIC_CLASS>)o;
 					final Entry KEY_VALUE_GENERIC f = findKey( KEY_CLASS2TYPE( e.getKey() ) );
 					return e.equals( f );
-				}					 
+				}
 
 				@SuppressWarnings("unchecked")
 				public boolean remove( final Object o ) {
@@ -1259,9 +1259,17 @@ public class RB_TREE_MAP KEY_VALUE_GENERIC extends ABSTRACT_SORTED_MAP KEY_VALUE
 					return f != null;
 				}
 
+				@SuppressWarnings("unchecked")
+				public MAP.Entry KEY_VALUE_GENERIC pop() {
+					if (lastEntry == null) { throw new NoSuchElementException(); }
+					BasicEntry KEY_VALUE_GENERIC e = new BasicEntry KEY_VALUE_GENERIC ( lastEntry.key, lastEntry.value );
+					RB_TREE_MAP.this.REMOVE_VALUE( lastEntry.key );
+					return e;
+				}
+
 				public int size() { return count; }
 				public void clear() { RB_TREE_MAP.this.clear(); }
-					 
+
 				public MAP.Entry KEY_VALUE_GENERIC first() { return firstEntry; }
 				public MAP.Entry KEY_VALUE_GENERIC last() { return lastEntry; }
 				public ObjectSortedSet<MAP.Entry KEY_VALUE_GENERIC> subSet( MAP.Entry KEY_VALUE_GENERIC from, MAP.Entry KEY_VALUE_GENERIC to  ) { return subMap( from.ENTRY_GET_KEY(), to.ENTRY_GET_KEY() ).ENTRYSET(); }
@@ -1474,6 +1482,15 @@ public class RB_TREE_MAP KEY_VALUE_GENERIC extends ABSTRACT_SORTED_MAP KEY_VALUE
 						final RB_TREE_MAP.Entry KEY_VALUE_GENERIC f = findKey( KEY_CLASS2TYPE( e.getKey() ) );
 						if ( f != null && in( f.key ) ) Submap.this.REMOVE_VALUE( f.key );
 						return f != null;
+					}
+
+					@SuppressWarnings("unchecked")
+					public MAP.Entry KEY_VALUE_GENERIC pop() {
+						MAP.Entry KEY_VALUE_GENERIC l = lastEntry();
+						if (l == null) { throw new NoSuchElementException(); }
+						BasicEntry KEY_VALUE_GENERIC e = new BasicEntry KEY_VALUE_GENERIC ( l.ENTRY_GET_KEY(), l.ENTRY_GET_VALUE() );
+						RB_TREE_MAP.this.REMOVE_VALUE( l.ENTRY_GET_KEY() );
+						return e;
 					}
 
 					public int size() {

--- a/drv/RBTreeSet.drv
+++ b/drv/RBTreeSet.drv
@@ -993,6 +993,13 @@ public class RB_TREE_SET KEY_GENERIC extends ABSTRACT_SORTED_SET KEY_GENERIC imp
 		return lastEntry.key;
 	}
 	 
+	public KEY_GENERIC_TYPE POP() {
+		if ( tree == null ) throw new NoSuchElementException();
+		KEY_GENERIC_TYPE k = lastEntry.key;
+		RB_TREE_SET.this.remove( k );
+		return k;
+	}
+
 
 	/** An iterator on the whole range.
 	 *
@@ -1257,7 +1264,6 @@ public class RB_TREE_SET KEY_GENERIC extends ABSTRACT_SORTED_SET KEY_GENERIC imp
 			return e;
 		}
 
-
 		public KEY_GENERIC_TYPE FIRST() {
 			RB_TREE_SET.Entry KEY_GENERIC e = firstEntry();
 			if ( e == null ) throw new NoSuchElementException();
@@ -1269,7 +1275,15 @@ public class RB_TREE_SET KEY_GENERIC extends ABSTRACT_SORTED_SET KEY_GENERIC imp
 			if ( e == null ) throw new NoSuchElementException();
 			return e.key;
 		}
-	 
+
+		public KEY_GENERIC_TYPE POP() {
+			RB_TREE_SET.Entry KEY_GENERIC e = lastEntry();
+			if ( e == null ) throw new NoSuchElementException();
+			KEY_GENERIC_TYPE k = e.key;
+			RB_TREE_SET.this.remove( k );
+			return k;
+		}
+
 		/** An iterator for subranges.
 		 * 
 		 * <P>This class inherits from {@link SetIterator}, but overrides the methods that

--- a/drv/Set.drv
+++ b/drv/Set.drv
@@ -47,4 +47,12 @@ public interface SET KEY_GENERIC extends COLLECTION KEY_GENERIC, Set<KEY_GENERIC
 	 * @see java.util.Collection#remove(Object)
 	 */
 	public boolean remove( KEY_TYPE k );
+
+#if #keys(primitive)
+	/** Pop (remove) a random element from this set. */
+	KEY_GENERIC_TYPE POP();
+#endif
+
+	/** Pop (remove) a random element from this set. */
+	KEY_GENERIC_CLASS pop();
 }

--- a/drv/Sets.drv
+++ b/drv/Sets.drv
@@ -19,6 +19,7 @@ package PACKAGE;
 
 import java.util.Collection;
 import java.util.Set;
+import java.util.NoSuchElementException;
 
 /** A class providing static methods and objects that do useful things with type-specific sets.
  *
@@ -43,6 +44,10 @@ public class SETS {
 		public boolean remove( KEY_TYPE ok ) { throw new UnsupportedOperationException(); }
 		public Object clone() { return EMPTY_SET; }
         private Object readResolve() { return EMPTY_SET; }
+#if #keys(primitive)
+		public KEY_GENERIC_TYPE POP() { throw new NoSuchElementException(); }
+#endif
+		public KEY_GENERIC_CLASS pop() { throw new NoSuchElementException(); }
 	}
 
 
@@ -97,6 +102,11 @@ public class SETS {
 		public int size() { return 1; }
 	
 		public Object clone() { return this; }
+
+#if #keys(primitive)
+		public KEY_GENERIC_TYPE POP() { throw new UnsupportedOperationException(); }
+#endif
+		public KEY_GENERIC_CLASS pop() { throw new UnsupportedOperationException(); }
 	}
 
 #if ! #keyclass(Reference)
@@ -144,6 +154,10 @@ public class SETS {
 		public boolean remove( final KEY_TYPE k ) { synchronized( sync ) { return collection.remove( KEY2OBJ( k ) ); } }
 		public boolean equals( final Object o ) { synchronized( sync ) { return collection.equals( o ); } }
 		public int hashCode() { synchronized( sync ) { return collection.hashCode(); } }
+#if #keys(primitive)
+		public KEY_GENERIC_TYPE POP() { synchronized(sync) { return ((SET)collection).POP(); } }
+#endif
+		public KEY_GENERIC_CLASS pop() { synchronized(sync) { return KEY_GENERIC_CAST(((SET)collection).pop()); } }
 	}
 
 
@@ -180,6 +194,10 @@ public class SETS {
 		public boolean remove( final KEY_TYPE k ) { throw new UnsupportedOperationException(); }
 		public boolean equals( final Object o ) { return collection.equals( o ); }
 		public int hashCode() { return collection.hashCode(); }
+#if #keys(primitive)
+		public KEY_GENERIC_TYPE POP() { throw new UnsupportedOperationException(); }
+#endif
+		public KEY_GENERIC_CLASS pop() { throw new UnsupportedOperationException(); }
 	}
 
 

--- a/drv/SortedSets.drv
+++ b/drv/SortedSets.drv
@@ -75,6 +75,8 @@ public class SORTED_SETS {
 		public KEY_GENERIC_CLASS last() { throw new NoSuchElementException(); }
 #endif
 
+		public KEY_GENERIC_TYPE POP() { throw new NoSuchElementException(); }
+
 		public Object clone() { return EMPTY_SET; }
 
         private Object readResolve() { return EMPTY_SET; }


### PR DESCRIPTION
Add a pop() function to the Set API.
Similar to a Stack, but without a predefined order.
The HashSets will usually pop the last occupied bucket, the tree sets return the last element.

Important: I have not yet tested all this, only done the gruntwork.
I'm not sure if I always chose the most effective solution, or if I got all the macros right.
So far, this has largely been a trial and error hack. Consider it a feature request for a "pop()" method, not a finished contribution.

My primary use case is to be able to pop integers from a hash set of integers, where I do not care about the order.