### PR TITLE
Making fastutil ArrayList#ensureCapacity compatible with jdk ArrayList#ensureCapacity

### DIFF
--- a/drv/ArrayList.drv
+++ b/drv/ArrayList.drv
@@ -280,13 +280,13 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 	}
 
 
-	/** Ensures that this array list can contain the given number of entries without resizing.
+	/** Ensures that this array list can contain the given number of entries without resizing, if necessary.
 	 *
 	 * @param capacity the new minimum capacity for this array list.
 	 */
 	SUPPRESS_WARNINGS_KEY_UNCHECKED
 	public void ensureCapacity(final int capacity) {
-		if (capacity <= a.length || a == ARRAYS.DEFAULT_EMPTY_ARRAY) return;
+		if (capacity <= a.length || (a == ARRAYS.DEFAULT_EMPTY_ARRAY && capacity <= DEFAULT_INITIAL_CAPACITY)) return;
 #if KEYS_PRIMITIVE
 		a = ARRAYS.ensureCapacity(a, capacity, size);
 #else


### PR DESCRIPTION
See [the comment](https://github.com/vigna/fastutil/commit/8e37a5581a5e4d5d9cb73afba013842992d3ff05#r32297290) for more information.