### PR TITLE
Override reversed() and thenComparing() for primitive Comparators

### DIFF
--- a/drv/Comparator.drv
+++ b/drv/Comparator.drv
@@ -43,6 +43,11 @@ public interface KEY_COMPARATOR KEY_GENERIC extends Comparator<KEY_GENERIC_CLASS
 
 	int compare(KEY_TYPE k1, KEY_TYPE k2);
 
+	@Override
+	default KEY_COMPARATOR KEY_GENERIC reversed() {
+		return COMPARATORS.oppositeComparator(this);
+	}
+
 #if KEYS_PRIMITIVE
 	/** {@inheritDoc}
 	 * <p>This implementation delegates to the corresponding type-specific method.
@@ -52,6 +57,18 @@ public interface KEY_COMPARATOR KEY_GENERIC extends Comparator<KEY_GENERIC_CLASS
 	default int compare(KEY_GENERIC_CLASS ok1, KEY_GENERIC_CLASS ok2) {
 		return compare(ok1.KEY_VALUE(), ok2.KEY_VALUE());
 	}
-#endif
 
+	default KEY_COMPARATOR KEY_GENERIC thenComparing(KEY_COMPARATOR KEY_SUPER_GENERIC second) {
+		return (KEY_COMPARATOR KEY_SUPER_GENERIC & java.io.Serializable) (k1, k2) -> {
+			int comp = compare(k1, k2);
+			return comp == 0 ? second.compare(k1, k2) : comp;
+		};
+	}
+
+	@Override
+	default Comparator<KEY_GENERIC_CLASS> KEY_GENERIC thenComparing(Comparator<? super KEY_CLASS> second) {
+		if (second instanceof KEY_COMPARATOR) return thenComparing((KEY_COMPARATOR KEY_SUPER_GENERIC)second);
+		return Comparator.super.thenComparing(second);
+	}
+#endif
 }

--- a/drv/Comparator.drv
+++ b/drv/Comparator.drv
@@ -66,7 +66,7 @@ public interface KEY_COMPARATOR KEY_GENERIC extends Comparator<KEY_GENERIC_CLASS
 	}
 
 	@Override
-	default Comparator<KEY_GENERIC_CLASS> KEY_GENERIC thenComparing(Comparator<? super KEY_CLASS> second) {
+	default Comparator<KEY_GENERIC_CLASS> KEY_GENERIC thenComparing(Comparator<? super KEY_GENERIC_CLASS> second) {
 		if (second instanceof KEY_COMPARATOR) return thenComparing((KEY_COMPARATOR KEY_SUPER_GENERIC)second);
 		return Comparator.super.thenComparing(second);
 	}

--- a/drv/Comparator.drv
+++ b/drv/Comparator.drv
@@ -58,6 +58,11 @@ public interface KEY_COMPARATOR KEY_GENERIC extends Comparator<KEY_GENERIC_CLASS
 		return compare(ok1.KEY_VALUE(), ok2.KEY_VALUE());
 	}
 
+	/** Return a new comparator that first uses this comparator, then uses the second comparator
+	 * if this comparator compared the two elements as equal.
+	 *
+	 * @see Comparator#thenComparing(Comparator)
+	 */
 	default KEY_COMPARATOR KEY_GENERIC thenComparing(KEY_COMPARATOR KEY_SUPER_GENERIC second) {
 		return (KEY_COMPARATOR KEY_SUPER_GENERIC & java.io.Serializable) (k1, k2) -> {
 			int comp = compare(k1, k2);

--- a/drv/Comparators.drv
+++ b/drv/Comparators.drv
@@ -43,6 +43,10 @@ public final class COMPARATORS {
 			return ((Comparable)a).compareTo(b);
 #endif
 		}
+
+		@Override
+		public KEY_COMPARATOR reversed() { return OPPOSITE_COMPARATOR; }
+		
 		private Object readResolve() { return NATURAL_COMPARATOR; }
 	};
 
@@ -66,6 +70,9 @@ public final class COMPARATORS {
 			return ((Comparable)b).compareTo(a);
 #endif
 		}
+		@Override
+		public KEY_COMPARATOR reversed() { return NATURAL_COMPARATOR; }
+
 		private Object readResolve() { return OPPOSITE_COMPARATOR; }
 	};
 
@@ -79,7 +86,7 @@ public final class COMPARATORS {
 #endif
 		private static final long serialVersionUID = 1L;
 
-		private final KEY_COMPARATOR KEY_GENERIC comparator;
+		final KEY_COMPARATOR KEY_GENERIC comparator;
 
 		protected OppositeComparator(final KEY_COMPARATOR KEY_GENERIC c) { comparator = c; }
 
@@ -95,7 +102,10 @@ public final class COMPARATORS {
 	 * @param c a comparator.
 	 * @return a comparator representing the opposite order of {@code c}.
 	 */
-	public static KEY_GENERIC KEY_COMPARATOR KEY_GENERIC oppositeComparator(final KEY_COMPARATOR KEY_GENERIC c) { return new OppositeComparator KEY_GENERIC_DIAMOND(c); }
+	public static KEY_GENERIC KEY_COMPARATOR KEY_GENERIC oppositeComparator(final KEY_COMPARATOR KEY_GENERIC c) {
+		if (c instanceof OppositeComparator) return ((OppositeComparator KEY_GENERIC)c).comparator;
+		return new OppositeComparator KEY_GENERIC_DIAMOND(c);
+	}
 
 #if KEYS_PRIMITIVE
 	/** Returns a type-specific comparator that is equivalent to the given comparator.

--- a/drv/Comparators.drv
+++ b/drv/Comparators.drv
@@ -85,6 +85,9 @@ public final class COMPARATORS {
 
 		@Override
 		public final int compare(final KEY_GENERIC_TYPE a, final KEY_GENERIC_TYPE b) { return comparator.compare(b, a); }
+
+		@Override
+		public final KEY_COMPARATOR KEY_GENERIC reversed() { return comparator; }
 	};
 
 	/** Returns a comparator representing the opposite order of the given comparator.


### PR DESCRIPTION
Only one overload of thenComparing() is overridden. The others that take
functions that do a key extraction will require more code gen (possibly more then it is worth).