### PR TITLE
overview.html: fix a couple typos

### DIFF
--- a/src/overview.html
+++ b/src/overview.html
@@ -117,7 +117,7 @@
 
     <p><strong>Warning</strong>: automatic boxing and unboxing can lead you
     to choose the wrong method when using <code>fastutil</code>. It is also extremely inefficient.
-    We suggest that your programming environment is set so to mark boxin/unboxing as
+    We suggest that your programming environment is set so to mark boxing/unboxing as
     a warning, or even better, as an error.
 
     <p>Of course, the main point of type-specific data structures is that the
@@ -195,7 +195,7 @@
     <p>For a number of data structures that were not available in the
     <a href="http://java.sun.com/j2se/1.5/docs/guide/collections/">Java&trade; Collections Framework</a>
     when <code>fastutil</code> was created, an object-based version is
-    contained {@link it.unimi.dsi.fastutil}, and in that case the prefix
+    contained in {@link it.unimi.dsi.fastutil}, and in that case the prefix
     <code>Object</code> is not used (see, e.g., {@link it.unimi.dsi.fastutil.PriorityQueue}).
 
     <p>Since there are eight primitive types in Java, and we support
@@ -224,7 +224,7 @@
     implementations. To get more information, you can look at a specific
     implementation in {@link
     it.unimi.dsi.fastutil} or, for instance, {@link it.unimi.dsi.fastutil.ints}. Note that a few existing
-    abstract classes have been deprecated and are not listed here (they are not longer necessary due to
+    abstract classes have been deprecated and are not listed here (they are no longer necessary due to
     default methods in the corresponding interfaces).
 
     <div align=center>


### PR DESCRIPTION
This fixes a couple minor typos in overview.html.