### PR TITLE
Add @Deprecated warnings to methods with better alternatives

### DIFF
--- a/drv/AVLTreeMap.drv
+++ b/drv/AVLTreeMap.drv
@@ -803,6 +803,10 @@ public class AVL_TREE_MAP KEY_VALUE_GENERIC extends ABSTRACT_SORTED_MAP  KEY_VAL
 	 
 
 #if ! #keyclass(Object) || #values(primitive)
+	/** {@inheritDoc}
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
+	@Override
 	public VALUE_GENERIC_CLASS put( final KEY_GENERIC_CLASS ok, final VALUE_GENERIC_CLASS ov ) {
 		final VALUE_GENERIC_TYPE oldValue = put( KEY_CLASS2TYPE(ok), VALUE_CLASS2TYPE(ov) );
 		return modified ? OBJECT_DEFAULT_RETURN_VALUE : VALUE2OBJ( oldValue );
@@ -812,6 +816,10 @@ public class AVL_TREE_MAP KEY_VALUE_GENERIC extends ABSTRACT_SORTED_MAP  KEY_VAL
 
 
 #if ! #keyclass(Object) || #values(primitive)
+	/** {@inheritDoc}
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
+	@Override
 	public VALUE_GENERIC_CLASS remove( final Object ok ) {
 		final VALUE_GENERIC_TYPE oldValue = REMOVE_VALUE( KEY_OBJ2TYPE( ok ) );
 		return modified ? VALUE2OBJ( oldValue ) : OBJECT_DEFAULT_RETURN_VALUE;
@@ -1007,6 +1015,11 @@ public class AVL_TREE_MAP KEY_VALUE_GENERIC extends ABSTRACT_SORTED_MAP  KEY_VAL
 			return prev;
 		}
 
+#if #keys(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+#endif
 		public KEY_GENERIC_CLASS getKey() {
 			return KEY2OBJ(key);
 		}
@@ -1017,6 +1030,11 @@ public class AVL_TREE_MAP KEY_VALUE_GENERIC extends ABSTRACT_SORTED_MAP  KEY_VAL
 		}
 #endif
 		  
+#if #values(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead.  */
+		@Deprecated
+#endif
 		public VALUE_GENERIC_CLASS getValue() {
 			return VALUE2OBJ(value);
 		}
@@ -1131,7 +1149,10 @@ public class AVL_TREE_MAP KEY_VALUE_GENERIC extends ABSTRACT_SORTED_MAP  KEY_VAL
 	}
 
 #if #keyclass(Object) && #values(primitive)
