### PR TITLE
Fast in-place compute/merge methods in OpenHashMap classes

### DIFF
--- a/drv/OpenHashMap.drv
+++ b/drv/OpenHashMap.drv
@@ -1260,6 +1260,74 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 		return value[pos] = VALUE_CLASS2TYPE(newValue);
 	}
 
+#if VALUES_INT_LONG_DOUBLE
+
+#if KEYS_PRIMITIVE && KEYS_AND_VALUES_WIDENED_ARE_SAME
+	public VALUE_GENERIC_TYPE COMPUTE_IF_PRESENT_PRIMITIVE(final KEY_GENERIC_TYPE k, final JDK_PRIMITIVE_VALUE_BINARY_OPERATOR remappingFunction) {
+		java.util.Objects.requireNonNull(remappingFunction);
+		final int pos = find(k);
+		if (pos < 0) return defRetValue;
+		final VALUE_GENERIC_TYPE newValue = VALUE_NARROWING(remappingFunction.JDK_PRIMITIVE_VALUE_OPERATOR_APPLY(k, value[pos]));
+		if (newValue == defRetValue) {
+			if (KEY_EQUALS_NULL(k)) removeNullEntry();
+			else removeEntry(pos);
+			return defRetValue;
+		}
+
+		return value[pos] = newValue;
+	}
+
+	public VALUE_GENERIC_TYPE COMPUTE_PRIMITIVE(final KEY_GENERIC_TYPE k, final JDK_PRIMITIVE_VALUE_BINARY_OPERATOR remappingFunction) {
+		java.util.Objects.requireNonNull(remappingFunction);
+		final int pos = find(k);
+		VALUE_GENERIC_TYPE newVal = VALUE_NARROWING(remappingFunction.JDK_PRIMITIVE_VALUE_OPERATOR_APPLY(k, pos >= 0 ? value[pos] : defRetValue));
+		if (newVal == defRetValue) {
+			if (pos >= 0) {
+				if (KEY_EQUALS_NULL(k)) removeNullEntry();
+				else removeEntry(pos);
+			}
+			return defRetValue;
+		}
+
+		if (pos < 0) {
+			insert(-pos - 1, k, newVal);
+			return newVal;
+		}
+
+		return value[pos] = newVal;
+	}
+#endif
+
+	public VALUE_GENERIC_TYPE MERGE_PRIMITIVE(final KEY_GENERIC_TYPE k, final VALUE_GENERIC_TYPE v, final JDK_PRIMITIVE_VALUE_BINARY_OPERATOR remappingFunction) {
+		java.util.Objects.requireNonNull(remappingFunction);
+
+		final int pos = find(k);
+		if (pos < 0 || value[pos] == defRetValue) {
+			if (v == defRetValue) return defRetValue;
+
+			insert(-pos - 1, k, v);
+			return v;
+		}
+		VALUE_GENERIC_TYPE newVal = VALUE_NARROWING(remappingFunction.JDK_PRIMITIVE_VALUE_OPERATOR_APPLY(value[pos], v));
+		if (newVal == defRetValue) {
+			if (pos >= 0) {
+				if (KEY_EQUALS_NULL(k)) removeNullEntry();
+				else removeEntry(pos);
+			}
+			return defRetValue;
+		}
+
+		return value[pos] = newVal;
+	}
+
+#if KEYS_REFERENCE
+	public VALUE_GENERIC_TYPE MERGE_TYPE_SPECIFIC(final KEY_GENERIC_TYPE k, final VALUE_GENERIC_TYPE v, final VALUE_PACKAGE.VALUE_BINARY_OPERATOR remappingFunction) {
+		java.util.Objects.requireNonNull(remappingFunction);
+		return MERGE_PRIMITIVE(k, v, (JDK_PRIMITIVE_VALUE_BINARY_OPERATOR)remappingFunction);
+	}
+#endif
+
+#endif
 
 #endif
 

--- a/drv/OpenHashMap.drv
+++ b/drv/OpenHashMap.drv
@@ -1263,6 +1263,108 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 
 #endif
 
