### PR TITLE
Immutable List and Set

### DIFF
--- a/drv/ImmutableList.drv
+++ b/drv/ImmutableList.drv
@@ -1,0 +1,297 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package PACKAGE;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Spliterator;
+import java.util.Spliterators;
+
+/**
+ * A type-specific immutable {@link java.util.List}. It provides some
+ * additional methods compared to {@link java.util.List} that use
+ * polymorphism to avoid (un)boxing.
+ * <p/>
+ * All operations that would modify the content of the list throw
+ * {@link UnsupportedOperationException}.
+ */
+public abstract class IMMUTABLE_LIST extends ABSTRACT_LIST {
+
+    public static IMMUTABLE_LIST of() {
+        return RegularImmutableList.EMPTY;
+    }
+
+    public static IMMUTABLE_LIST of(KEY_TYPE element) {
+        return new SingletonImmutableList(element);
+    }
+
+    public static IMMUTABLE_LIST of(KEY_TYPE... elements) {
+        return copyOf(ARRAY_LIST.wrap(elements));
+    }
+
+    public static IMMUTABLE_LIST copyOf(Collection<KEY_GENERIC_CLASS> collection) {
+        if (collection instanceof IMMUTABLE_LIST) {
+            return (IMMUTABLE_LIST) collection;
+        }
+        int size = collection.size();
+        switch (size) {
+            case 0:
+                return of();
+            case 1:
+                return new SingletonImmutableList(collection.iterator().next());
+            default:
+                return new RegularImmutableList(collection);
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static Builder builder(int initialCapacity) {
+        return new Builder(initialCapacity);
+    }
+
+    @Override
+    public IMMUTABLE_LIST subList(int from, int to) {
+        ensureIndex(from);
+        ensureIndex(to);
+        if (from > to) {
+            throw new IndexOutOfBoundsException(
+                "Start index (" + from + ") is greater than end index (" + to + ')');
+        }
+        return new ImmutableSubList(this, from, to);
+    }
+
+#ifdef JDK_PRIMITIVE_SPLITERATOR
+    @Override
+    public abstract JDK_PRIMITIVE_SPLITERATOR spliterator();
+#endif
+
+    /** Implementation of this immutable list used for 0 or 2+ elements (not 1). */
+    private static class RegularImmutableList extends IMMUTABLE_LIST {
+        private static final RegularImmutableList EMPTY = new RegularImmutableList(ARRAYS.EMPTY_ARRAY);
+
+        private final KEY_TYPE[] data;
+
+        private RegularImmutableList(KEY_TYPE[] data) {
+            this.data = data;
+        }
+
+        private RegularImmutableList(Collection<KEY_GENERIC_CLASS> collection) {
+            data = new KEY_TYPE[collection.size()];
+            Iterator<KEY_GENERIC_CLASS> iterator = collection.iterator();
+            int pos = 0;
+            while (iterator.hasNext()) {
+                data[pos++] = iterator.next();
+            }
+        }
+
+        @Override
+        public KEY_TYPE GET_KEY(int index) {
+            return data[index];
+        }
+
+        @Override
+        public int size() {
+            return data.length;
+        }
+
+#ifdef JDK_PRIMITIVE_SPLITERATOR
+        @Override
+        public JDK_PRIMITIVE_SPLITERATOR spliterator() {
+            return Spliterators.spliterator(data, Spliterator.IMMUTABLE | Spliterator.NONNULL | Spliterator.ORDERED);
+        }
+#endif
+    }
+
+    /** Implementation of this immutable list with exactly one element. */
+    private static class SingletonImmutableList extends IMMUTABLE_LIST {
+        private final KEY_TYPE element;
+
+        private SingletonImmutableList(KEY_TYPE element) {
+            this.element = element;
+        }
+
+        @Override
+        public KEY_TYPE GET_KEY(int index) {
+            if (index != 0) {
+                throw new IndexOutOfBoundsException();
+            }
+            return element;
+        }
+
+        @Override
+        public int size() {
+            return 1;
+        }
+
+#ifdef JDK_PRIMITIVE_SPLITERATOR
+		@Override
+        public JDK_PRIMITIVE_SPLITERATOR spliterator() {
+            return IMMUTABLES.singletonSpliterator(element);
+        }
+#endif
+    }
+
+    public static class Builder extends IMMUTABLES.ArrayBasedBuilder {
+
+        public Builder(int initialCapacity) {
+            super(initialCapacity);
+        }
+
+        public Builder() {
+            this(DEFAULT_INITIAL_CAPACITY);
+        }
+
+        @Override
+        public Builder add(KEY_TYPE element) {
+            super.add(element);
+            return this;
+        }
+
+        @Override
+        public Builder add(KEY_TYPE... elements) {
+            super.add(elements);
+            return this;
+        }
+
+        @Override
+        public Builder addAll(LIST elements) {
+            super.addAll(elements);
+            return this;
+        }
+
+        @Override
+        public Builder addAll(Iterable<KEY_GENERIC_CLASS> elements) {
+            super.addAll(elements);
+            return this;
+        }
+
+        public int size() {
+            return size;
+        }
+
+        public boolean isEmpty() {
+            return size == 0;
+        }
+
+        public IMMUTABLE_LIST build() {
+            switch (size) {
+                case 0:
+                    return of();
+                case 1:
+                    return new SingletonImmutableList(elements[0]);
+                default:
+                    KEY_TYPE[] copy = new KEY_TYPE[size];
+                    System.arraycopy(elements, 0, copy, 0, size);
+                    return new RegularImmutableList(copy);
+            }
+        }
+    }
+
+    private static class ImmutableSubList extends IMMUTABLE_LIST {
+        /** The list this sublist restricts. */
+        private final IMMUTABLE_LIST l;
+
+        /** Initial (inclusive) index of this sublist. */
+        private final int from;
+
+        /** Final (exclusive) index of this sublist. */
+        private int to;
+
+        private ImmutableSubList(IMMUTABLE_LIST l, int from, int to) {
+            this.l = l;
+            this.from = from;
+            this.to = to;
+        }
+
+        @Override
+        public KEY_TYPE GET_KEY(int index) {
+            ensureRestrictedIndex(index);
+            return l.GET_KEY(from + index);
+        }
+
+        @Override
+        public int size() {
+            return to - from;
+        }
+
+        @Override
+        public void getElements(int from, KEY_TYPE[] a, int offset, int length) {
+            ensureIndex(from);
+            if (from + length > size()) {
+                throw new IndexOutOfBoundsException(
+                    "End index (" + from + length + ") is greater than list size (" + size() + ")");
+            }
+            l.getElements(this.from + from, a, offset, length);
+        }
+
+        @Override
+        public KEY_LIST_ITERATOR KEY_GENERIC listIterator(int index) {
+            ensureIndex(index);
+            return new KEY_LIST_ITERATOR() {
+                private int pos = index;
+
+                @Override
+                public boolean hasNext() {
+                    return pos < size();
+                }
+
+                @Override
+                public boolean hasPrevious() {
+                    return pos > 0;
+                }
+
+                @Override
+                public KEY_GENERIC_TYPE NEXT_KEY() {
+                    if (!hasNext()) {
+                        throw new NoSuchElementException();
+                    }
+                    return l.GET_KEY(from + (pos++));
+                }
+
+                @Override
+                public KEY_GENERIC_TYPE PREV_KEY() {
+                    if (!hasPrevious()) {
+                        throw new NoSuchElementException();
+                    }
+                    return l.GET_KEY(from + (--pos));
+                }
+
+                @Override
+                public int nextIndex() {
+                    return pos;
+                }
+
+                @Override
+                public int previousIndex() {
+                    return pos - 1;
+                }
+            };
+        }
+
+#ifdef JDK_PRIMITIVE_SPLITERATOR
+        @Override
+        public JDK_PRIMITIVE_SPLITERATOR spliterator() {
+            return Spliterators.spliterator(iterator(), size(), Spliterator.IMMUTABLE | Spliterator.NONNULL | Spliterator.ORDERED);
+        }
+#endif
+
+    }
+}
+

--- a/drv/ImmutableSet.drv
+++ b/drv/ImmutableSet.drv
@@ -1,0 +1,396 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package PACKAGE;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.NoSuchElementException;
+import java.util.Spliterator;
+import java.util.Spliterators;
+
+import it.unimi.dsi.fastutil.Hash;
+import it.unimi.dsi.fastutil.HashCommon;
+
+/**
+ * A type-specific immutable {@link java.util.Set}. It provides some additional
+ * methods compared to {@link java.util.Set} that use polymorphism to avoid
+ * (un)boxing.
+ * <p/>
+ * All operations that would modify the content of the set throw
+ * {@link UnsupportedOperationException}.
+ * <p/>
+ * The implementation here is open addressing and is very similar to Guava's
+ * ImmutableSet (see https://github.com/google/guava). Some of the helper
+ * methods are adapted from Guava implementation which is licensed under
+ * Apache 2.0.
+ */
+public abstract class IMMUTABLE_SET extends ABSTRACT_SET {
+
+    /** Returns the empty immutable set. */
+    public static IMMUTABLE_SET of() {
+        return RegularImmutableSet.EMPTY;
+    }
+
+    /** Returns an immutable set containing {@code element}. */
+    public static IMMUTABLE_SET of(KEY_TYPE element) {
+        return new SingletonImmutableSet(element);
+    }
+
+    /**
+     * Returns an immutable set containing the given elements.
+     */
+    public static IMMUTABLE_SET of(KEY_TYPE... elements) {
+    	// Make a copy of the provided elements array since construct
+        // method modifies the provided array and we don't own the
+        // provided elements array here.
+		KEY_TYPE[] copy = Arrays.copyOf(elements, elements.length);
+        return construct(elements.length, copy);
+    }
+
+    /**
+     * Returns an immutable set containing each of {@code elements}.
+     */
+    public static IMMUTABLE_SET copyOf(Collection<KEY_GENERIC_CLASS> elements) {
+        if (elements instanceof IMMUTABLE_SET) {
+            return (IMMUTABLE_SET) elements;
+        }
+        return construct(elements.size(), new ARRAY_LIST(elements).TO_KEY_ARRAY());
+    }
+
+#ifdef JDK_PRIMITIVE_SPLITERATOR
+    @Override
+    public abstract JDK_PRIMITIVE_SPLITERATOR spliterator();
+#endif
+
+    /** Returns a new Builder. */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Returns a new Builder which is initialized with the provided initial
+     * capacity.
+    */
+    public static Builder builder(int initialCapacity) {
+        return new Builder(initialCapacity);
+    }
+
+    public static class Builder extends IMMUTABLES.ArrayBasedBuilder {
+        public Builder(int initialCapacity) {
+            super(initialCapacity);
+        }
+
+        public Builder() {
+            this(DEFAULT_INITIAL_CAPACITY);
+        }
+
+        @Override
+        public Builder add(KEY_TYPE element) {
+            super.add(element);
+            return this;
+        }
+
+        @Override
+        public Builder add(KEY_TYPE... elements) {
+            super.add(elements);
+            return this;
+        }
+
+        @Override
+        public Builder addAll(LIST elements) {
+            super.addAll(elements);
+            return this;
+        }
+
+        @Override
+        public Builder addAll(COLLECTION elements) {
+            super.addAll(elements);
+            return this;
+        }
+
+        @Override
+        public Builder addAll(Iterable<KEY_GENERIC_CLASS> elements) {
+            super.addAll(elements);
+            return this;
+        }
+
+        public IMMUTABLE_SET build() {
+            IMMUTABLE_SET result = construct(size, elements);
+            // construct has the side effect of de-duping contents, so we
+            // update size accordingly.
+            size = result.size();
+            return result;
+        }
+    }
+
+    /**
+     * Constructs an immutable set from the first {@code n} elements of the
+     * specified array. Note that this method modifies the provided
+     * {@code elements} array.
+     */
+    private static IMMUTABLE_SET construct(int n, KEY_TYPE... elements) {
+        switch (n) {
+            case 0:
+                return of();
+            case 1:
+                return of(elements[0]);
+            default:
+                // continue below to handle the general case
+        }
+        int nonZeroCount = nonZeroCount(elements, n);
+        if (nonZeroCount == 0) {
+            // All elements are zero.
+            return new SingletonImmutableSet((KEY_TYPE) 0);
+        }
+
+        int tableSize = chooseTableSize(nonZeroCount);
+        KEY_TYPE[] table = new KEY_TYPE[tableSize];
+        int mask = tableSize - 1;
+        int hashCode = 0;
+        int uniques = 0;
+        boolean hasZero = false;
+        for (int i = 0; i < n; i++) {
+            KEY_TYPE element = elements[i];
+            if (element == 0) {
+                hasZero = true;
+                continue;
+            }
+            int j = KEY2INTHASH(element);
+            while (true) {
+                int index = j & mask;
+                KEY_TYPE value = table[index];
+                if (value == 0) {
+                    // Came to an empty slot. Put the element here.
+                    elements[uniques++] = element;
+                    table[index] = element;
+                    hashCode += KEY2JAVAHASH(element);
+                    break;
+                }
+                if (value == element) {
+                    break;
+                }
+                j++;
+            }
+        }
+        if (uniques == 1 && !hasZero) {
+            return new SingletonImmutableSet(elements[0]);
+        }
+        int size = uniques + (hasZero ? 1 : 0);
+        if (tableSize != chooseTableSize(uniques)) {
+            // Resize the table when the array includes too many duplicates.
+            if (hasZero) {
+                elements[uniques] = 0;
+            }
+            return construct(size, elements);
+        }
+        return new RegularImmutableSet(table, mask, hasZero, size, hashCode);
+    }
+
+    /**
+     * Returns the number of non-zero elements in [0, size) range in the
+     * provided array.
+     */
+    private static int nonZeroCount(KEY_TYPE[] elements, int size) {
+        int nonZeroCount = 0;
+        for (int i = 0; i < size; ++i) {
+            if (elements[i] != 0) {
+                ++nonZeroCount;
+            }
+        }
+        return nonZeroCount;
+    }
+
+    /**
+     * Returns an array size suitable for the backing array of a hash table
+     * that uses open addressing with linear probing in its implementation.
+     * The returned size is the smallest power of two that can hold
+     * {@code setSize} elements with the desired load factor.
+     */
+    private static int chooseTableSize(int setSize) {
+        int tableSize = HashCommon.arraySize(setSize, Hash.DEFAULT_LOAD_FACTOR);
+        assert tableSize > setSize;
+        return tableSize;
+    }
+
+    /** Implementation of this immutable set used for 0 or 2+ elements (not 1). */
+    private static class RegularImmutableSet extends IMMUTABLE_SET {
+        private static final RegularImmutableSet EMPTY = new RegularImmutableSet(null, 0, false, 0, 0);
+
+        /** The array of elements in hashed positions. */
+        private final KEY_TYPE[] table;
+        /** 'and' with an int to get a valid table index. */
+        private final int mask;
+        /** Whether this set contains zero. */
+        private final boolean hasZero;
+        private final int size;
+        private final int hashCode;
+
+        private RegularImmutableSet(KEY_TYPE[] table, int mask, boolean hasZero, int size, int hashCode) {
+            this.table = table;
+            this.mask = mask;
+            this.hasZero = hasZero;
+            this.size = size;
+            this.hashCode = hashCode;
+        }
+
+        @Override
+        public boolean contains(KEY_TYPE k) {
+            if (k == 0) {
+                return hasZero;
+            }
+            if (table == null) {
+                return false;
+            }
+            int i = KEY2INTHASH(k);
+            while (true) {
+                i &= mask;
+                KEY_TYPE candidate = table[i];
+                if (candidate == 0) {
+                    return false;
+                }
+                if (candidate == k) {
+                    return true;
+                }
+                i++;
+            }
+        }
+
+        @Override
+        public KEY_ITERATOR iterator() {
+            if (table == null) {
+                return ITERATORS.EMPTY_ITERATOR;
+            }
+            return new SetIterator();
+        }
+
+#ifdef JDK_PRIMITIVE_SPLITERATOR
+		@Override
+        public JDK_PRIMITIVE_SPLITERATOR spliterator() {
+            return Spliterators.spliterator(iterator(), size, Spliterator.IMMUTABLE | Spliterator.NONNULL | Spliterator.DISTINCT);
+        }
+#endif
+
+        @Override
+        public int size() {
+            return size;
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (other == this) {
+                return true;
+            }
+            if (other instanceof IMMUTABLE_SET && hashCode != other.hashCode()) {
+                return false;
+            }
+            return super.equals(other);
+        }
+
+        /** An iterator over a hash set. */
+        private class SetIterator implements KEY_ITERATOR {
+            /**
+             * The index of the last entry returned; initially,
+             * {@link #size}.
+             */
+            int pos = table.length;
+
+            /**
+             * A downward counter measuring how many entries must still be
+              returned.
+             */
+            private int c = size;
+
+            /** Whether zero should be returned. */
+            private boolean mustReturnZero = hasZero;
+
+            @Override
+            public boolean hasNext() {
+                return c != 0;
+            }
+
+            @Override
+            public KEY_TYPE NEXT_KEY() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+                c--;
+                if (mustReturnZero) {
+                    mustReturnZero = false;
+                    return 0;
+                }
+                while (true) {
+                    --pos;
+                    if (table[pos] != 0) {
+                        return table[pos];
+                    }
+                }
+            }
+        }
+    }
+
+    /** Implementation of this immutable set with exactly one element. */
+    private static class SingletonImmutableSet extends IMMUTABLE_SET {
+        private final KEY_TYPE element;
+
+        private SingletonImmutableSet(KEY_TYPE element) {
+            this.element = element;
+        }
+
+        @Override
+        public boolean contains(KEY_TYPE k) {
+            return element == k;
+        }
+
+        @Override
+        public int size() {
+            return 1;
+        }
+
+        @Override
+        public int hashCode() {
+            return KEY2JAVAHASH(element);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (other == this) {
+                return true;
+            }
+            if (other instanceof IMMUTABLE_SET && hashCode() != other.hashCode()) {
+                return false;
+            }
+            return super.equals(other);
+        }
+
+        @Override
+        public KEY_ITERATOR iterator() {
+            return ITERATORS.singleton(element);
+        }
+
+#ifdef JDK_PRIMITIVE_SPLITERATOR
+		@Override
+        public JDK_PRIMITIVE_SPLITERATOR spliterator() {
+            return IMMUTABLES.singletonSpliterator(element);
+        }
+#endif
+    }
+}
+

--- a/drv/Immutables.drv
+++ b/drv/Immutables.drv
@@ -1,0 +1,160 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package PACKAGE;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Spliterator;
+
+final class IMMUTABLES {
+
+    private IMMUTABLES() { }
+
+    private abstract static class Builder {
+        Builder() { }
+
+        public abstract Builder add(KEY_TYPE element);
+
+        public Builder add(KEY_TYPE... elements) {
+            for (KEY_TYPE element : elements) {
+                add(element);
+            }
+            return this;
+        }
+
+        public Builder addAll(Iterable<KEY_GENERIC_CLASS> elements) {
+            for (KEY_TYPE element : elements) {
+                add(element);
+            }
+            return this;
+        }
+    }
+
+    abstract static class ArrayBasedBuilder extends Builder {
+        static final int DEFAULT_INITIAL_CAPACITY = 4;
+
+        static int expandedCapacity(int oldCapacity, int minCapacity) {
+            assert minCapacity > 0;
+            int newCapacity = oldCapacity + (oldCapacity >> 1) + 1;
+            if (newCapacity < minCapacity) {
+                newCapacity = Integer.highestOneBit(minCapacity - 1) << 1;
+            }
+            if (newCapacity < 0) {
+                newCapacity = Integer.MAX_VALUE;
+            }
+            return newCapacity;
+        }
+
+        protected KEY_TYPE[] elements;
+        protected int size;
+
+        ArrayBasedBuilder(int initialCapacity) {
+            elements = new KEY_TYPE[initialCapacity];
+            size = 0;
+        }
+
+        private void ensureCapacity(int minCapacity) {
+            if (elements.length < minCapacity) {
+                int newLength = expandedCapacity(elements.length, minCapacity);
+                elements = Arrays.copyOf(elements, newLength);
+            }
+        }
+
+        @Override
+        public ArrayBasedBuilder add(KEY_TYPE element) {
+            ensureCapacity(size + 1);
+            elements[size++] = element;
+            return this;
+        }
+
+        @Override
+        public ArrayBasedBuilder add(KEY_TYPE... elements) {
+            ensureCapacity(size + elements.length);
+            System.arraycopy(elements, 0, this.elements, size, elements.length);
+            size += elements.length;
+            return this;
+        }
+
+        public ArrayBasedBuilder addAll(LIST elements) {
+            int n = elements.size();
+            ensureCapacity(size + n);
+            for (int i = 0; i < n; ++i) {
+                this.elements[size++] = elements.GET_KEY(i);
+            }
+            return this;
+        }
+
+        public ArrayBasedBuilder addAll(COLLECTION elements) {
+             int n = elements.size();
+             ensureCapacity(size + n);
+             KEY_ITERATOR iterator = elements.iterator();
+             while (iterator.hasNext()) {
+                 this.elements[size++] = iterator.NEXT_KEY();
+             }
+             return this;
+         }
+
+        @Override
+        public ArrayBasedBuilder addAll(Iterable<KEY_GENERIC_CLASS> elements) {
+            if (elements instanceof Collection) {
+                Collection<?> collection = (Collection<?>) elements;
+                ensureCapacity(size + collection.size());
+            }
+            super.addAll(elements);
+            return this;
+        }
+    }
+
+#ifdef JDK_PRIMITIVE_SPLITERATOR
+
+		/**
+     * Creates a {@link Spliterator} with only the specified element.
+     */
+    static JDK_PRIMITIVE_SPLITERATOR singletonSpliterator(KEY_TYPE element) {
+        return new JDK_PRIMITIVE_SPLITERATOR() {
+            private long est = 1;
+
+            @Override
+            public JDK_PRIMITIVE_SPLITERATOR trySplit() {
+                return null;
+            }
+
+            @Override
+            public boolean tryAdvance(JDK_PRIMITIVE_KEY_CONSUMER consumer) {
+                Objects.requireNonNull(consumer);
+                if (est > 0) {
+                    est--;
+                    consumer.accept(element);
+                    return true;
+                }
+                return false;
+            }
+
+            @Override
+            public long estimateSize() {
+                return est;
+            }
+
+            @Override
+            public int characteristics() {
+                return Spliterator.NONNULL | Spliterator.SIZED | Spliterator.SUBSIZED | Spliterator.IMMUTABLE |
+                       Spliterator.DISTINCT | Spliterator.ORDERED;
+            }
+        };
+    }
+
+#endif
+}

--- a/gencsource.sh
+++ b/gencsource.sh
@@ -46,6 +46,7 @@ else
     abstract=Abstract
 fi
 class=${class#Striped}
+class=${class#Immutable}
 
 # Now we rip off the types.
 rem=${class##[A-Z]+([a-z])}
@@ -138,6 +139,7 @@ $(if [[ "${CLASS[$k]}" != "" ]]; then\
 	fi;\
 	if [[ "${CLASS[$k]}" == "Integer" || "${CLASS[$k]}" == "Long" || "${CLASS[$k]}" == "Double" ]]; then\
 		echo "#define JDK_PRIMITIVE_ITERATOR PrimitiveIterator.Of${TYPE_CAP[$k]}\\n";\
+		echo "#define JDK_PRIMITIVE_SPLITERATOR Spliterator.Of${TYPE_CAP[$k]}\\n";\
 	fi;\
  fi)\
 $(if [[ "${CLASS[$v]}" != "" ]]; then\
@@ -322,6 +324,7 @@ fi)\
 \
 "#define COLLECTION ${TYPE_CAP[$k]}Collection\n"\
 "#define SET ${TYPE_CAP[$k]}Set\n"\
+"#define IMMUTABLE_SET Immutable${TYPE_CAP[$k]}Set\n"\
 "#define HASH ${TYPE_CAP[$k]}Hash\n"\
 "#define SORTED_SET ${TYPE_CAP[$k]}SortedSet\n"\
 "#define STD_SORTED_SET ${TYPE_STD[$k]}SortedSet\n"\
@@ -336,6 +339,7 @@ fi)\
 "#define STRATEGY PACKAGE.${TYPE_CAP[$k]}Hash.Strategy\n"\
 "#endif\n"\
 "#define LIST ${TYPE_CAP[$k]}List\n"\
+"#define IMMUTABLE_LIST Immutable${TYPE_CAP[$k]}List\n"\
 "#define BIG_LIST ${TYPE_CAP[$k]}BigList\n"\
 "#define STACK ${TYPE_STD[$k]}Stack\n"\
 "#define PRIORITY_QUEUE ${TYPE_STD[$k]}PriorityQueue\n"\
@@ -404,6 +408,7 @@ fi)\
 "#define SORTED_SETS ${TYPE_CAP[$k]}SortedSets\n"\
 "#define LISTS ${TYPE_CAP[$k]}Lists\n"\
 "#define BIG_LISTS ${TYPE_CAP[$k]}BigLists\n"\
+"#define IMMUTABLES ${TYPE_CAP[$k]}Immutables\n"\
 "#define MAPS ${TYPE_CAP[$k]}2${TYPE_CAP[$v]}Maps\n"\
 "#define FUNCTIONS ${TYPE_CAP[$k]}2${TYPE_CAP[$v]}Functions\n"\
 "#define SORTED_MAPS ${TYPE_CAP[$k]}2${TYPE_CAP[$v]}SortedMaps\n"\

--- a/makefile
+++ b/makefile
@@ -174,6 +174,16 @@ $(LISTS): drv/List.drv; ./gencsource.sh $< $@ >$@
 
 CSOURCES += $(LISTS)
 
+IMMUTABLE_LIST := $(foreach k,$(TYPE_NOBOOL_NOOBJ), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/Immutable$(k)List.c)
+$(IMMUTABLE_LIST): drv/ImmutableList.drv; ./gencsource.sh $< $@ >$@
+
+CSOURCES += $(IMMUTABLE_LIST)
+
+IMMUTABLE_SET := $(foreach k,$(TYPE_NOBOOL_NOOBJ), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/Immutable$(k)Set.c)
+$(IMMUTABLE_SET): drv/ImmutableSet.drv; ./gencsource.sh $< $@ >$@
+
+CSOURCES += $(IMMUTABLE_SET)
+
 STACKS := $(foreach k,$(TYPE_NOOBJ), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/$(k)Stack.c)
 $(STACKS): drv/Stack.drv; ./gencsource.sh $< $@ >$@
 
@@ -223,6 +233,7 @@ BIG_LIST_ITERATORS := $(foreach k,$(TYPE_NOREF), $(GEN_SRCDIR)/$(PKG_PATH)/$(PAC
 $(BIG_LIST_ITERATORS): drv/BigListIterator.drv; ./gencsource.sh $< $@ >$@
 
 CSOURCES += $(BIG_LIST_ITERATORS)
+
 
 #
 # Abstract implementations
@@ -436,6 +447,11 @@ CSOURCES += $(ARRAY_INDIRECT_PRIORITY_QUEUES)
 #
 # Static containers
 #
+
+IMMUTABLES := $(foreach k,$(TYPE_NOBOOL_NOOBJ), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/$(k)Immutables.c)
+$(IMMUTABLES): drv/Immutables.drv; ./gencsource.sh $< $@ >$@
+
+CSOURCES += $(IMMUTABLES)
 
 ITERATORS_STATIC := $(foreach k,$(TYPE_NOREF), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/$(k)Iterators.c)
 $(ITERATORS_STATIC): drv/Iterators.drv; ./gencsource.sh $< $@ >$@


### PR DESCRIPTION
This patch implements immutable versions of List and Set. fastutil
already had helper methods like "IntLists.unmodifiable(list1)" but
the resturned list in this case was just an unmodifiable view of
list1 and not truely immutable. Updating list1 would still result
in changes in the unmodifiable view.

The ImmutableList and ImmutableSet implementations here use Builder
pattern or static methods to collect the data in the collections and
then build the immutable collection from that. Hence in addition to
immutability, they also use the minimum memory required for the
provided size of data.