### PR TITLE
Fix any issue where longs were using a smaller radix sort threshold

### DIFF
--- a/drv/Arrays.drv
+++ b/drv/Arrays.drv
@@ -1842,9 +1842,9 @@ public final class ARRAYS {
 #if KEY_CLASS_Byte || KEY_CLASS_Short
 	static final int RADIX_SORT_MIN_THRESHOLD = 1000;
 #elif KEY_CLASS_Long || KEY_CLASS_Double
-	static final int RADIX_SORT_MIN_THRESHOLD = 2000;
-#else
 	static final int RADIX_SORT_MIN_THRESHOLD = 4000;
+#else
+	static final int RADIX_SORT_MIN_THRESHOLD = 2000;
 #endif
 
 	/** This method fixes negative numbers so that the combination exponent/significand is lexicographically sorted. */


### PR DESCRIPTION
It was intended that longs and doubles had the greatest radix sort
threshold, but it got swapped with ints' thresholds accidentally.