### PR TITLE
 Primitives should not be boxed just for "String" conversion

### DIFF
--- a/test/it/unimi/dsi/fastutil/doubles/DoubleBigArraysTest.java
+++ b/test/it/unimi/dsi/fastutil/doubles/DoubleBigArraysTest.java
@@ -84,8 +84,8 @@ public class DoubleBigArraysTest {
 		double[][] b = DoubleBigArrays.wrap( a.clone() );
 
 		for( int i = -1; i < 20; i++ ) {
-			assertEquals( "" + i, Arrays.binarySearch( a, i ), DoubleBigArrays.binarySearch( b, i ) );
-			assertEquals( "" + i, Arrays.binarySearch( a, i ), DoubleBigArrays.binarySearch( b, i, DoubleComparators.NATURAL_COMPARATOR ) );
+			assertEquals( String.valueOf(i), Arrays.binarySearch( a, i ), DoubleBigArrays.binarySearch( b, i ) );
+			assertEquals( String.valueOf(i), Arrays.binarySearch( a, i ), DoubleBigArrays.binarySearch( b, i, DoubleComparators.NATURAL_COMPARATOR ) );
 		}
 	
 		for( int i = -1; i < 20; i++ ) {

--- a/test/it/unimi/dsi/fastutil/ints/IntBigArraysTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntBigArraysTest.java
@@ -81,8 +81,8 @@ public class IntBigArraysTest {
 		int[][] b = IntBigArrays.wrap( a.clone() );
 
 		for( int i = -1; i < 20; i++ ) {
-			assertEquals( "" + i, Arrays.binarySearch( a, i ), IntBigArrays.binarySearch( b, i ) );
-			assertEquals( "" + i, Arrays.binarySearch( a, i ), IntBigArrays.binarySearch( b, i, IntComparators.NATURAL_COMPARATOR ) );
+			assertEquals( String.valueOf(i), Arrays.binarySearch( a, i ), IntBigArrays.binarySearch( b, i ) );
+			assertEquals( String.valueOf(i), Arrays.binarySearch( a, i ), IntBigArrays.binarySearch( b, i, IntComparators.NATURAL_COMPARATOR ) );
 		}
 	
 		for( int i = -1; i < 20; i++ ) {

--- a/test/it/unimi/dsi/fastutil/objects/ObjectBigArraysTest.java
+++ b/test/it/unimi/dsi/fastutil/objects/ObjectBigArraysTest.java
@@ -76,8 +76,8 @@ public class ObjectBigArraysTest {
 		Integer[][] b = ObjectBigArrays.wrap( a.clone() );
 
 		for( int i = -1; i < 20; i++ ) { 
-			assertEquals( "" + i, Arrays.binarySearch( a, i ), ObjectBigArrays.binarySearch( b, i ) );
-			assertEquals( "" + i, Arrays.binarySearch( a, i ), ObjectBigArrays.binarySearch( b, i, ObjectComparators.NATURAL_COMPARATOR ) );
+			assertEquals( String.valueOf(i), Arrays.binarySearch( a, i ), ObjectBigArrays.binarySearch( b, i ) );
+			assertEquals( String.valueOf(i), Arrays.binarySearch( a, i ), ObjectBigArrays.binarySearch( b, i, ObjectComparators.NATURAL_COMPARATOR ) );
 		}
 	
 		for( int i = -1; i < 20; i++ ) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2131 - “Primitives should not be boxed just for "String" conversion”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2131
Please let me know if you have any questions.
Ayman Abdelghany.