-
+	/** {@inheritDoc}
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
+	@Override
 	SUPPRESS_WARNINGS_KEY_UNCHECKED
 	public VALUE_GENERIC_CLASS get( final Object ok ) {
 		final Entry KEY_VALUE_GENERIC e = findKey( KEY_GENERIC_CAST ok );
@@ -1599,7 +1620,10 @@ public class AVL_TREE_MAP KEY_VALUE_GENERIC extends ABSTRACT_SORTED_MAP  KEY_VAL
 		  
 		  
 #if #keyclass(Object) && #values(primitive)
-
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead.  */
+		@Deprecated
+		@Override
 		SUPPRESS_WARNINGS_KEY_UNCHECKED
 		public VALUE_GENERIC_CLASS get( final Object ok ) {
 			final AVL_TREE_MAP.Entry KEY_VALUE_GENERIC e;
@@ -1617,6 +1641,10 @@ public class AVL_TREE_MAP KEY_VALUE_GENERIC extends ABSTRACT_SORTED_MAP  KEY_VAL
 
 		  
 #if ! #keyclass(Object) || #values(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead.  */
+		@Deprecated
+		@Override
 		public VALUE_GENERIC_CLASS put( final KEY_GENERIC_CLASS ok, final VALUE_GENERIC_CLASS ov ) {
 			final VALUE_GENERIC_TYPE oldValue = put( KEY_CLASS2TYPE(ok), VALUE_CLASS2TYPE(ov) );
 			return modified ? OBJECT_DEFAULT_RETURN_VALUE : VALUE2OBJ( oldValue );
@@ -1632,6 +1660,10 @@ public class AVL_TREE_MAP KEY_VALUE_GENERIC extends ABSTRACT_SORTED_MAP  KEY_VAL
 		}
 
 #if ! #keyclass(Object) || #values(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead.  */
+		@Deprecated
+		@Override
 		public VALUE_GENERIC_CLASS remove( final Object ok ) {
 			final VALUE_GENERIC_TYPE oldValue = REMOVE_VALUE( KEY_OBJ2TYPE( ok ) );
 			return modified ? VALUE2OBJ( oldValue ) : OBJECT_DEFAULT_RETURN_VALUE;
@@ -1727,12 +1759,20 @@ public class AVL_TREE_MAP KEY_VALUE_GENERIC extends ABSTRACT_SORTED_MAP  KEY_VAL
 		}
 	 
 #if !#keyclass(Object)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead.  */
+		@Deprecated
+		@Override
 		public KEY_GENERIC_CLASS firstKey() {
 			AVL_TREE_MAP.Entry KEY_VALUE_GENERIC e = firstEntry();
 			if ( e == null ) throw new NoSuchElementException();
 			return e.getKey();
 		}
 	 
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead.  */
+		@Deprecated
+		@Override
 		public KEY_GENERIC_CLASS lastKey() {
 			AVL_TREE_MAP.Entry KEY_VALUE_GENERIC e = lastEntry();
 			if ( e == null ) throw new NoSuchElementException();

--- a/drv/AVLTreeSet.drv
+++ b/drv/AVLTreeSet.drv
@@ -1200,7 +1200,7 @@ public class AVL_TREE_SET KEY_GENERIC extends ABSTRACT_SORTED_SET KEY_GENERIC im
 		public void clear() {
 			final SubsetIterator i = new SubsetIterator();
 			while( i.hasNext() ) {
-				i.next();
+				i.NEXT_KEY();
 				i.remove();
 			}
 		}
@@ -1236,7 +1236,7 @@ public class AVL_TREE_SET KEY_GENERIC extends ABSTRACT_SORTED_SET KEY_GENERIC im
 				
 			while( i.hasNext() ) {
 				n++;
-				i.next();
+				i.NEXT_KEY();
 			}
 				
 			return n;

--- a/drv/AbstractBigList.drv
+++ b/drv/AbstractBigList.drv
@@ -363,12 +363,22 @@ public abstract class ABSTRACT_BIG_LIST KEY_GENERIC extends ABSTRACT_COLLECTION 
 		return true;
 	}
 
-	/** Delegates to a more generic method. */
+	/** {@inheritDoc}
+	 *
+	 * Delegates to a more generic method.
+	 *
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public boolean addAll( final long index, final COLLECTION c ) {
 		return addAll( index, (Collection<? extends KEY_CLASS>)c );
 	}
 
-	/** Delegates to a more generic method. */
+	/** {@inheritDoc}
+	 *
+	 * Delegates to a more generic method.
+	 *
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public boolean addAll( final long index, final BIG_LIST l ) {
 		return addAll( index, (COLLECTION)l );
 	}
@@ -381,57 +391,109 @@ public abstract class ABSTRACT_BIG_LIST KEY_GENERIC extends ABSTRACT_COLLECTION 
 		return addAll( size64(), l );
 	}
 
-	/** Delegates to the corresponding type-specific method. */
+	/** {@inheritDoc}
+	 *
+	 * Delegates to a more generic method.
+	 *
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public void add( final long index, final KEY_CLASS ok ) {
 		add( index, ok.KEY_VALUE() );
 	}
 
-	/** Delegates to the corresponding type-specific method. */
+	/** Delegates to the corresponding type-specific method.
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public KEY_CLASS set( final long index, final KEY_CLASS ok ) {
 		return KEY2OBJ( set( index, ok.KEY_VALUE() ) );
 	}
 
-	/** Delegates to the corresponding type-specific method. */
+	/** {@inheritDoc}
+	 *
+	 * Delegates to a more generic method.
+	 *
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public KEY_CLASS get( final long index ) {
 		return KEY2OBJ( GET_KEY( index ) );
 	}
 
-	/** Delegates to the corresponding type-specific method. */
+	/** {@inheritDoc}
+	 *
+	 * Delegates to a more generic method.
+	 *
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public long indexOf( final Object ok ) {
 		return indexOf( KEY_OBJ2TYPE( ok ) );
 	}
 
-	/** Delegates to the corresponding type-specific method. */
+	/** {@inheritDoc}
+	 *
+	 * Delegates to a more generic method.
+	 *
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public long lastIndexOf( final Object ok ) {
 		return lastIndexOf( KEY_OBJ2TYPE( ok ) );
 	}
 
-	/** Delegates to the corresponding type-specific method. */
+	/** {@inheritDoc}
+	 *
+	 * Delegates to a more generic method.
+	 *
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public KEY_CLASS remove( final int index ) {
 		return KEY2OBJ( REMOVE_KEY( index ) );
 	}
 
-	/** Delegates to the corresponding type-specific method. */
+	/** {@inheritDoc}
+	 *
+	 * Delegates to a more generic method.
+	 *
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public KEY_CLASS remove( final long index ) {
 		return KEY2OBJ( REMOVE_KEY( index ) );
 	}
 
-	/** Delegates to the corresponding type-specific method. */
+	/** {@inheritDoc}
+	 *
+	 * Delegates to a more generic method.
+	 *
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public void push( KEY_CLASS o ) {
 		push( o.KEY_VALUE() ); 
 	}
 
-	/** Delegates to the corresponding type-specific method. */
+	/** {@inheritDoc}
+	 *
+	 * Delegates to a more generic method.
+	 *
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public KEY_CLASS pop() {
 		return KEY_CLASS.valueOf( POP() ); 
 	}
 
-	/** Delegates to the corresponding type-specific method. */
+	/** {@inheritDoc}
+	 *
+	 * Delegates to a more generic method.
+	 *
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public KEY_CLASS top() {
 		return KEY_CLASS.valueOf( TOP() ); 
 	}
 
-	/** Delegates to the corresponding type-specific method. */
+	/** {@inheritDoc}
+	 *
+	 * Delegates to a more generic method.
+	 *
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public KEY_CLASS peek( int i ) {
 		return KEY_CLASS.valueOf( PEEK( i ) ); 
 	}

--- a/drv/AbstractFunction.drv
+++ b/drv/AbstractFunction.drv
@@ -77,21 +77,41 @@ public abstract class ABSTRACT_FUNCTION KEY_VALUE_GENERIC implements FUNCTION KE
 
 #if #keys(primitive) || #values(primitive)
                                                                                                                                              
+#if #values(primitive)
+	/** Delegates to the corresponding type-specific method, taking care of returning <code>null</code> on a missing key.
+	 *
+	 * <P>This method must check whether the provided key is in the map using <code>containsKey()</code>. Thus,
+	 * it probes the map <em>twice</em>. Implementors of subclasses should override it with a more efficient method.
+	 *
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
+#else
 	/** Delegates to the corresponding type-specific method, taking care of returning <code>null</code> on a missing key.
 	 *
 	 * <P>This method must check whether the provided key is in the map using <code>containsKey()</code>. Thus,
 	 * it probes the map <em>twice</em>. Implementors of subclasses should override it with a more efficient method.
 	 */
+#endif
 	public VALUE_GENERIC_CLASS get( final Object ok ) {
 		final KEY_TYPE k = KEY_OBJ2TYPE( ok );
 		return containsKey( k ) ? VALUE2OBJ( GET_VALUE( k ) ) : null;
 	}
                                                                                                                                              
+#if #values(primitive)
+	/** Delegates to the corresponding type-specific method, taking care of returning <code>null</code> on a missing key. 
+	 *
+	 * <P>This method must check whether the provided key is in the map using <code>containsKey()</code>. Thus,
+	 * it probes the map <em>twice</em>. Implementors of subclasses should override it with a more efficient method.
+	 *
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
+#else
 	/** Delegates to the corresponding type-specific method, taking care of returning <code>null</code> on a missing key. 
 	 *
 	 * <P>This method must check whether the provided key is in the map using <code>containsKey()</code>. Thus,
 	 * it probes the map <em>twice</em>. Implementors of subclasses should override it with a more efficient method.
 	 */
+#endif
 	public VALUE_GENERIC_CLASS put( final KEY_GENERIC_CLASS ok, final VALUE_GENERIC_CLASS ov ) {
 		final KEY_GENERIC_TYPE k = KEY_CLASS2TYPE( ok );
 		final boolean containsKey = containsKey( k );
@@ -99,11 +119,21 @@ public abstract class ABSTRACT_FUNCTION KEY_VALUE_GENERIC implements FUNCTION KE
 		return containsKey ? VALUE2OBJ( v ) : null;
 	}
                                                                                                                                              
+#if #values(primitive)
+	/** Delegates to the corresponding type-specific method, taking care of returning <code>null</code> on a missing key. 
+	 *
+	 * <P>This method must check whether the provided key is in the map using <code>containsKey()</code>. Thus,
+	 * it probes the map <em>twice</em>. Implementors of subclasses should override it with a more efficient method.
+	 *
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
+#else
 	/** Delegates to the corresponding type-specific method, taking care of returning <code>null</code> on a missing key. 
 	 *
 	 * <P>This method must check whether the provided key is in the map using <code>containsKey()</code>. Thus,
 	 * it probes the map <em>twice</em>. Implementors of subclasses should override it with a more efficient method.
 	 */
+#endif
 	public VALUE_GENERIC_CLASS remove( final Object ok ) {
 		final KEY_TYPE k = KEY_OBJ2TYPE( ok );
 		final boolean containsKey = containsKey( k );

--- a/drv/AbstractIterator.drv
+++ b/drv/AbstractIterator.drv
@@ -39,7 +39,9 @@ public abstract class KEY_ABSTRACT_ITERATOR KEY_GENERIC implements KEY_ITERATOR 
 	/** Delegates to the corresponding generic method. */
 	public KEY_TYPE NEXT_KEY() { return next().KEY_VALUE(); }
 
-	/** Delegates to the corresponding type-specific method. */
+	/** Delegates to the corresponding type-specific method.
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public KEY_GENERIC_CLASS next() { return KEY_CLASS.valueOf( NEXT_KEY() ); }
 
 #endif

--- a/drv/AbstractList.drv
+++ b/drv/AbstractList.drv
@@ -390,12 +390,16 @@ public abstract class ABSTRACT_LIST KEY_GENERIC extends ABSTRACT_COLLECTION KEY_
 		add( index, ok.KEY_VALUE() );
 	}
 
-	/** Delegates to the corresponding type-specific method. */
+	/** Delegates to the corresponding type-specific method.
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public KEY_CLASS set( final int index, final KEY_CLASS ok ) {
 		return KEY2OBJ( set( index, ok.KEY_VALUE() ) );
 	}
 
-	/** Delegates to the corresponding type-specific method. */
+	/** Delegates to the corresponding type-specific method.
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public KEY_CLASS get( final int index ) {
 		return KEY2OBJ( GET_KEY( index ) );
 	}
@@ -410,7 +414,9 @@ public abstract class ABSTRACT_LIST KEY_GENERIC extends ABSTRACT_COLLECTION KEY_
 		return lastIndexOf( KEY_OBJ2TYPE( ok ) );
 	}
 
-	/** Delegates to the corresponding type-specific method. */
+	/** Delegates to the corresponding type-specific method.
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public KEY_CLASS remove( final int index ) {
 		return KEY2OBJ( REMOVE_KEY( index ) );
 	}
@@ -420,17 +426,23 @@ public abstract class ABSTRACT_LIST KEY_GENERIC extends ABSTRACT_COLLECTION KEY_
 		push( o.KEY_VALUE() ); 
 	}
 
-	/** Delegates to the corresponding type-specific method. */
+	/** Delegates to the corresponding type-specific method.
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public KEY_CLASS pop() {
 		return KEY_CLASS.valueOf( POP() ); 
 	}
 
-	/** Delegates to the corresponding type-specific method. */
+	/** Delegates to the corresponding type-specific method.
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public KEY_CLASS top() {
 		return KEY_CLASS.valueOf( TOP() ); 
 	}
 
-	/** Delegates to the corresponding type-specific method. */
+	/** Delegates to the corresponding type-specific method.
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public KEY_CLASS peek( int i ) {
 		return KEY_CLASS.valueOf( PEEK( i ) ); 
 	}

--- a/drv/AbstractMap.drv
+++ b/drv/AbstractMap.drv
@@ -73,7 +73,9 @@ public abstract class ABSTRACT_MAP KEY_VALUE_GENERIC extends ABSTRACT_FUNCTION K
 	 * @param m a map.
 	 */
 #if #keys(primitive) ^ #values(primitive)
-	 @SuppressWarnings("unchecked")
+	 @SuppressWarnings({"unchecked", "deprecation"})
+#else
+	 @SuppressWarnings("deprecation")
 #endif
 	public void putAll(Map<? extends KEY_GENERIC_CLASS,? extends VALUE_GENERIC_CLASS> m) {
 		int n = m.size();
@@ -124,6 +126,11 @@ public abstract class ABSTRACT_MAP KEY_VALUE_GENERIC extends ABSTRACT_FUNCTION K
 		  
 #endif
 
+#if #keys(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+#endif
 		public KEY_GENERIC_CLASS getKey() {
 			return KEY2OBJ(key);
 		}
@@ -134,6 +141,11 @@ public abstract class ABSTRACT_MAP KEY_VALUE_GENERIC extends ABSTRACT_FUNCTION K
 		}
 #endif
 
+#if #values(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+#endif
 		public VALUE_GENERIC_CLASS getValue() {
 			return VALUE2OBJ(value);
 		}
@@ -149,7 +161,9 @@ public abstract class ABSTRACT_MAP KEY_VALUE_GENERIC extends ABSTRACT_FUNCTION K
 		}
 		  
 #if #values(primitive)
-		  
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
 		public VALUE_GENERIC_CLASS setValue( final VALUE_GENERIC_CLASS value ) {
 			return VALUE_CLASS.valueOf(setValue(value.VALUE_VALUE()));
 		}
@@ -199,6 +213,9 @@ public abstract class ABSTRACT_MAP KEY_VALUE_GENERIC extends ABSTRACT_FUNCTION K
 					return new KEY_ABSTRACT_ITERATOR KEY_GENERIC() {
 							final ObjectIterator<Map.Entry<KEY_GENERIC_CLASS,VALUE_GENERIC_CLASS>> i = entrySet().iterator();
 
+							/** {@inheritDoc}
+							 * @deprecated Please use the corresponding type-specific method instead. */
+							@Deprecated
 							public KEY_GENERIC_TYPE NEXT_KEY() { return ((MAP.Entry KEY_VALUE_GENERIC)i.next()).ENTRY_GET_KEY(); };
 
 							public boolean hasNext() { return i.hasNext(); }
@@ -232,6 +249,9 @@ public abstract class ABSTRACT_MAP KEY_VALUE_GENERIC extends ABSTRACT_FUNCTION K
 					return new VALUE_ABSTRACT_ITERATOR VALUE_GENERIC() {
 							final ObjectIterator<Map.Entry<KEY_GENERIC_CLASS,VALUE_GENERIC_CLASS>> i = entrySet().iterator();
 
+							/** {@inheritDoc}
+							 * @deprecated Please use the corresponding type-specific method instead. */
+							@Deprecated
 							public VALUE_GENERIC_TYPE NEXT_VALUE() { return ((MAP.Entry KEY_VALUE_GENERIC)i.next()).ENTRY_GET_VALUE(); };
 
 							public boolean hasNext() { return i.hasNext(); }

--- a/drv/AbstractPriorityQueue.drv
+++ b/drv/AbstractPriorityQueue.drv
@@ -25,16 +25,24 @@ import it.unimi.dsi.fastutil.AbstractPriorityQueue;
 
 public abstract class ABSTRACT_PRIORITY_QUEUE KEY_GENERIC extends AbstractPriorityQueue<KEY_GENERIC_CLASS> implements java.io.Serializable, PRIORITY_QUEUE KEY_GENERIC  {
 
-	/** Delegates to the corresponding type-specific method. */
+	/** Delegates to the corresponding type-specific method.
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public void enqueue( final KEY_GENERIC_CLASS x ) { enqueue( x.KEY_VALUE() ); }
 
-	/** Delegates to the corresponding type-specific method. */
+	/** Delegates to the corresponding type-specific method.
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public KEY_GENERIC_CLASS dequeue() { return KEY2OBJ( DEQUEUE() ); }
 
-	/** Delegates to the corresponding type-specific method. */
+	/** Delegates to the corresponding type-specific method.
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public KEY_GENERIC_CLASS first() { return KEY2OBJ( FIRST() ); }
 
-	/** Delegates to the corresponding type-specific method. */
+	/** Delegates to the corresponding type-specific method.
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public KEY_GENERIC_CLASS last() { return KEY2OBJ( LAST() ); }
 
 	/** Throws an {@link UnsupportedOperationException}. */

--- a/drv/AbstractSortedMap.drv
+++ b/drv/AbstractSortedMap.drv
@@ -38,27 +38,37 @@ public abstract class ABSTRACT_SORTED_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP
 	protected ABSTRACT_SORTED_MAP() {}
 
 #if #keys(primitive)
-	/** Delegates to the corresponding type-specific method. */
+	/** Delegates to the corresponding type-specific method.
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public SORTED_MAP KEY_VALUE_GENERIC headMap( final KEY_GENERIC_CLASS to  ) {
 		return headMap( KEY_CLASS2TYPE( to ) );
 	}
 
-	/** Delegates to the corresponding type-specific method. */
+	/** Delegates to the corresponding type-specific method.
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public SORTED_MAP KEY_VALUE_GENERIC tailMap( final KEY_GENERIC_CLASS from ) {
 		return tailMap( KEY_CLASS2TYPE( from ) );
 	}
 
-	/** Delegates to the corresponding type-specific method. */
+	/** Delegates to the corresponding type-specific method.
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public SORTED_MAP KEY_VALUE_GENERIC subMap( final KEY_GENERIC_CLASS from, final KEY_GENERIC_CLASS to ) {
 		return subMap( KEY_CLASS2TYPE( from ), KEY_CLASS2TYPE( to ) );
 	}
 
-	/** Delegates to the corresponding type-specific method. */
+	/** Delegates to the corresponding type-specific method.
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public KEY_GENERIC_CLASS firstKey() {
 		return KEY2OBJ( FIRST_KEY() );
 	}
 	 
-	/** Delegates to the corresponding type-specific method. */
+	/** Delegates to the corresponding type-specific method.
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public KEY_GENERIC_CLASS lastKey() {
 		return KEY2OBJ( LAST_KEY() );
 	}

--- a/drv/AbstractSortedSet.drv
+++ b/drv/AbstractSortedSet.drv
@@ -24,27 +24,37 @@ public abstract class ABSTRACT_SORTED_SET KEY_GENERIC extends ABSTRACT_SET KEY_G
 	protected ABSTRACT_SORTED_SET() {}
 
 #if #keys(primitive)
-	/** Delegates to the corresponding type-specific method. */
+	/** Delegates to the corresponding type-specific method.
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public SORTED_SET KEY_GENERIC headSet( final KEY_GENERIC_CLASS to  ) {
 		return headSet( to.KEY_VALUE() );
 	}
 
-	/** Delegates to the corresponding type-specific method. */
+	/** Delegates to the corresponding type-specific method.
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public SORTED_SET KEY_GENERIC tailSet( final KEY_GENERIC_CLASS from ) {
 		return tailSet( from.KEY_VALUE() );
 	}
 
-	/** Delegates to the corresponding type-specific method. */
+	/** Delegates to the corresponding type-specific method.
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public SORTED_SET KEY_GENERIC subSet( final KEY_GENERIC_CLASS from, final KEY_GENERIC_CLASS to ) {
 		return subSet( from.KEY_VALUE(), to.KEY_VALUE() );
 	}
 
-	/** Delegates to the corresponding type-specific method. */
+	/** Delegates to the corresponding type-specific method.
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public KEY_GENERIC_CLASS first() {
 		return KEY2OBJ( FIRST() );
 	}
 	 
-	/** Delegates to the corresponding type-specific method. */
+	/** Delegates to the corresponding type-specific method.
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
 	public KEY_GENERIC_CLASS last() {
 		return KEY2OBJ( LAST() );
 	}

--- a/drv/BigListIterators.drv
+++ b/drv/BigListIterators.drv
@@ -124,7 +124,13 @@ public class BIG_LIST_ITERATORS {
 		public long nextIndex() { return i.nextIndex(); }
 		public long previousIndex() { return i.previousIndex(); }
 #if #keys(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
 		public KEY_GENERIC_CLASS next() { return i.next(); }
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
 		public KEY_GENERIC_CLASS previous() { return i.previous(); }
 #endif
 	}

--- a/drv/BigLists.drv
+++ b/drv/BigLists.drv
@@ -200,6 +200,8 @@ public class BIG_LISTS {
 #if #keys(primitive)
 		public boolean rem( final KEY_GENERIC_TYPE k ) { throw new UnsupportedOperationException(); }
 		public boolean addAll( final COLLECTION c ) { throw new UnsupportedOperationException(); }
+		@Deprecated
+		@Override
 		public boolean addAll( final long i, final COLLECTION c ) { throw new UnsupportedOperationException(); }
 #else
 		public boolean remove( Object k ) { throw new UnsupportedOperationException(); }
@@ -409,7 +411,19 @@ public class BIG_LISTS {
 		public KEY_TYPE[] TO_KEY_ARRAY( KEY_TYPE[] a ) { return list.TO_KEY_ARRAY( a ); }
 #endif
 		public void add( long index, KEY_GENERIC_TYPE key ) { list.add( intIndex( index ), key ); }
+#if #keys(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
+#endif
 		public boolean addAll( long index, COLLECTION KEY_GENERIC c ) { return list.addAll( intIndex( index ), c ); }
+#if #keys(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
+#endif
 		public boolean addAll( long index, BIG_LIST KEY_GENERIC c ) { return list.addAll( intIndex( index ), c ); }
 		public boolean add( KEY_GENERIC_TYPE key ) { return list.add( key ); }
 		public boolean addAll( BIG_LIST KEY_GENERIC c ) { return list.addAll( c ); }

--- a/drv/Functions.drv
+++ b/drv/Functions.drv
@@ -48,6 +48,12 @@ public class FUNCTIONS {
 		public void defaultReturnValue( final VALUE_GENERIC_TYPE defRetValue )  { throw new UnsupportedOperationException(); }
 	
 #if #keys(primitive)
+#if #values(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
+#endif
 		public VALUE_GENERIC_CLASS get( final Object k ) { return null; }
 #endif
 
@@ -158,19 +164,61 @@ public class FUNCTIONS {
 		public String toString() { synchronized( sync ) { return function.toString(); } }
 
 #if #keys(primitive) || #values(primitive)
+#if #values(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
+#endif
 		public VALUE_GENERIC_CLASS put( final KEY_GENERIC_CLASS k, final VALUE_GENERIC_CLASS v ) { synchronized( sync ) { return function.put( k, v ); } }
+#if #values(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
+#endif
 		public VALUE_GENERIC_CLASS get( final Object k ) { synchronized( sync ) { return function.get( k ); } }
+#if #values(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
+#endif
 		public VALUE_GENERIC_CLASS remove( final Object k ) { synchronized( sync ) { return function.remove( k ); } }
 #endif
 
 #if #keys(primitive)
+#if #values(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
+#endif
 		public VALUE_GENERIC_TYPE remove( final KEY_GENERIC_TYPE k ) { synchronized( sync ) { return function.remove( k ); } }
+#if #values(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
+#endif
 		public VALUE_GENERIC_TYPE get( final KEY_GENERIC_TYPE k ) { synchronized( sync ) { return function.get( k ); } }
 		public boolean containsKey( final Object ok ) { synchronized( sync ) { return function.containsKey( ok ); } }
 #endif
 
 #if #keys(reference)
+#if #values(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
+#endif
 		public VALUE_GENERIC_TYPE REMOVE_VALUE( final Object k ) { synchronized( sync ) { return function.REMOVE_VALUE( k ); } }
+#if #values(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
+#endif
 		public VALUE_GENERIC_TYPE GET_VALUE( final Object k ) { synchronized( sync ) { return function.GET_VALUE( k ); } }
 #endif
 
@@ -221,13 +269,37 @@ public class FUNCTIONS {
 		public String toString() { return function.toString(); }
 
 #if #keys(primitive)
+#if #values(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
+#endif
 		public VALUE_GENERIC_TYPE remove( final KEY_GENERIC_TYPE k ) { throw new UnsupportedOperationException(); }
+#if #values(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
+#endif
 		public VALUE_GENERIC_TYPE get( final KEY_GENERIC_TYPE k ) { return function.get( k ); }
 		public boolean containsKey( final Object ok ) { return function.containsKey( ok ); }
 #endif
 
 #if #keys(reference) || #values(reference)
+#if #values(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
+#endif
 		public VALUE_GENERIC_TYPE REMOVE_VALUE( final Object k ) { throw new UnsupportedOperationException(); }
+#if #values(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
+#endif
 		public VALUE_GENERIC_TYPE GET_VALUE( final Object k ) { return function.GET_VALUE( k ); }
 #endif
 

--- a/drv/Iterators.drv
+++ b/drv/Iterators.drv
@@ -660,6 +660,10 @@ public class ITERATORS {
 
 		public KEY_GENERIC_TYPE NEXT_KEY() { return i.NEXT_KEY(); }
 #if #keys(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
 		public KEY_GENERIC_CLASS next() { return i.next(); }
 #endif
 	}
@@ -688,7 +692,15 @@ public class ITERATORS {
 		public KEY_GENERIC_TYPE NEXT_KEY() { return i.NEXT_KEY(); }
 		public KEY_GENERIC_TYPE PREV_KEY() { return i.PREV_KEY(); }
 #if #keys(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
 		public KEY_GENERIC_CLASS next() { return i.next(); }
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
 		public KEY_GENERIC_CLASS previous() { return i.previous(); }
 #endif
 	}
@@ -718,7 +730,15 @@ public class ITERATORS {
 		public int nextIndex() { return i.nextIndex(); }
 		public int previousIndex() { return i.previousIndex(); }
 #if #keys(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
 		public KEY_GENERIC_CLASS next() { return i.next(); }
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
 		public KEY_GENERIC_CLASS previous() { return i.previous(); }
 #endif
 	}

--- a/drv/Map.drv
+++ b/drv/Map.drv
@@ -116,10 +116,26 @@ public interface MAP KEY_VALUE_GENERIC extends FUNCTION KEY_VALUE_GENERIC, Map<K
 	interface Entry KEY_VALUE_GENERIC extends Map.Entry <KEY_GENERIC_CLASS,VALUE_GENERIC_CLASS> {
 		  
 #if #keys(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
+		KEY_GENERIC_CLASS getKey();
+#endif
+
+#if #keys(primitive)
 		/**
 		 * @see java.util.Map.Entry#getKey()
 		 */
 		KEY_TYPE ENTRY_GET_KEY();
+#endif
+
+#if #values(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
+		VALUE_GENERIC_CLASS getValue();
 #endif
 
 #if #values(primitive)

--- a/drv/Maps.drv
+++ b/drv/Maps.drv
@@ -126,7 +126,17 @@ public class MAPS {
 		public VALUE_COLLECTION VALUE_GENERIC values() { if ( values == null ) values = VALUE_SETS.singleton( value ); return values; }
 
 		protected class SingletonEntry implements MAP.Entry KEY_VALUE_GENERIC, Map.Entry<KEY_GENERIC_CLASS,VALUE_GENERIC_CLASS> {
+#if #keys(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+#endif
 			public KEY_GENERIC_CLASS getKey() { return KEY2OBJ( Singleton.this.key ); }
+#if #values(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+#endif
 			public VALUE_GENERIC_CLASS getValue() { return VALUE2OBJ( Singleton.this.value ); }
 
 #if #keys(primitive)
@@ -243,21 +253,49 @@ public class MAPS {
 		public String toString() { synchronized( sync ) { return map.toString(); } }
 
 #if #keys(primitive) || #values(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
 		public VALUE_GENERIC_CLASS put( final KEY_GENERIC_CLASS k, final VALUE_GENERIC_CLASS v ) { synchronized( sync ) { return map.put( k, v ); } }
 #endif
 
 #if #keys(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
 		public VALUE_GENERIC_TYPE remove( final KEY_GENERIC_TYPE k ) { synchronized( sync ) { return map.remove( k ); } }
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
 		public VALUE_GENERIC_TYPE get( final KEY_GENERIC_TYPE k ) { synchronized( sync ) { return map.get( k ); } }
 		public boolean containsKey( final Object ok ) { synchronized( sync ) { return map.containsKey( ok ); } }
 #endif
 
 #if #values(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
 		public boolean containsValue( final Object ov ) { synchronized( sync ) { return map.containsValue( ov ); } }
 #endif
 
 #if #keys(reference)
+#if #values(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
+#endif
 		public VALUE_GENERIC_TYPE REMOVE_VALUE( final Object k ) { synchronized( sync ) { return map.REMOVE_VALUE( k ); } }
+#if #values(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
+#endif
 		public VALUE_GENERIC_TYPE GET_VALUE( final Object k ) { synchronized( sync ) { return map.GET_VALUE( k ); } }
 #endif
 
@@ -325,11 +363,23 @@ public class MAPS {
 		public String toString() { return map.toString(); }
 
 #if #keys(primitive) && #values(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
 		public VALUE_GENERIC_CLASS put( final KEY_GENERIC_CLASS k, final VALUE_GENERIC_CLASS v ) { throw new UnsupportedOperationException(); }
 #endif
 
 #if #keys(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
 		public VALUE_GENERIC_TYPE remove( final KEY_GENERIC_TYPE k ) { throw new UnsupportedOperationException(); }
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
 		public VALUE_GENERIC_TYPE get( final KEY_GENERIC_TYPE k ) { return map.get( k ); }
 		public boolean containsKey( final Object ok ) { return map.containsKey( ok ); }
 #endif
@@ -339,7 +389,19 @@ public class MAPS {
 #endif
 
 #if #keys(reference) || #values(reference)
+#if #values(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
+#endif
 		public VALUE_GENERIC_TYPE REMOVE_VALUE( final Object k ) { throw new UnsupportedOperationException(); }
+#if #values(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
+#endif
 		public VALUE_GENERIC_TYPE GET_VALUE( final Object k ) { return map.GET_VALUE( k ); }
 #endif
 

--- a/drv/OpenHashMap.drv
+++ b/drv/OpenHashMap.drv
@@ -577,6 +577,10 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 
 
 #if #values(primitive) || #keys(primitive)
+	/** {@inheritDoc}
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
+	@Override
 	public VALUE_GENERIC_CLASS put( final KEY_GENERIC_CLASS ok, final VALUE_GENERIC_CLASS ov ) {
 		final VALUE_GENERIC_TYPE v = VALUE_CLASS2TYPE( ov );
 
@@ -718,6 +722,10 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 
 
 #if #keys(primitive) || #values(primitive)
+	/** {@inheritDoc}
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
+	@Override
 	SUPPRESS_WARNINGS_KEY_UNCHECKED
 	public VALUE_GENERIC_CLASS remove( final Object ok ) {
 		final KEY_GENERIC_TYPE k = KEY_GENERIC_CAST KEY_OBJ2TYPE( ok );
@@ -1161,6 +1169,11 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 		
 		MapEntry() {}
 		
+#if #keys(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+#endif
 		public KEY_GENERIC_CLASS getKey() {
 			return KEY2OBJ( key[ index ] );
 		}
@@ -1171,6 +1184,11 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 		}
 #endif
 
+#if #values(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+#endif
 		public VALUE_GENERIC_CLASS getValue() {
 			return VALUE2OBJ( value[ index ] );
 		}
@@ -1799,7 +1817,11 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 
 #ifdef Linked
 		public ObjectBidirectionalIterator<MAP.Entry KEY_VALUE_GENERIC> iterator( final MAP.Entry KEY_VALUE_GENERIC from ) {
+#if #keys(primitive)
+			return new EntryIterator( from.ENTRY_GET_KEY() );
+#else
 			return new EntryIterator( KEY_CLASS2TYPE( from.getKey() ) );
+#endif
 		}
 
 		public ObjectBidirectionalIterator<MAP.Entry KEY_VALUE_GENERIC> fastIterator() {
@@ -1807,7 +1829,11 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 		}
 				
 		public ObjectBidirectionalIterator<MAP.Entry KEY_VALUE_GENERIC> fastIterator( final MAP.Entry KEY_VALUE_GENERIC from ) {
+#if #keys(primitive)
+			return new FastEntryIterator( from.ENTRY_GET_KEY() );
+#else
 			return new FastEntryIterator( KEY_CLASS2TYPE( from.getKey() ) );
+#endif
 		}
 				
 #endif
@@ -1949,6 +1975,10 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 		public ValueIterator() { super(); }
 		public VALUE_GENERIC_TYPE NEXT_VALUE() { return value[ nextEntry() ]; }
 #if ! #values(reference)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
 		public VALUE_GENERIC_CLASS next() { return VALUE2OBJ( value[ nextEntry() ] ); }
 #endif
 	}

--- a/drv/RBTreeMap.drv
+++ b/drv/RBTreeMap.drv
@@ -756,6 +756,10 @@ public class RB_TREE_MAP KEY_VALUE_GENERIC extends ABSTRACT_SORTED_MAP KEY_VALUE
 
 
 #if ! #keyclass(Object) || #values(primitive)
+	/** {@inheritDoc}
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
+	@Override
 	public VALUE_GENERIC_CLASS put( final KEY_GENERIC_CLASS ok, final VALUE_GENERIC_CLASS ov ) {
 		final VALUE_GENERIC_TYPE oldValue = put( KEY_CLASS2TYPE(ok), VALUE_CLASS2TYPE(ov) );
 		return modified ? OBJECT_DEFAULT_RETURN_VALUE : VALUE2OBJ( oldValue );
@@ -763,6 +767,10 @@ public class RB_TREE_MAP KEY_VALUE_GENERIC extends ABSTRACT_SORTED_MAP KEY_VALUE
 #endif
 
 #if ! #keyclass(Object) || #values(primitive)
+	/** {@inheritDoc}
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
+	@Override
 	public VALUE_GENERIC_CLASS remove( final Object ok ) {
 		final VALUE_GENERIC_TYPE oldValue = REMOVE_VALUE( KEY_OBJ2TYPE( ok ) );
 		return modified ? VALUE2OBJ( oldValue ) : OBJECT_DEFAULT_RETURN_VALUE;
@@ -950,6 +958,11 @@ public class RB_TREE_MAP KEY_VALUE_GENERIC extends ABSTRACT_SORTED_MAP KEY_VALUE
 			return prev;
 		}
 
+#if #keys(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+#endif
 		public KEY_GENERIC_CLASS getKey() {
 			return KEY2OBJ(key);
 		}
@@ -960,6 +973,11 @@ public class RB_TREE_MAP KEY_VALUE_GENERIC extends ABSTRACT_SORTED_MAP KEY_VALUE
 		}
 #endif
 		  
+#if #values(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+#endif
 		public VALUE_GENERIC_CLASS getValue() {
 			return VALUE2OBJ(value);
 		}
@@ -1071,7 +1089,10 @@ public class RB_TREE_MAP KEY_VALUE_GENERIC extends ABSTRACT_SORTED_MAP KEY_VALUE
 	}
 
 #if #keyclass(Object) && #values(primitive)
-
+	/** {@inheritDoc}
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
+	@Override
 	SUPPRESS_WARNINGS_KEY_UNCHECKED
 	public VALUE_GENERIC_CLASS get( final Object ok ) {
 		final Entry KEY_VALUE_GENERIC e = findKey( KEY_GENERIC_CAST ok );
@@ -1534,7 +1555,10 @@ public class RB_TREE_MAP KEY_VALUE_GENERIC extends ABSTRACT_SORTED_MAP KEY_VALUE
 		  
 		  
 #if #keyclass(Object) && #values(primitive)
-
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
 		SUPPRESS_WARNINGS_KEY_UNCHECKED
 		public VALUE_GENERIC_CLASS get( final Object ok ) {
 			final RB_TREE_MAP.Entry KEY_VALUE_GENERIC e;
@@ -1552,6 +1576,10 @@ public class RB_TREE_MAP KEY_VALUE_GENERIC extends ABSTRACT_SORTED_MAP KEY_VALUE
 
 		  
 #if ! #keyclass(Object) || #values(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
 		public VALUE_GENERIC_CLASS put( final KEY_GENERIC_CLASS ok, final VALUE_GENERIC_CLASS ov ) {
 			final VALUE_GENERIC_TYPE oldValue = put( KEY_CLASS2TYPE(ok), VALUE_CLASS2TYPE(ov) );
 			return modified ? OBJECT_DEFAULT_RETURN_VALUE : VALUE2OBJ( oldValue );
@@ -1567,6 +1595,10 @@ public class RB_TREE_MAP KEY_VALUE_GENERIC extends ABSTRACT_SORTED_MAP KEY_VALUE
 		}
 
 #if ! #keyclass(Object) || #values(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
 		public VALUE_GENERIC_CLASS remove( final Object ok ) {
 			final VALUE_GENERIC_TYPE oldValue = REMOVE_VALUE( KEY_OBJ2TYPE( ok ) );
 			return modified ? VALUE2OBJ( oldValue ) : OBJECT_DEFAULT_RETURN_VALUE;
@@ -1662,12 +1694,20 @@ public class RB_TREE_MAP KEY_VALUE_GENERIC extends ABSTRACT_SORTED_MAP KEY_VALUE
 		}
 	 
 #if !#keyclass(Object)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
 		public KEY_GENERIC_CLASS firstKey() {
 			RB_TREE_MAP.Entry KEY_VALUE_GENERIC e = firstEntry();
 			if ( e == null ) throw new NoSuchElementException();
 			return e.getKey();
 		}
 	 
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
+		@Override
 		public KEY_GENERIC_CLASS lastKey() {
 			RB_TREE_MAP.Entry KEY_VALUE_GENERIC e = lastEntry();
 			if ( e == null ) throw new NoSuchElementException();

--- a/drv/RBTreeSet.drv
+++ b/drv/RBTreeSet.drv
@@ -1141,7 +1141,7 @@ public class RB_TREE_SET KEY_GENERIC extends ABSTRACT_SORTED_SET KEY_GENERIC imp
 		public void clear() {
 			final SubsetIterator i = new SubsetIterator();
 			while( i.hasNext() ) {
-				i.next();
+				i.NEXT_KEY();
 				i.remove();
 			}
 		}
@@ -1177,7 +1177,7 @@ public class RB_TREE_SET KEY_GENERIC extends ABSTRACT_SORTED_SET KEY_GENERIC imp
 				
 			while( i.hasNext() ) {
 				n++;
-				i.next();
+				i.NEXT_KEY();
 			}
 				
 			return n;

--- a/drv/SortedMaps.drv
+++ b/drv/SortedMaps.drv
@@ -83,11 +83,26 @@ public class SORTED_MAPS {
 		public KEY_GENERIC_TYPE LAST_KEY() { throw new NoSuchElementException(); }
 
 #if #keys(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
 		public SORTED_MAP KEY_VALUE_GENERIC headMap( KEY_GENERIC_CLASS oto ) { return headMap( KEY_CLASS2TYPE( oto ) ); }
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
 		public SORTED_MAP KEY_VALUE_GENERIC tailMap( KEY_GENERIC_CLASS ofrom ) { return tailMap( KEY_CLASS2TYPE( ofrom ) ); }
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
 		public SORTED_MAP KEY_VALUE_GENERIC subMap( KEY_GENERIC_CLASS ofrom, KEY_GENERIC_CLASS oto ) { return subMap( KEY_CLASS2TYPE( ofrom ), KEY_CLASS2TYPE( oto ) ); }
 
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
 		public KEY_GENERIC_CLASS firstKey() { return KEY2OBJ( FIRST_KEY() ); }
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
 		public KEY_GENERIC_CLASS lastKey() { return KEY2OBJ( LAST_KEY() ); }
 #endif
 
@@ -149,11 +164,26 @@ public class SORTED_MAPS {
 		public KEY_GENERIC_TYPE LAST_KEY() { return key; }
 
 #if #keys(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
 		public SORTED_MAP KEY_VALUE_GENERIC headMap( KEY_GENERIC_CLASS oto ) { return headMap( KEY_CLASS2TYPE( oto ) ); }
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
 		public SORTED_MAP KEY_VALUE_GENERIC tailMap( KEY_GENERIC_CLASS ofrom ) { return tailMap( KEY_CLASS2TYPE( ofrom ) ); }
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
 		public SORTED_MAP KEY_VALUE_GENERIC subMap( KEY_GENERIC_CLASS ofrom, KEY_GENERIC_CLASS oto ) { return subMap( KEY_CLASS2TYPE( ofrom ), KEY_CLASS2TYPE( oto ) ); }
 
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
 		public KEY_GENERIC_CLASS firstKey() { return KEY2OBJ( FIRST_KEY() ); }
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
 		public KEY_GENERIC_CLASS lastKey() { return KEY2OBJ( LAST_KEY() ); }
 #endif
 	}

--- a/drv/SortedSets.drv
+++ b/drv/SortedSets.drv
@@ -142,12 +142,27 @@ public class SORTED_SETS {
 		public KEY_GENERIC_TYPE LAST() { return element; }
 
 #if #keys(primitive)
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
 		public KEY_CLASS first() { return KEY2OBJ( element ); }
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
 		public KEY_CLASS last() { return KEY2OBJ( element ); }
 
 
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
 		public SORTED_SET KEY_GENERIC subSet( final KEY_CLASS from, final KEY_CLASS to ) { return subSet( KEY_CLASS2TYPE( from ), KEY_CLASS2TYPE( to ) ); }
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
 		public SORTED_SET KEY_GENERIC headSet( final KEY_CLASS to ) { return headSet( KEY_CLASS2TYPE( to ) ); }
+		/** {@inheritDoc}
+		 * @deprecated Please use the corresponding type-specific method instead. */
+		@Deprecated
 		public SORTED_SET KEY_GENERIC tailSet( final KEY_CLASS from ) { return tailSet( KEY_CLASS2TYPE( from ) ); }
 #endif
 	}


### PR DESCRIPTION
This patch adds @Deprecated warnings to various methods, where a non-boxed alternative exists.
This is useful for finding such locations in user code to improve the code, e.g. if getIntKey() exists, then getKey() will be deprecated and cause a warning.
Conditionals are in place to not deprecate methods for non-primitives.