### PR TITLE
Improved constructors for array-based maps: use fast iterator if possible

### DIFF
--- a/drv/ArrayMap.drv
+++ b/drv/ArrayMap.drv
@@ -80,7 +80,9 @@ public class ARRAY_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENERIC 
 	public ARRAY_MAP(final MAP KEY_VALUE_GENERIC m) {
 		this(m.size());
 		int i = 0;
-		for(MAP.Entry KEY_VALUE_GENERIC e : m.ENTRYSET()) {
+		ObjectIterator<MAP.Entry KEY_VALUE_GENERIC> iterator = MAPS.fastIterator(m);
+		while(iterator.hasNext()) {
+			MAP.Entry KEY_VALUE_GENERIC e = iterator.next();
 			key[i] = e.ENTRY_GET_KEY();
 			value[i] = e.ENTRY_GET_VALUE();
 			i++;
@@ -95,8 +97,8 @@ public class ARRAY_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENERIC 
 		this(m.size());
 		int i = 0;
 		for(Map.Entry<? extends KEY_GENERIC_CLASS, ? extends VALUE_GENERIC_CLASS> e : m.entrySet()) {
-			key[i] = KEY_OBJ2TYPE(e.getKey());
-			value[i] = VALUE_OBJ2TYPE(e.getValue());
+			key[i] = e.getKey();
+			value[i] = e.getValue();
 			i++;
 		}
 	}


### PR DESCRIPTION
Small correction — for fastutil map fast iterator should be used for performance reasons.

For other map I removed class cast `KEY_OBJ2TYPE` because it is highlighted as unnecessary class cast. 

Resulting java code:

```java
public Object2ObjectArrayMap(final Object2ObjectMap <K,V> m) {
	 this(m.size());
	 int i = 0;
	 ObjectIterator<Object2ObjectMap.Entry <K,V> > iterator = Object2ObjectMaps.fastIterator(m);
	 while(iterator.hasNext()) {
	  Object2ObjectMap.Entry <K,V> e = iterator.next();
	  key[i] = e.getKey();
	  value[i] = e.getValue();
	  i++;
	 }
	}
```