+
+	/** {@inheritDoc} */
+	@Override
+	SUPPRESS_WARNINGS_KEY_UNCHECKED
+	public VALUE_GENERIC_CLASS getOrDefault(final Object k, final VALUE_GENERIC_CLASS defaultValue) {
+		if (k == null) return defaultValue;
+		if (KEY_EQUALS_NULL(KEY_CLASS_CAST k)) return containsNullKey ? value[n] : defaultValue;
+
+		KEY_GENERIC_CLASS curr;
+		final KEY_GENERIC_TYPE[] key = this.key;
+		int pos;
+
+		// The starting point.
+		if (KEY_IS_NULL(curr = key[pos = KEY2INTHASH_CAST(KEY_CLASS_CAST k) & mask])) return defaultValue;
+		if (KEY_EQUALS_NOT_NULL_CAST(KEY_CLASS_CAST k, curr)) return value[pos];
+		// There's always an unused entry.
+		while(true) {
+			if (KEY_IS_NULL(curr = key[pos = (pos + 1) & mask])) return defaultValue;
+			if (KEY_EQUALS_NOT_NULL_CAST(KEY_CLASS_CAST k, curr)) return value[pos];
+		}
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public VALUE_GENERIC_CLASS computeIfAbsent(final KEY_GENERIC_CLASS k, final java.util.function.Function<? super KEY_GENERIC_CLASS, ? extends VALUE_GENERIC_CLASS> mappingFunction) {
+		java.util.Objects.requireNonNull(mappingFunction);
+		if (k == null) return null;
+		final int pos = find(k);
+		if (pos >= 0) return value[pos];
+		final VALUE_GENERIC_CLASS newValue = mappingFunction.apply(k);
+		if (newValue == null) return null;
+		final VALUE_GENERIC_CLASS v = VALUE_CLASS2TYPE(newValue);
+		insert(-pos - 1, k, v);
+		return v;
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public VALUE_GENERIC_CLASS computeIfPresent(final KEY_GENERIC_CLASS k, final java.util.function.BiFunction<? super KEY_GENERIC_CLASS, ? super VALUE_GENERIC_CLASS, ? extends VALUE_GENERIC_CLASS> remappingFunction) {
+		java.util.Objects.requireNonNull(remappingFunction);
+		if (k == null) return null;
+		final int pos = find(k);
+		if (pos < 0) return null;
+		final VALUE_GENERIC_CLASS newValue = remappingFunction.apply(KEY2OBJ(k), VALUE2OBJ(value[pos]));
+		if (newValue == null) {
+			if (KEY_EQUALS_NULL(KEY_CLASS_CAST k)) removeNullEntry();
+			else removeEntry(pos);
+			return null;
+		}
+		return value[pos] = VALUE_CLASS2TYPE(newValue);
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public VALUE_GENERIC_CLASS compute(final KEY_GENERIC_CLASS k, final java.util.function.BiFunction<? super KEY_GENERIC_CLASS, ? super VALUE_GENERIC_CLASS, ? extends VALUE_GENERIC_CLASS> remappingFunction) {
+		java.util.Objects.requireNonNull(remappingFunction);
+		final int pos = find(k);
+		final VALUE_GENERIC_CLASS newValue = remappingFunction.apply(KEY2OBJ(k), pos >= 0 ? VALUE2OBJ(value[pos]) : null);
+		if (newValue == null) {
+			if (pos >= 0) {
+				if (KEY_EQUALS_NULL(KEY_CLASS_CAST k)) removeNullEntry();
+				else removeEntry(pos);
+			}
+			return null;
+		}
+
+		VALUE_GENERIC_CLASS newVal = VALUE_CLASS2TYPE(newValue);
+		if (pos < 0) {
+			insert(-pos - 1, k, newVal);
+			return newVal;
+		}
+
+		return value[pos] = newVal;
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public VALUE_GENERIC_CLASS merge(final KEY_GENERIC_CLASS k, final VALUE_GENERIC_CLASS v, final java.util.function.BiFunction<? super VALUE_GENERIC_CLASS, ? super VALUE_GENERIC_CLASS, ? extends VALUE_GENERIC_CLASS> remappingFunction) {
+		java.util.Objects.requireNonNull(remappingFunction);
+		java.util.Objects.requireNonNull(v);
+
+		final int pos = find(k);
+#if VALUES_PRIMITIVE
+		if (pos < 0) {
+#else
+		if (pos < 0 || value[pos] == null) {
+			if (v == null) return null;
+#endif
+			insert(-pos - 1, k, v);
+			return v;
+		}
+
+		final VALUE_GENERIC_CLASS newValue = remappingFunction.apply(VALUE2OBJ(value[pos]), VALUE2OBJ(v));
+		if (newValue == null) {
+			if (KEY_EQUALS_NULL(KEY_CLASS_CAST k)) removeNullEntry();
+			else removeEntry(pos);
+			return null;
+		}
+
+		return value[pos] = VALUE_CLASS2TYPE(newValue);
+	}
+
 	/* Removes all elements from this map.
 	 *
 	 * <p>To increase object reuse, this method does not change the table size.

--- a/gencsource.sh
+++ b/gencsource.sh
@@ -395,6 +395,7 @@ fi)\
 "#define VALUE_ITERATOR ${TYPE_CAP2[$v]}Iterator\n"\
 "#define VALUE_SPLITERATOR ${TYPE_CAP2[$v]}Spliterator\n"\
 "#define VALUE_LIST_ITERATOR ${TYPE_CAP2[$v]}ListIterator\n"\
+"#define VALUE_BINARY_OPERATOR ${TYPE_STD[$v]}BinaryOperator\n"\
 \
 \
 "/* Types and methods related to primitive-type support in the JDK */\n"\
@@ -445,6 +446,9 @@ $(if [[ "${CLASS[$k]}" != "" && "${CLASS[$v]}" != "" ]]; then\
 			echo "#define JDK_PRIMITIVE_FUNCTION_APPLY test\\n";\
 		fi;\
 	fi;\
+  if [[ "${TYPE_CAP[$wk]}" == "${TYPE_CAP[$wv]}" ]]; then\
+    echo "#define KEYS_AND_VALUES_WIDENED_ARE_SAME 1\\n";\
+  fi;\
  fi)\
 \
 "#if KEYS_INT_LONG_DOUBLE\n"\
@@ -699,6 +703,10 @@ $(if [[ "${CLASS[$k]}" != "" && "${CLASS[$v]}" != "" ]]; then\
 "#define COMPUTE compute${TYPE_STD[$v]}\n"\
 "#define COMPUTE_IF_PRESENT compute${TYPE_STD[$v]}IfPresent\n"\
 "#define MERGE merge${TYPE_STD[$v]}\n"\
+"#if VALUES_INT_LONG_DOUBLE\n"\
+"#define MERGE_PRIMITIVE MERGE\n"\
+"#define MERGE_TYPE_SPECIFIC MERGE\n"\
+"#endif\n"\
 "#else\n"\
 "#define GET_VALUE get\n"\
 "#define REMOVE_VALUE remove\n"\
@@ -707,6 +715,14 @@ $(if [[ "${CLASS[$k]}" != "" && "${CLASS[$v]}" != "" ]]; then\
 "#define COMPUTE_IF_ABSENT_PARTIAL computeIfAbsentPartial\n"\
 "#define COMPUTE compute\n"\
 "#define COMPUTE_IF_PRESENT computeIfPresent\n"\
+"#define MERGE merge\n"\
+"#if VALUES_INT_LONG_DOUBLE\n"\
+"#define MERGE_PRIMITIVE merge${TYPE_STD[$v]}\n"\
+"#endif\n"\
+"#if KEYS_AND_VALUES_WIDENED_ARE_SAME\n"\
+"#define COMPUTE_IF_PRESENT_PRIMITIVE compute${TYPE_STD[$v]}IfPresent\n"\
+"#define COMPUTE_PRIMITIVE compute${TYPE_STD[$v]}\n"\
+"#endif\n"\
 "#endif\n"\
 \
 \

--- a/test/it/unimi/dsi/fastutil/ints/Int2IntMapGenericOpenHashTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/Int2IntMapGenericOpenHashTest.java
@@ -21,6 +21,8 @@ import static org.junit.Assert.assertEquals;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
+import java.util.function.BiFunction;
+import java.util.function.IntBinaryOperator;
 import java.util.function.Supplier;
 
 import org.junit.Test;
@@ -28,6 +30,9 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 import it.unimi.dsi.fastutil.Hash;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
 
 public class Int2IntMapGenericOpenHashTest extends Int2IntMapGenericTest<Int2IntOpenHashMap> {
 	@Parameter(2)
@@ -62,5 +67,140 @@ public class Int2IntMapGenericOpenHashTest extends Int2IntMapGenericTest<Int2Int
 		assertEquals(1, m.get(1));
 		assertEquals(1, m.addTo(1, -2));
 		assertEquals(-1, m.get(1));
+	}
+
+	@Test
+	public void testComputeIfPresentPrimitiveNoBoxing() {
+		m.defaultReturnValue(-1);
+		m.put(1, 1);
+
+		final IntBinaryOperator add = (key, value) -> key + value;
+
+		assertEquals(-1, m.computeIntIfPresent(2, add));
+		assertFalse(m.containsKey(2));
+
+		assertEquals(2, m.computeIntIfPresent(1, add));
+		assertEquals(2, m.get(1));
+		assertEquals(3, m.computeIntIfPresent(1, add));
+		assertEquals(3, m.get(1));
+
+		assertEquals(1, m.computeIntIfPresent(1, (key, value) -> 1));
+		assertTrue(m.containsKey(1));
+
+		assertEquals(-1, m.computeIntIfPresent(1, (key, value) -> -1));
+		assertFalse(m.containsKey(1));
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testComputeIfPresentPrimitiveNoBoxingNullFunction() {
+		m.put(1, 1);
+		m.computeIntIfPresent(1, null);
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testComputeIfPresentPrimitiveNoBoxingNullFunctionMissingKey() {
+		m.computeIntIfPresent(1, null);
+	}
+
+
+	@Test
+	public void testComputePrimitiveNoBoxing() {
+		m.defaultReturnValue(-1);
+
+		// Test parameters of function
+		assertEquals(1, m.computeInt(1, (key, value) -> {
+			assertEquals(1, key);
+			assertEquals(-1, value);
+			return 1;
+		}));
+		assertEquals(1, m.get(1));
+
+		assertEquals(2, m.computeInt(1, (key, value) -> {
+			assertEquals(1, key);
+			assertEquals(1, value);
+			return 2;
+		}));
+		assertEquals(2, m.get(1));
+
+		assertEquals(-1, m.computeInt(1, (key, value) -> {
+			assertEquals(1, key);
+			assertEquals(2, value);
+			return -1;
+		}));
+		assertFalse(m.containsKey(1));
+
+		// Test functionality
+		assertEquals(1000, m.computeInt(0, (x, y) -> x + (y != -1 ? y : 1000)));
+		assertEquals(1000, m.get(0));
+		assertEquals(2000, m.computeInt(0, (x, y) -> x + y * 2));
+		assertEquals(2000, m.get(0));
+		assertEquals(-1, m.computeInt(0, (x, y) -> -1));
+		assertEquals(-1, m.get(0));
+
+		assertEquals(1001, m.computeInt(1, (x, y) -> x + (y != -1 ? y : 1000)));
+		assertEquals(1001, m.get(1));
+		assertEquals(2003, m.computeInt(1, (x, y) -> x + y * 2));
+		assertEquals(2003, m.get(1));
+		assertEquals(-1, m.computeInt(1, (x, y) -> -1));
+		assertEquals(-1, m.get(1));
+
+		assertEquals(-1, m.computeInt(2, (x, y) -> -1));
+		assertEquals(-1, m.get(2));
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testComputePrimitiveNoBoxingNullFunction() {
+		m.put(1, 1);
+		m.computeInt(1, null);
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testComputePrimitiveNoBoxingNullFunctionMissingKey() {
+		m.computeInt(1, null);
+	}
+
+
+	@Test
+	public void testMergePrimitiveNoBoxing() {
+		m.defaultReturnValue(-1);
+
+		assertEquals(0, m.mergeInt(1, 0, (oldVal, newVal) -> {
+			fail();
+			return Integer.valueOf(0);
+		}));
+		assertEquals(0, m.mergeInt(1, 0, (oldVal, newVal) -> {
+			assertEquals(0, oldVal);
+			assertEquals(0, newVal);
+			return Integer.valueOf(0);
+		}));
+		assertEquals(0, m.get(1));
+		m.clear();
+
+		final IntBinaryOperator add =
+			(oldVal, newVal) -> oldVal + newVal;
+
+		assertEquals(0, m.mergeInt(1, 0, add));
+		assertEquals(1, m.mergeInt(1, 1, add));
+		assertEquals(3, m.mergeInt(1, 2, add));
+		assertEquals(0, m.mergeInt(2, 0, add));
+		assertTrue(m.containsKey(1));
+
+		assertEquals(-1, m.mergeInt(1, 2, (key, value) -> -1));
+		assertEquals(-1, m.mergeInt(2, 2, (key, value) -> -1));
+
+		assertTrue(m.isEmpty());
+	}
+
+
+	@Test(expected = NullPointerException.class)
+	public void testMergePrimitiveNoBoxingNullFunction() {
+		m.put(1, 1);
+		m.mergeInt(1, 1, null);
+	}
+
+
+	@Test(expected = NullPointerException.class)
+	public void testMergePrimitiveNoBoxingNullFunctionMissingKey() {
+		m.mergeInt(1, 1, null);
 	}
 }

--- a/test/it/unimi/dsi/fastutil/ints/Int2IntMapGenericTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/Int2IntMapGenericTest.java
@@ -16,11 +16,7 @@
 
 package it.unimi.dsi.fastutil.ints;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.junit.Assume.assumeTrue;
 
 import java.io.ByteArrayInputStream;
@@ -1035,7 +1031,11 @@ public abstract class Int2IntMapGenericTest<M extends Int2IntMap> {
 		m.defaultReturnValue(-1);
 
 		assertEquals(0, m.merge(1, 0, (oldVal, newVal) -> {
-			assertNull(oldVal);
+			fail();
+			return Integer.valueOf(0);
+		}));
+		assertEquals(0, m.merge(1, 0, (oldVal, newVal) -> {
+			assertEquals(0, oldVal.intValue());
 			assertEquals(0, newVal.intValue());
 			return Integer.valueOf(0);
 		}));


### PR DESCRIPTION
Some things I'd like to highlight:

* `null` handling is preserved for default Map methods, so no `defaultValue` support (checked in tests)
* `0` is treated as `null` element in `Double/Float2xxx` maps which seems rather suspicious
* `xxxMap#computeIfAbsent` methods with `xxxUnaryOperator` can be named `computeIfAbsentFast` to avoid clashing