### PR TITLE
Add addOrGet(k) to ObjectHashSets.

### DIFF
--- a/drv/OpenHashBigSet.drv
+++ b/drv/OpenHashBigSet.drv
@@ -319,6 +319,46 @@ public class OPEN_HASH_BIG_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC impl
 		return true;
 	}
 
+#if #keyclass(Object)
+	/** Add a random element if not present, get the existing value if already present.
+	 *
+	 * This is equivalent to (but faster than) doing a:
+	 * <pre>
+	 * K exist = set.get(k);
+	 * if (exist == null) {
+	 *   set.add(k);
+	 *   exist = k;
+	 * }
+	 * </pre>
+	 */
+	public KEY_GENERIC_TYPE addOrGet( final KEY_GENERIC_TYPE k ) {
+		int displ, base;
+
+		if ( KEY_IS_NULL( k ) ) {
+			if ( containsNull ) return null;
+			containsNull = true;
+		}
+		else {
+			KEY_GENERIC_TYPE curr;
+			final KEY_GENERIC_TYPE[][] key = this.key;
+			final long h = KEY2LONGHASH( k );
+
+			// The starting point.
+			if ( ! KEY_IS_NULL( curr = key[ base = (int)( ( h & mask ) >>> BigArrays.SEGMENT_SHIFT ) ][ displ = (int)( h & segmentMask ) ] ) ) {
+				if ( KEY_EQUALS_NOT_NULL( curr, k ) ) return curr;
+				while( ! KEY_IS_NULL( curr = key[ base = ( base + ( ( displ = ( displ + 1 ) & segmentMask ) == 0 ? 1 : 0 ) ) & baseMask ][ displ ] ) )
+					if ( KEY_EQUALS_NOT_NULL( curr, k ) ) return curr;
+			}
+
+			key[ base ][ displ ] = k;
+		}
+
+		if ( size++ >= maxFill ) rehash( 2 * n );
+		if ( ASSERTS ) checkTable();
+		return k;
+	}
+#endif
+
 	/** Shifts left entries with the specified hash code, starting at the specified position,
 	 * and empties the resulting free entry.
 	 *

--- a/drv/OpenHashSet.drv
+++ b/drv/OpenHashSet.drv
@@ -639,6 +639,63 @@ public class OPEN_HASH_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implemen
 		return true;
 	}
 
+#if #keyclass(Object)
+	/** Add a random element if not present, get the existing value if already present.
+	 *
+	 * This is equivalent to (but faster than) doing a:
+	 * <pre>
+	 * K exist = set.get(k);
+	 * if (exist == null) {
+	 *   set.add(k);
+	 *   exist = k;
+	 * }
+	 * </pre>
+	 */
+	public KEY_GENERIC_TYPE addOrGet( final KEY_GENERIC_TYPE k ) {
+		int pos;
+
+		if ( KEY_EQUALS_NULL( KEY_GENERIC_CAST k ) ) {
+			if ( containsNull ) return key [ n ];
+#ifdef Linked
+			pos = n;
+#endif
+			containsNull = true;
+#ifdef Custom
+			key [ n ] = k;
+#endif
+		}
+		else {
+			KEY_GENERIC_TYPE curr;
+			final KEY_GENERIC_TYPE[] key = this.key;
+
+			// The starting point.
+			if ( ! KEY_IS_NULL( curr = key[ pos = KEY2INTHASH( k ) & mask ] ) ) {
+				if ( KEY_EQUALS_NOT_NULL( curr, k ) ) return curr;
+				while( ! KEY_IS_NULL( curr = key[ pos = ( pos + 1 ) & mask ] ) ) 
+					if ( KEY_EQUALS_NOT_NULL( curr, k ) ) return curr;
+			}
+			key[ pos ] = k;
+		}
+
+#ifdef Linked
+		if ( size == 0 ) {
+			first = last = pos;
+			// Special case of SET_UPPER_LOWER(link[ pos ], -1, -1);
+			link[ pos ] = -1L;
+		}
+		else {
+			SET_NEXT( link[ last ], pos );
+			SET_UPPER_LOWER( link[ pos ], last, -1 );
+			last = pos;
+		}
+#endif
+
+		if ( size++ >= maxFill ) rehash( arraySize( size + 1, f ) );
+		if ( ASSERTS ) checkTable();
+		return k;
+	}
+#endif
+
 	/** Shifts left entries with the specified hash code, starting at the specified position,
 	 * and empties the resulting free entry.
 	 *

--- a/test/it/unimi/dsi/fastutil/objects/ObjectOpenHashBigSetTest.java
+++ b/test/it/unimi/dsi/fastutil/objects/ObjectOpenHashBigSetTest.java
@@ -146,6 +146,18 @@ public class ObjectOpenHashBigSetTest {
 			Object T = genKey();
 			assertTrue( "Error: divergence between t and m (standard method)", m.contains( ( T ) ) == t.contains( ( T ) ) );
 		}
+		/*
+		 * Check that addOrGet does indeed return the original instance, not a copy
+		 */
+		for ( java.util.Iterator i = m.iterator(); i.hasNext(); ) {
+			Object e = i.next();
+			Object e2 = m.addOrGet( new StringBuilder((String)e).toString() ); // Make a new object!
+			assertTrue( "addOrGet does not return the same object", e == e2 /* NOT just equals, but identity */ );
+		}
+		/* This should not have modified the table */
+		assertTrue( "Error: !m.equals(t) after addOrGet no-op", m.equals( t ) );
+		assertTrue( "Error: !t.equals(m) after addOrGet no-op", t.equals( m ) );
+
 		/* Now we put and remove random data in m and t, checking that the result is the same. */
 		for ( int i = 0; i < 20 * n; i++ ) {
 			Object T = genKey();
@@ -205,7 +217,7 @@ public class ObjectOpenHashBigSetTest {
 			assertTrue( "Error: divergence in remove() between t and m after save/read", m.remove( ( T ) ) == t.remove( ( T ) ) );
 		}
 		assertTrue( "Error: !m.equals(t) after post-save/read removal", m.equals( t ) );
-		assertTrue( "Error: !t.equals(m) after post-save/read removal", t.equals( m ) ); 		
+		assertTrue( "Error: !t.equals(m) after post-save/read removal", t.equals( m ) );
 		/*
 		 * Now we take out of m everything , and check that it is empty.
 		 */

--- a/test/it/unimi/dsi/fastutil/objects/ObjectOpenHashSetTest.java
+++ b/test/it/unimi/dsi/fastutil/objects/ObjectOpenHashSetTest.java
@@ -153,6 +153,18 @@ public class ObjectOpenHashSetTest {
 			Object T = genKey();
 			assertTrue( "Error: divergence between t and m (standard method)", m.contains( ( T ) ) == t.contains( ( T ) ) );
 		}
+		/*
+		 * Check that addOrGet does indeed return the original instance, not a copy
+		 */
+		for ( java.util.Iterator i = m.iterator(); i.hasNext(); ) {
+			Object e = i.next();
+			Object e2 = m.addOrGet( new StringBuilder((String)e).toString() ); // Make a new object!
+			assertTrue( "addOrGet does not return the same object", e == e2 );
+		}
+		/* This should not have modified the table */
+		assertTrue( "Error: !m.equals(t) after addOrGet no-op", m.equals( t ) );
+		assertTrue( "Error: !t.equals(m) after addOrGet no-op", t.equals( m ) );
+
 		/* Now we put and remove random data in m and t, checking that the result is the same. */
 		for ( int i = 0; i < 20 * n; i++ ) {
 			Object T = genKey();
@@ -162,7 +174,7 @@ public class ObjectOpenHashSetTest {
 		}
 		assertTrue( "Error: !m.equals(t) after removal", m.equals( t ) );
 		assertTrue( "Error: !t.equals(m) after removal", t.equals( m ) );
-		
+
 		checkTable( m );
 		printProbes( m );
 
@@ -218,7 +230,7 @@ public class ObjectOpenHashSetTest {
 			assertTrue( "Error: divergence in remove() between t and m after save/read", m.remove( ( T ) ) == t.remove( ( T ) ) );
 		}
 		assertTrue( "Error: !m.equals(t) after post-save/read removal", m.equals( t ) );
-		assertTrue( "Error: !t.equals(m) after post-save/read removal", t.equals( m ) ); 		
+		assertTrue( "Error: !t.equals(m) after post-save/read removal", t.equals( m ) );
 		/*
 		 * Now we take out of m everything , and check that it is empty.
 		 */


### PR DESCRIPTION
Works like add(k) followed by get(k), but is cheaper.

This is useful for managing unique objects, e.g.

ObjectHashSet<String> unique;
key = unique.addOrGet(key);

I have wrapped this code in "#if #keyclass(Object)", because for primitives it is equivalent to "add(k); return k;".

For hash sets, the code duplication isn't too bad. But for the tree-based sets it is massive, so I didn't do these.

Again, untested code, sorry. Consider this to be a feature request.