### PR TITLE
Fix SafeMath#safeDoubleToFloat for values <= 0

### DIFF
--- a/src/it/unimi/dsi/fastutil/SafeMath.java
+++ b/src/it/unimi/dsi/fastutil/SafeMath.java
@@ -42,7 +42,7 @@ public final class SafeMath {
 	public static float safeDoubleToFloat(final double value) {
 		if (Double.isNaN(value)) return Float.NaN;
 		if (Double.isInfinite(value)) return value < 0.0d ? Float.NEGATIVE_INFINITY : Float.POSITIVE_INFINITY;
-		if (value < Float.MIN_VALUE || Float.MAX_VALUE < value) throw new IllegalArgumentException(value + " can't be represented as float (out of range)");
+		if (value < -Float.MAX_VALUE || Float.MAX_VALUE < value) throw new IllegalArgumentException(value + " can't be represented as float (out of range)");
 		final float floatValue = (float) value;
 		if (floatValue != value) throw new IllegalArgumentException(value + " can't be represented as float (imprecise)");
 		return floatValue;


### PR DESCRIPTION
MIN_VALUE is actually the positive closest-to-zero value that a float can represent. So this function would break on 0 and negative float values.