### PR TITLE
Extend primitive iterators of the JDK

### DIFF
--- a/drv/Iterator.drv
+++ b/drv/Iterator.drv
@@ -17,7 +17,11 @@
 
 package PACKAGE;
 
+#ifdef JDK_PRIMITIVE_ITERATOR
+import java.util.PrimitiveIterator;
+#else
 import java.util.Iterator;
+#endif
 
 /** A type-specific {@link Iterator}; provides an additional method to avoid (un)boxing, and
  * the possibility to skip elements.
@@ -25,8 +29,11 @@ import java.util.Iterator;
  * @see Iterator
  */
 
+#ifdef JDK_PRIMITIVE_ITERATOR
+public interface KEY_ITERATOR KEY_GENERIC extends JDK_PRIMITIVE_ITERATOR {
+#else
 public interface KEY_ITERATOR KEY_GENERIC extends Iterator<KEY_GENERIC_CLASS> {
-
+#endif
 
 #if KEYS_PRIMITIVE
 	/**
@@ -36,6 +43,9 @@ public interface KEY_ITERATOR KEY_GENERIC extends Iterator<KEY_GENERIC_CLASS> {
 	 * @see Iterator#next()
 	 */
 
+#ifdef JDK_PRIMITIVE_ITERATOR
+	@Override
+#endif
 	KEY_TYPE NEXT_KEY();
 
 	/** {@inheritDoc}

--- a/gencsource.sh
+++ b/gencsource.sh
@@ -118,6 +118,9 @@ $(if [[ "${CLASS[$k]}" != "" ]]; then\
 	else\
 		echo "#define KEYS_REFERENCE 1\\n";\
 	fi;\
+	if [[ "${CLASS[$k]}" == "Integer" || "${CLASS[$k]}" == "Long" || "${CLASS[$k]}" == "Double" ]]; then\
+		echo "#define JDK_PRIMITIVE_ITERATOR PrimitiveIterator.Of${TYPE_CAP[$k]}\\n";\
+	fi;\
  fi)\
 $(if [[ "${CLASS[$v]}" != "" ]]; then\
 	echo "#define VALUE_CLASS_${CLASS[$v]} 1\\n";\


### PR DESCRIPTION
Type-specific iterators now extend the primitive iterators of the JDK if available.

Closes #43