### PR TITLE
Make every unit test and main test use unique filename

### DIFF
--- a/drv/AVLTreeMap.drv
+++ b/drv/AVLTreeMap.drv
@@ -2441,7 +2441,7 @@ public class AVL_TREE_MAP KEY_VALUE_GENERIC extends ABSTRACT_SORTED_MAP  KEY_VAL
 		SORTED_MAP m2 = null;
 
 		try {
-			java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test");
+			java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test." + m.getClass().getSimpleName() + "." + n);
 			java.io.OutputStream os = new java.io.FileOutputStream(ff);
 			java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(os);
 

--- a/drv/AVLTreeSet.drv
+++ b/drv/AVLTreeSet.drv
@@ -1942,7 +1942,7 @@ public class AVL_TREE_SET KEY_GENERIC extends ABSTRACT_SORTED_SET KEY_GENERIC im
 		SORTED_SET m2 = null;
 
 		try {
-			java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test");
+			java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test." + m.getClass().getSimpleName() + "." + n);
 			java.io.OutputStream os = new java.io.FileOutputStream(ff);
 			java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(os);
 

--- a/drv/ArrayFrontCodedList.drv
+++ b/drv/ArrayFrontCodedList.drv
@@ -678,7 +678,7 @@ public class ARRAY_FRONT_CODED_LIST extends AbstractObjectList<KEY_TYPE[]> imple
 
 
 		try {
-			java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test");
+			java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test." + m.getClass().getSimpleName() + "." + n);
 			java.io.OutputStream os = new java.io.FileOutputStream(ff);
 			java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(os);
 

--- a/drv/ArrayList.drv
+++ b/drv/ArrayList.drv
@@ -1105,7 +1105,7 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 		LIST m2 = null;
 
 		try {
-			java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test");
+			java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test." + m.getClass().getSimpleName() + "." + n);
 			java.io.OutputStream os = new java.io.FileOutputStream(ff);
 			java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(os);
 

--- a/drv/BigArrayBigList.drv
+++ b/drv/BigArrayBigList.drv
@@ -1016,7 +1016,7 @@ public class BIG_ARRAY_BIG_LIST KEY_GENERIC extends ABSTRACT_BIG_LIST KEY_GENERI
 		BIG_LIST m2 = null;
 
 		try {
-			java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test");
+			java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test." + m.getClass().getSimpleName() + "." + n);
 			java.io.OutputStream os = new java.io.FileOutputStream(ff);
 			java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(os);
 

--- a/drv/BigLists.drv
+++ b/drv/BigLists.drv
@@ -1102,7 +1102,7 @@ public final class BIG_LISTS {
 		BIG_LIST m2 = null;
 
 		try {
-			java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test");
+			java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test." + m.getClass().getSimpleName() + "." + n);
 			java.io.OutputStream os = new java.io.FileOutputStream(ff);
 			java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(os);
 

--- a/drv/Lists.drv
+++ b/drv/Lists.drv
@@ -1008,7 +1008,7 @@ public final class LISTS {
 		LIST m2 = null;
 
 		try {
-			java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test");
+			java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test." + m.getClass().getSimpleName() + "." + n);
 			java.io.OutputStream os = new java.io.FileOutputStream(ff);
 			java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(os);
 

--- a/drv/OpenHashBigSet.drv
+++ b/drv/OpenHashBigSet.drv
@@ -1201,7 +1201,7 @@ public class OPEN_HASH_BIG_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC impl
 		/* Now we save and read m. */
 
 		try {
-			java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test");
+			java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test." + m.getClass().getSimpleName() + "." + n);
 			java.io.OutputStream os = new java.io.FileOutputStream(ff);
 			java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(os);
 

--- a/drv/OpenHashMap.drv
+++ b/drv/OpenHashMap.drv
@@ -3104,7 +3104,7 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 		/* Now we save and read m. */
 
 		try {
-			java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test");
+			java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test." + m.getClass().getSimpleName() + "." + n);
 			java.io.OutputStream os = new java.io.FileOutputStream(ff);
 			java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(os);
 

--- a/drv/OpenHashSet.drv
+++ b/drv/OpenHashSet.drv
@@ -2174,7 +2174,7 @@ public class OPEN_HASH_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implemen
 		/* Now we save and read m. */
 
 		try {
-			java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test");
+			java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test." + m.getClass().getSimpleName() + "." + n);
 			java.io.OutputStream os = new java.io.FileOutputStream(ff);
 			java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(os);
 

--- a/drv/RBTreeMap.drv
+++ b/drv/RBTreeMap.drv
@@ -2411,7 +2411,7 @@ public class RB_TREE_MAP KEY_VALUE_GENERIC extends ABSTRACT_SORTED_MAP KEY_VALUE
 		SORTED_MAP m2 = null;
 
 		try {
-			java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test");
+			java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test." + m.getClass().getSimpleName() + "." + n);
 			java.io.OutputStream os = new java.io.FileOutputStream(ff);
 			java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(os);
 

--- a/drv/RBTreeSet.drv
+++ b/drv/RBTreeSet.drv
@@ -1913,7 +1913,7 @@ public class RB_TREE_SET KEY_GENERIC extends ABSTRACT_SORTED_SET KEY_GENERIC imp
 		SORTED_SET m2 = null;
 
 		try {
-			java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test");
+			java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test." + m.getClass().getSimpleName() + "." + n);
 			java.io.OutputStream os = new java.io.FileOutputStream(ff);
 			java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(os);
 

--- a/drv/Sets.drv
+++ b/drv/Sets.drv
@@ -485,7 +485,7 @@ public final class SETS {
 		SET m2 = null;
 
 		try {
-			java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test");
+			java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test." + m.getClass().getSimpleName() + "." + n);
 			java.io.OutputStream os = new java.io.FileOutputStream(ff);
 			java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(os);
 

--- a/drv/SortedMaps.drv
+++ b/drv/SortedMaps.drv
@@ -894,7 +894,7 @@ public final class SORTED_MAPS {
 		SORTED_MAP m2 = null;
 
 		try {
-			java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test");
+			java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test." + m.getClass().getSimpleName() + "." + n);
 			java.io.OutputStream os = new java.io.FileOutputStream(ff);
 			java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(os);
 

--- a/drv/SortedSets.drv
+++ b/drv/SortedSets.drv
@@ -683,7 +683,7 @@ public final class SORTED_SETS {
 		SORTED_SET m2 = null;
 
 		try {
-			java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test");
+			java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test." + m.getClass().getSimpleName() + "." + n);
 			java.io.OutputStream os = new java.io.FileOutputStream(ff);
 			java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(os);
 

--- a/test/it/unimi/dsi/fastutil/bytes/ByteArrayFrontCodedListTest.java
+++ b/test/it/unimi/dsi/fastutil/bytes/ByteArrayFrontCodedListTest.java
@@ -101,7 +101,7 @@ public class ByteArrayFrontCodedListTest {
 				}
 			}
 		}
-		java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test");
+		java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test.junit." + m.getClass().getSimpleName() + "." + n);
 		java.io.OutputStream os = new java.io.FileOutputStream(ff);
 		java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(os);
 		oos.writeObject(m);

--- a/test/it/unimi/dsi/fastutil/chars/CharArrayFrontCodedListTest.java
+++ b/test/it/unimi/dsi/fastutil/chars/CharArrayFrontCodedListTest.java
@@ -101,7 +101,7 @@ public class CharArrayFrontCodedListTest {
 				}
 			}
 		}
-		java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test");
+		java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test.junit." + m.getClass().getSimpleName() + "." + n);
 		java.io.OutputStream os = new java.io.FileOutputStream(ff);
 		java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(os);
 		oos.writeObject(m);

--- a/test/it/unimi/dsi/fastutil/ints/Int2IntOpenCustomHashMapTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/Int2IntOpenCustomHashMapTest.java
@@ -221,7 +221,7 @@ public class Int2IntOpenCustomHashMapTest {
 
 		/* Now we save and read m. */
 
-		java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test");
+		java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test.junit." + m.getClass().getSimpleName() + "." + n);
 		java.io.OutputStream os = new java.io.FileOutputStream(ff);
 		java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(os);
 

--- a/test/it/unimi/dsi/fastutil/ints/IntArrayFrontCodedListTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntArrayFrontCodedListTest.java
@@ -100,7 +100,7 @@ public class IntArrayFrontCodedListTest {
 				}
 			}
 		}
-		java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test");
+		java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test.junit." + m.getClass().getSimpleName() + "." + n);
 		java.io.OutputStream os = new java.io.FileOutputStream(ff);
 		java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(os);
 		oos.writeObject(m);

--- a/test/it/unimi/dsi/fastutil/ints/IntBigArrayBigListTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntBigArrayBigListTest.java
@@ -380,7 +380,7 @@ public class IntBigArrayBigListTest {
 		/* Now we save and read m. */
 		IntBigList m2 = null;
 		try {
-			final java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test");
+			final java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test.junit." + m.getClass().getSimpleName() + "." + n);
 			final java.io.OutputStream os = new java.io.FileOutputStream(ff);
 			final java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(os);
 			oos.writeObject(m);

--- a/test/it/unimi/dsi/fastutil/ints/IntLinkedOpenHashSetTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntLinkedOpenHashSetTest.java
@@ -149,7 +149,7 @@ public class IntLinkedOpenHashSetTest {
 		assertTrue("Error: m.clone() does not equal m", s.clone().equals(s));
 		int h = s.hashCode();
 		/* Now we save and read m. */
-		java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test");
+		java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test.junit." + s.getClass().getSimpleName() + "." + n);
 		java.io.OutputStream os = new java.io.FileOutputStream(ff);
 		java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(os);
 		oos.writeObject(s);

--- a/test/it/unimi/dsi/fastutil/ints/IntOpenCustomHashSetTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntOpenCustomHashSetTest.java
@@ -237,7 +237,7 @@ public class IntOpenCustomHashSetTest {
 
 		/* Now we save and read m. */
 
-		java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test");
+		java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test.junit." + m.getClass().getSimpleName() + "." + n);
 		java.io.OutputStream os = new java.io.FileOutputStream(ff);
 		java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(os);
 

--- a/test/it/unimi/dsi/fastutil/ints/IntOpenHashBigSetTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntOpenHashBigSetTest.java
@@ -254,7 +254,7 @@ public class IntOpenHashBigSetTest {
 
 		/* Now we save and read m. */
 
-		java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test");
+		java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test.junit." + m.getClass().getSimpleName() + "." + n);
 		java.io.OutputStream os = new java.io.FileOutputStream(ff);
 		java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(os);
 

--- a/test/it/unimi/dsi/fastutil/ints/IntOpenHashSetTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntOpenHashSetTest.java
@@ -415,7 +415,7 @@ public class IntOpenHashSetTest {
 
 		/* Now we save and read m. */
 
-		java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test");
+		java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test.junit." + m.getClass().getSimpleName() + "." + n);
 		java.io.OutputStream os = new java.io.FileOutputStream(ff);
 		java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(os);
 

--- a/test/it/unimi/dsi/fastutil/ints/StripedInt2IntOpenHashMapTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/StripedInt2IntOpenHashMapTest.java
@@ -150,7 +150,7 @@ public class StripedInt2IntOpenHashMapTest {
 //		}
 //		int h = m.hashCode();
 //		/* Now we save and read m. */
-//		java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test");
+//		java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test.junit." + m.getClass().getSimpleName() + "." + n);
 //		java.io.OutputStream os = new java.io.FileOutputStream(ff);
 //		java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(os);
 //		oos.writeObject(m);

--- a/test/it/unimi/dsi/fastutil/longs/LongArrayFrontCodedListTest.java
+++ b/test/it/unimi/dsi/fastutil/longs/LongArrayFrontCodedListTest.java
@@ -101,7 +101,7 @@ public class LongArrayFrontCodedListTest {
 				}
 			}
 		}
-		java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test");
+		java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test.junit." + m.getClass().getSimpleName() + "." + n);
 		java.io.OutputStream os = new java.io.FileOutputStream(ff);
 		java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(os);
 		oos.writeObject(m);

--- a/test/it/unimi/dsi/fastutil/objects/Object2IntOpenHashMapTest.java
+++ b/test/it/unimi/dsi/fastutil/objects/Object2IntOpenHashMapTest.java
@@ -153,7 +153,7 @@ public class Object2IntOpenHashMapTest {
 		}
 		int h = m.hashCode();
 		/* Now we save and read m. */
-		java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test");
+		java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test.junit." + m.getClass().getSimpleName() + "." + n);
 		java.io.OutputStream os = new java.io.FileOutputStream(ff);
 		java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(os);
 		oos.writeObject(m);

--- a/test/it/unimi/dsi/fastutil/objects/ObjectBigArrayBigListTest.java
+++ b/test/it/unimi/dsi/fastutil/objects/ObjectBigArrayBigListTest.java
@@ -376,7 +376,7 @@ public class ObjectBigArrayBigListTest {
 		/* Now we save and read m. */
 		ObjectBigList m2 = null;
 		try {
-			final java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test");
+			final java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test.junit." + m.getClass().getSimpleName() + "." + n);
 			final java.io.OutputStream os = new java.io.FileOutputStream(ff);
 			final java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(os);
 			oos.writeObject(m);

--- a/test/it/unimi/dsi/fastutil/objects/ObjectOpenHashBigSetTest.java
+++ b/test/it/unimi/dsi/fastutil/objects/ObjectOpenHashBigSetTest.java
@@ -209,7 +209,7 @@ public class ObjectOpenHashBigSetTest {
 		assertTrue("Error: m.clone() does not equal m", m.clone().equals(m));
 		int h = m.hashCode();
 		/* Now we save and read m. */
-		java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test");
+		java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test.junit." + m.getClass().getSimpleName() + "." + n);
 		java.io.OutputStream os = new java.io.FileOutputStream(ff);
 		java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(os);
 		oos.writeObject(m);

--- a/test/it/unimi/dsi/fastutil/objects/ObjectOpenHashSetTest.java
+++ b/test/it/unimi/dsi/fastutil/objects/ObjectOpenHashSetTest.java
@@ -217,7 +217,7 @@ public class ObjectOpenHashSetTest {
 		int h = m.hashCode();
 		/* Now we save and read m. */
 		try {
-			java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test");
+			java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test.junit." + m.getClass().getSimpleName() + "." + n);
 			java.io.OutputStream os = new java.io.FileOutputStream(ff);
 			java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(os);
 			oos.writeObject(m);

--- a/test/it/unimi/dsi/fastutil/shorts/ShortArrayFrontCodedListTest.java
+++ b/test/it/unimi/dsi/fastutil/shorts/ShortArrayFrontCodedListTest.java
@@ -102,7 +102,7 @@ public class ShortArrayFrontCodedListTest {
 				}
 			}
 		}
-		java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test");
+		java.io.File ff = new java.io.File("it.unimi.dsi.fastutil.test.junit." + m.getClass().getSimpleName() + "." + n);
 		java.io.OutputStream os = new java.io.FileOutputStream(ff);
 		java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(os);
 		oos.writeObject(m);


### PR DESCRIPTION
Previously, every test tried to serialize to the same file,
"it.unimi.dsi.fastutil.test". This mean if the tests were run in
parallel, they would "step on each others toes" and overwrite each
others' serialized files, causing strange exceptions in the
deserialization tests when run in parallel.

Now each test has a unique file it writes to by keying off the name of
the class of the thing being serialized.

This fixes https://github.com/vigna/fastutil/issues/119