### PR TITLE
Add an identity-based hash strategy

### DIFF
--- a/src/it/unimi/dsi/fastutil/Hash.java
+++ b/src/it/unimi/dsi/fastutil/Hash.java
@@ -105,6 +105,36 @@ public interface Hash {
 		 * @return true if the two specified objects are equal with respect to this hash strategy.
 		 */
 		boolean equals(K a, K b);
+
+		/**
+		 * Returns an identity-based hash strategy.
+		 *
+		 * @param <K> the type to be used in the strategy
+		 * @return an identity-based hash strategy
+		 */
+		@SuppressWarnings("unchecked")
+		static <K> Strategy<K> identity() {
+			return (Strategy<K>) Identity.INSTANCE;
+		}
+
+		/**
+		 * An identity-based hash strategy.
+		 *
+		 * @param <K> the type to be used in the strategy
+		 */
+		final class Identity<K> implements Strategy<K> {
+			static final Identity<?> INSTANCE = new Identity<>();
+
+			@Override
+			public int hashCode(final K o) {
+				return System.identityHashCode(o);
+			}
+
+			@Override
+			public boolean equals(final K a, final K b) {
+				return a == b;
+			}
+		}
 	}
 
 	/** The default growth factor of a hash table. */

--- a/test/it/unimi/dsi/fastutil/HashStrategyTest.java
+++ b/test/it/unimi/dsi/fastutil/HashStrategyTest.java
@@ -1,0 +1,55 @@
+package it.unimi.dsi.fastutil;
+
+/*
+ * Copyright (C) 2017 Sebastiano Vigna
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *		 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class HashStrategyTest {
+	@Test
+	public void testIdentityStrategy_equals() {
+		final Object to = new Object();
+		assertTrue(Hash.Strategy.identity().equals(to, to));
+		// AlwaysEqual's equals method returns true, but our hash strategy should not
+		assertFalse(Hash.Strategy.identity().equals(new AlwaysEqual(), new AlwaysEqual()));
+	}
+
+	@Test
+	public void testIdentityStrategy_hashCode() {
+		final Object to = new Object();
+		// We shouldn't be getting the value of AlwaysEqual's hashCode method here
+		assertNotEquals(42, Hash.Strategy.identity().hashCode(new AlwaysEqual()));
+		assertEquals(System.identityHashCode(to), Hash.Strategy.identity().hashCode(to));
+	}
+
+	private static final class AlwaysEqual {
+		@Override
+		public int hashCode() {
+			return 42;
+		}
+
+		@Override
+		public boolean equals(final Object that) {
+			return that instanceof AlwaysEqual;
+		}
+	}
+}


### PR DESCRIPTION
This introduces a new `Hash.Strategy` that is identity based.