### PR TITLE
Avoid allocating large arrays that crash the JVM

### DIFF
--- a/drv/Arrays.drv
+++ b/drv/Arrays.drv
@@ -174,6 +174,10 @@ public final class ARRAYS {
 	 * entries are the same as those of {@code array}.
 	 */
 	public static KEY_GENERIC KEY_GENERIC_TYPE[] forceCapacity(final KEY_GENERIC_TYPE[] array, final int length, final int preserve) {
+		if (length > Arrays.MAX_ARRAY_SIZE) {
+			throw new OutOfMemoryError("Requested array size " + length + " exceeds the maximum size of " + Arrays.MAX_ARRAY_SIZE);
+		}
+
 		final KEY_GENERIC_TYPE t[] =
 #if KEY_CLASS_Object
 			newArray(array, length);


### PR DESCRIPTION
Allocating an array of size close to 2^31 will cause an internal `OutOfMemoryError: Requested array size exceeds VM limit`
that triggers any configured JVM OOM behavior such as `-XX:+ExitOnOutOfMemoryError` or `-XX:+CrashOnOutOfMemoryError`. These errors can be difficult to debug. Instead, we can throw a normal `OutOfMemoryError` exception.