### PR TITLE
Priority queue improvements

### DIFF
--- a/drv/ArrayFIFOQueue.drv
+++ b/drv/ArrayFIFOQueue.drv
@@ -25,7 +25,6 @@ import java.util.Comparator;
 import java.io.Serializable;
 import it.unimi.dsi.fastutil.HashCommon;
 import it.unimi.dsi.fastutil.PriorityQueue;
-import it.unimi.dsi.fastutil.ints.IntArrayList;
 
 import java.util.NoSuchElementException;
 

--- a/drv/ArrayFIFOQueue.drv
+++ b/drv/ArrayFIFOQueue.drv
@@ -305,16 +305,21 @@ public class ARRAY_FIFO_QUEUE KEY_GENERIC implements PRIORITY_QUEUE KEY_GENERIC,
 
 #if KEYS_PRIMITIVE
 	/** Returns an array containing all of the elements in this PriorityQueue. */
+	@Deprecated
 	@Override
 	public KEY_GENERIC_CLASS[] toArray(KEY_GENERIC_CLASS[] input) {
-		if(input == null || input.length < length)
-		{
-			input = new KEY_GENERIC_CLASS[length];
+	final int length = size();
+		if(input == null || input.length < length) input = new KEY_GENERIC_CLASS[length];
+		if (start <= end) {
+			for(int i = 0,m=end-start;i<m;i++)
+				input[i] = KEY2OBJ(array[start + i]);
 		}
-		if (start <= end) System.arraycopy(array, start, input, 0, end - start);
 		else {
-			System.arraycopy(array, start, input, 0, length - start);
-			System.arraycopy(array, 0, input, length - start, end);
+			int offset = 0;
+			for(int i = 0,m=length-start;i<m;i++,offset++)
+				input[i] = KEY2OBJ(array[start + i]);
+			for(int i = 0;i<end;i++)
+				input[offset+i] = KEY2OBJ(array[i]);
 		}
 		return input;
 	}

--- a/drv/ArrayFIFOQueue.drv
+++ b/drv/ArrayFIFOQueue.drv
@@ -18,7 +18,6 @@
 package PACKAGE;
 
 #if KEY_CLASS_Object
-import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Comparator;
 #endif

--- a/drv/ArrayFIFOQueue.drv
+++ b/drv/ArrayFIFOQueue.drv
@@ -267,9 +267,9 @@ public class ARRAY_FIFO_QUEUE KEY_GENERIC implements PRIORITY_QUEUE KEY_GENERIC,
 		return apparentLength >= 0 ? apparentLength : length + apparentLength;
 	}
 
+	/** Returns an array containing all of the elements in this PriorityQueue. */
 	@Override
-	public KEY_GENERIC_TYPE[] TO_KEY_ARRAY()
-	{
+	public KEY_GENERIC_TYPE[] TO_KEY_ARRAY() {
 		final int length = size();
 #if KEYS_PRIMITIVE
 		final KEY_GENERIC_TYPE[] newArray = new KEY_GENERIC_TYPE[length];
@@ -284,9 +284,9 @@ public class ARRAY_FIFO_QUEUE KEY_GENERIC implements PRIORITY_QUEUE KEY_GENERIC,
 		return newArray;
 	}
 
+	/** Returns an array containing all of the elements in this PriorityQueue. */
 	@Override
-	public KEY_GENERIC_TYPE[] TO_KEY_ARRAY(KEY_GENERIC_TYPE[] input)
-	{
+	public KEY_GENERIC_TYPE[] TO_KEY_ARRAY(KEY_GENERIC_TYPE[] input) {
 		final int length = size();
 		if(input == null || input.length < length)
 		{
@@ -305,9 +305,9 @@ public class ARRAY_FIFO_QUEUE KEY_GENERIC implements PRIORITY_QUEUE KEY_GENERIC,
 	}
 
 #if KEYS_PRIMITIVE
+	/** Returns an array containing all of the elements in this PriorityQueue. */
 	@Override
-	public KEY_GENERIC_CLASS[] toArray(KEY_GENERIC_CLASS[] input)
-	{
+	public KEY_GENERIC_CLASS[] toArray(KEY_GENERIC_CLASS[] input) {
 		if(input == null || input.length < length)
 		{
 			input = new KEY_GENERIC_CLASS[length];

--- a/drv/ArrayFIFOQueue.drv
+++ b/drv/ArrayFIFOQueue.drv
@@ -18,6 +18,7 @@
 package PACKAGE;
 
 #if KEY_CLASS_Object
+import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Comparator;
 #endif
@@ -55,6 +56,23 @@ public class ARRAY_FIFO_QUEUE KEY_GENERIC implements PRIORITY_QUEUE KEY_GENERIC,
 	/** The end position in {@link #array}. It is always strictly smaller than {@link #length}.
 	 *  Might be actually smaller than {@link #start} because {@link #array} is used cyclically. */
 	protected transient int end;
+
+	public ARRAY_FIFO_QUEUE(final KEY_GENERIC_TYPE[] values) {
+		this(values, 0, values.length);
+	}
+
+	public ARRAY_FIFO_QUEUE(final KEY_GENERIC_TYPE[] values, int size) {
+		this(values, 0, size);
+	}
+
+	public ARRAY_FIFO_QUEUE(final KEY_GENERIC_TYPE[] values, int offset, int size) {
+		if (values.length < size) throw new IllegalArgumentException("Initial array (" + values.length + ") is smaller then the expected size (" + size + ")");
+		array = values;
+		length = values.length;
+		start = offset;
+		end = (offset + size) % length;
+		if(length == size) expand();
+	}
 
 	/** Creates a new empty queue with given capacity.
 	 *
@@ -123,11 +141,11 @@ public class ARRAY_FIFO_QUEUE KEY_GENERIC implements PRIORITY_QUEUE KEY_GENERIC,
 		length = newLength;
 	}
 
-	private final void expand() {
+	protected void expand() {
 		resize(length, (int)Math.min(it.unimi.dsi.fastutil.Arrays.MAX_ARRAY_SIZE, 2L * length));
 	}
 
-	private final void reduce() {
+	protected void reduce() {
 		final int size = size();
 		if (length > INITIAL_CAPACITY && size <= length / 4) resize(size, length / 2);
 	}
@@ -154,11 +172,61 @@ public class ARRAY_FIFO_QUEUE KEY_GENERIC implements PRIORITY_QUEUE KEY_GENERIC,
 		return array[start];
 	}
 
-
 	@Override
 	public KEY_GENERIC_TYPE LAST() {
 		if (start == end) throw new NoSuchElementException();
 		return array[(end == 0 ? length : end) - 1];
+	}
+
+	@Override
+	public KEY_GENERIC_TYPE PEEK(int index) {
+		if(index < 0 || index >= size()) throw new NoSuchElementException();
+		return array[(start + index) % length];
+	}
+
+	@Override
+	public boolean REMOVE_KEY(KEY_GENERIC_TYPE x) {
+		if(start == end) return false;
+		for(int i = 0,m=size();i<m;i++) {
+			int index = (start + i) % length;
+			if(KEY_EQUALS(x, array[index])) {
+				if(index > end) {
+					System.arraycopy(array, start, array, start+1, (index - start) + 1);
+#if KEYS_REFERENCE
+					array[start] = null;
+#endif
+					start = (start+1) % length;
+				}
+				else if(index < start) {
+					System.arraycopy(array, index+1, array, index, (end - index) + 1);
+#if KEYS_REFERENCE
+					array[end] = null;
+#endif
+					end--;
+					if(end < 0) end += length;
+				}
+				else {
+					if(index - start < end - index) {
+						System.arraycopy(array, start, array, start+1, (index - start) + 1);
+#if KEYS_REFERENCE
+						array[start] = null;
+#endif
+						start = (start+1) % length;
+					}
+					else {
+						System.arraycopy(array, index+1, array, index, (end - index) + 1);
+#if KEYS_REFERENCE
+						array[end] = null;
+#endif
+						end--;
+						if(end < 0) end += length;
+					}
+				}
+				reduce();
+				return true;
+			}
+		}
+		return false;
 	}
 
 	@Override
@@ -175,15 +243,15 @@ public class ARRAY_FIFO_QUEUE KEY_GENERIC implements PRIORITY_QUEUE KEY_GENERIC,
 
 	/** Trims the queue to the smallest possible size. */
 	SUPPRESS_WARNINGS_KEY_UNCHECKED
+	@Override
 	public void trim() {
 		final int size = size();
-		final KEY_GENERIC_TYPE[] newArray =
 #if KEYS_PRIMITIVE
-											new KEY_GENERIC_TYPE[size + 1];
+		final KEY_GENERIC_TYPE[] newArray = new KEY_GENERIC_TYPE[size + 1];
 #else
-											(KEY_GENERIC_TYPE[])new Object[size + 1];
+		final KEY_GENERIC_TYPE[] newArray = (KEY_GENERIC_TYPE[])new Object[size + 1];
 #endif
-		if (start <= end) System.arraycopy(array, start, newArray, 0, end - start);
+		if(start <= end) System.arraycopy(array, start, newArray, 0, end - start);
 		else {
 			System.arraycopy(array, start, newArray, 0, length - start);
 			System.arraycopy(array, 0, newArray, length - start, end);
@@ -198,6 +266,60 @@ public class ARRAY_FIFO_QUEUE KEY_GENERIC implements PRIORITY_QUEUE KEY_GENERIC,
 		final int apparentLength = end - start;
 		return apparentLength >= 0 ? apparentLength : length + apparentLength;
 	}
+
+	@Override
+	public KEY_GENERIC_TYPE[] TO_KEY_ARRAY()
+	{
+		final int length = size();
+#if KEYS_PRIMITIVE
+		final KEY_GENERIC_TYPE[] newArray = new KEY_GENERIC_TYPE[length];
+#else
+		final KEY_GENERIC_TYPE[] newArray = (KEY_GENERIC_TYPE[])new Object[length];
+#endif
+		if (start <= end) System.arraycopy(array, start, newArray, 0, end - start);
+		else {
+			System.arraycopy(array, start, newArray, 0, length - start);
+			System.arraycopy(array, 0, newArray, length - start, end);
+		}
+		return newArray;
+	}
+
+	@Override
+	public KEY_GENERIC_TYPE[] TO_KEY_ARRAY(KEY_GENERIC_TYPE[] input)
+	{
+		final int length = size();
+		if(input == null || input.length < length)
+		{
+#if KEYS_PRIMITIVE
+			input = new KEY_GENERIC_TYPE[length];
+#else
+			input = (KEY_GENERIC_TYPE[])new Object[length];
+#endif
+		}
+		if (start <= end) System.arraycopy(array, start, input, 0, end - start);
+		else {
+			System.arraycopy(array, start, input, 0, length - start);
+			System.arraycopy(array, 0, input, length - start, end);
+		}
+		return input;
+	}
+
+#if KEYS_PRIMITIVE
+	@Override
+	public KEY_GENERIC_CLASS[] toArray(KEY_GENERIC_CLASS[] input)
+	{
+		if(input == null || input.length < length)
+		{
+			input = new KEY_GENERIC_CLASS[length];
+		}
+		if (start <= end) System.arraycopy(array, start, input, 0, end - start);
+		else {
+			System.arraycopy(array, start, input, 0, length - start);
+			System.arraycopy(array, 0, input, length - start, end);
+		}
+		return input;
+	}
+#endif
 
 	private void writeObject(java.io.ObjectOutputStream s) throws java.io.IOException {
 		s.defaultWriteObject();

--- a/drv/ArrayFIFOQueue.drv
+++ b/drv/ArrayFIFOQueue.drv
@@ -25,6 +25,7 @@ import java.util.Comparator;
 import java.io.Serializable;
 import it.unimi.dsi.fastutil.HashCommon;
 import it.unimi.dsi.fastutil.PriorityQueue;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 
 import java.util.NoSuchElementException;
 
@@ -190,14 +191,14 @@ public class ARRAY_FIFO_QUEUE KEY_GENERIC implements PRIORITY_QUEUE KEY_GENERIC,
 			int index = (start + i) % length;
 			if(KEY_EQUALS(x, array[index])) {
 				if(index > end) {
-					System.arraycopy(array, start, array, start+1, (index - start) + 1);
+					System.arraycopy(array, start, array, start+1, (index - start));
 #if KEYS_REFERENCE
 					array[start] = null;
 #endif
 					start = (start+1) % length;
 				}
 				else if(index < start) {
-					System.arraycopy(array, index+1, array, index, (end - index) + 1);
+					System.arraycopy(array, index+1, array, index, (end - index) - 1);
 #if KEYS_REFERENCE
 					array[end] = null;
 #endif
@@ -206,14 +207,14 @@ public class ARRAY_FIFO_QUEUE KEY_GENERIC implements PRIORITY_QUEUE KEY_GENERIC,
 				}
 				else {
 					if(index - start < end - index) {
-						System.arraycopy(array, start, array, start+1, (index - start) + 1);
+						System.arraycopy(array, start, array, start+1, (index - start));
 #if KEYS_REFERENCE
 						array[start] = null;
 #endif
 						start = (start+1) % length;
 					}
 					else {
-						System.arraycopy(array, index+1, array, index, (end - index) + 1);
+						System.arraycopy(array, index+1, array, index, (end - index) - 1);
 #if KEYS_REFERENCE
 						array[end] = null;
 #endif

--- a/drv/ArrayPriorityQueue.drv
+++ b/drv/ArrayPriorityQueue.drv
@@ -102,7 +102,6 @@ public class ARRAY_PRIORITY_QUEUE KEY_GENERIC implements PRIORITY_QUEUE KEY_GENE
 		this.size = size;
 	}
 
-
 	/** Wraps a given array in a queue using a given comparator.
 	 *
 	 * <p>The queue returned by this method will be backed by the given array.
@@ -125,7 +124,6 @@ public class ARRAY_PRIORITY_QUEUE KEY_GENERIC implements PRIORITY_QUEUE KEY_GENE
 		this(a, size, null);
 	}
 
-
 	/** Wraps a given array in a queue using the natural order.
 	 *
 	 * <p>The queue returned by this method will be backed by the given array.
@@ -135,8 +133,6 @@ public class ARRAY_PRIORITY_QUEUE KEY_GENERIC implements PRIORITY_QUEUE KEY_GENE
 	public ARRAY_PRIORITY_QUEUE(final KEY_GENERIC_TYPE[] a) {
 		this(a, a.length);
 	}
-
-
 
 	/** Returns the index of the smallest element. */
 	SUPPRESS_WARNINGS_KEY_UNCHECKED
@@ -234,14 +230,12 @@ public class ARRAY_PRIORITY_QUEUE KEY_GENERIC implements PRIORITY_QUEUE KEY_GENE
 	}
 
 	@Override
-	public KEY_GENERIC_TYPE[] TO_KEY_ARRAY()
-	{
+	public KEY_GENERIC_TYPE[] TO_KEY_ARRAY() {
 		return ARRAYS.copy(array, 0, size);
 	}
 
 	@Override
-	public KEY_GENERIC_TYPE[] TO_KEY_ARRAY(KEY_GENERIC_TYPE[] input)
-	{
+	public KEY_GENERIC_TYPE[] TO_KEY_ARRAY(KEY_GENERIC_TYPE[] input) {
 		final int length = size();
 		if(input == null || input.length < length)
 		{
@@ -254,6 +248,19 @@ public class ARRAY_PRIORITY_QUEUE KEY_GENERIC implements PRIORITY_QUEUE KEY_GENE
 		System.arraycopy(array, 0, input, 0, size);
 		return input;
 	}
+
+#if KEYS_PRIMITIVE
+	/** Returns an array containing all of the elements in this PriorityQueue. */
+	@Override
+	public KEY_GENERIC_CLASS[] toArray(KEY_GENERIC_CLASS[] input) {
+		if(input == null || input.length < size)
+		{
+			input = new KEY_GENERIC_CLASS[size];
+		}
+		System.arraycopy(array, 0, input, 0, size);
+		return input;
+	}
+#endif
 
 	@Override
 	public KEY_COMPARATOR KEY_SUPER_GENERIC comparator() { return c; }

--- a/drv/ArrayPriorityQueue.drv
+++ b/drv/ArrayPriorityQueue.drv
@@ -251,13 +251,12 @@ public class ARRAY_PRIORITY_QUEUE KEY_GENERIC implements PRIORITY_QUEUE KEY_GENE
 
 #if KEYS_PRIMITIVE
 	/** Returns an array containing all of the elements in this PriorityQueue. */
+	@Deprecated
 	@Override
 	public KEY_GENERIC_CLASS[] toArray(KEY_GENERIC_CLASS[] input) {
-		if(input == null || input.length < size)
-		{
-			input = new KEY_GENERIC_CLASS[size];
-		}
-		System.arraycopy(array, 0, input, 0, size);
+		if(input == null || input.length < size) input = new KEY_GENERIC_CLASS[size];
+		for(int i = 0;i<size;i++)
+			input[i] = KEY2OBJ(array[i]);
 		return input;
 	}
 #endif

--- a/drv/ArrayPriorityQueue.drv
+++ b/drv/ArrayPriorityQueue.drv
@@ -139,7 +139,6 @@ public class ARRAY_PRIORITY_QUEUE KEY_GENERIC implements PRIORITY_QUEUE KEY_GENE
 
 
 	/** Returns the index of the smallest element. */
-
 	SUPPRESS_WARNINGS_KEY_UNCHECKED
 	private int findFirst() {
 		if (firstIndexValid) return this.firstIndex;
@@ -190,6 +189,27 @@ public class ARRAY_PRIORITY_QUEUE KEY_GENERIC implements PRIORITY_QUEUE KEY_GENE
 	}
 
 	@Override
+	public boolean REMOVE_KEY(KEY_GENERIC_TYPE x) {
+		for(int i = 0;i<size;i++) {
+			if(KEY_EQUALS(x, array[i])) {
+				System.arraycopy(array, i + 1, array, i, --size - i);
+#if KEY_CLASS_Object
+				array[i] = null;
+#endif
+				if(firstIndexValid && i < firstIndex) firstIndexValid = false;
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public KEY_GENERIC_TYPE PEEK(int index) {
+		if(index < 0 || index >= size) throw new NoSuchElementException();
+		return array[index];
+	}
+
+	@Override
 	public void changed() {
 		ensureNonEmpty();
 		firstIndexValid = false;
@@ -208,9 +228,31 @@ public class ARRAY_PRIORITY_QUEUE KEY_GENERIC implements PRIORITY_QUEUE KEY_GENE
 	}
 
 	/** Trims the underlying array so that it has exactly {@link #size()} elements. */
-
+	@Override
 	public void trim() {
 		array = ARRAYS.trim(array, size);
+	}
+
+	@Override
+	public KEY_GENERIC_TYPE[] TO_KEY_ARRAY()
+	{
+		return ARRAYS.copy(array, 0, size);
+	}
+
+	@Override
+	public KEY_GENERIC_TYPE[] TO_KEY_ARRAY(KEY_GENERIC_TYPE[] input)
+	{
+		final int length = size();
+		if(input == null || input.length < length)
+		{
+#if KEYS_PRIMITIVE
+			input = new KEY_GENERIC_TYPE[length];
+#else
+			input = (KEY_GENERIC_TYPE[])new Object[length];
+#endif
+		}
+		System.arraycopy(array, 0, input, 0, size);
+		return input;
 	}
 
 	@Override

--- a/drv/HeapPriorityQueue.drv
+++ b/drv/HeapPriorityQueue.drv
@@ -213,7 +213,7 @@ public class HEAP_PRIORITY_QUEUE KEY_GENERIC implements PRIORITY_QUEUE KEY_GENER
 #endif
 
 	@Override
-		public void enqueue(KEY_GENERIC_TYPE x) {
+	public void enqueue(KEY_GENERIC_TYPE x) {
 		if (size == heap.length) heap = ARRAYS.grow(heap, size + 1);
 
 		heap[size++] = x;
@@ -240,6 +240,27 @@ public class HEAP_PRIORITY_QUEUE KEY_GENERIC implements PRIORITY_QUEUE KEY_GENER
 	}
 
 	@Override
+	public KEY_GENERIC_TYPE PEEK(int index) {
+		if(index < 0 || index >= size) throw new NoSuchElementException();
+		return heap[index];
+	}
+	
+	@Override
+	public boolean REMOVE_KEY(KEY_GENERIC_TYPE x) {
+		for(int i = 0;i<size;i++) {
+			if(KEY_EQUALS(x, heap[i])) {
+				heap[i] = heap[--size];
+#if KEY_CLASS_Object
+				heap[size] = null;
+#endif
+				if(size != i) HEAPS.downHeap(heap, size, i, c);
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
 	public void changed() {
 		HEAPS.downHeap(heap, size, 0, c);
 	}
@@ -256,11 +277,33 @@ public class HEAP_PRIORITY_QUEUE KEY_GENERIC implements PRIORITY_QUEUE KEY_GENER
 	}
 
 	/** Trims the underlying heap array so that it has exactly {@link #size()} elements. */
-
+	@Override
 	public void trim() {
 		heap = ARRAYS.trim(heap, size);
 	}
-
+	
+	@Override
+	public KEY_GENERIC_TYPE[] TO_KEY_ARRAY()
+	{
+		return ARRAYS.copy(heap, 0, size);
+	}
+	
+	@Override
+	public KEY_GENERIC_TYPE[] TO_KEY_ARRAY(KEY_GENERIC_TYPE[] input)
+	{
+		final int length = size();
+		if(input == null || input.length < length)
+		{
+#if KEYS_PRIMITIVE
+			input = new KEY_GENERIC_TYPE[length];
+#else
+			input = (KEY_GENERIC_TYPE[])new Object[length];
+#endif
+		}
+		System.arraycopy(heap, 0, input, 0, size);
+		return input;
+	}
+	
 	@Override
 	public KEY_COMPARATOR KEY_SUPER_GENERIC comparator() { return c; }
 
@@ -502,5 +545,4 @@ public class HEAP_PRIORITY_QUEUE KEY_GENERIC implements PRIORITY_QUEUE KEY_GENER
 	}
 
 #endif
-
 }

--- a/drv/HeapPriorityQueue.drv
+++ b/drv/HeapPriorityQueue.drv
@@ -244,7 +244,7 @@ public class HEAP_PRIORITY_QUEUE KEY_GENERIC implements PRIORITY_QUEUE KEY_GENER
 		if(index < 0 || index >= size) throw new NoSuchElementException();
 		return heap[index];
 	}
-	
+
 	@Override
 	public boolean REMOVE_KEY(KEY_GENERIC_TYPE x) {
 		for(int i = 0;i<size;i++) {
@@ -281,16 +281,14 @@ public class HEAP_PRIORITY_QUEUE KEY_GENERIC implements PRIORITY_QUEUE KEY_GENER
 	public void trim() {
 		heap = ARRAYS.trim(heap, size);
 	}
-	
+
 	@Override
-	public KEY_GENERIC_TYPE[] TO_KEY_ARRAY()
-	{
+	public KEY_GENERIC_TYPE[] TO_KEY_ARRAY() {
 		return ARRAYS.copy(heap, 0, size);
 	}
-	
+
 	@Override
-	public KEY_GENERIC_TYPE[] TO_KEY_ARRAY(KEY_GENERIC_TYPE[] input)
-	{
+	public KEY_GENERIC_TYPE[] TO_KEY_ARRAY(KEY_GENERIC_TYPE[] input) {
 		final int length = size();
 		if(input == null || input.length < length)
 		{
@@ -303,7 +301,20 @@ public class HEAP_PRIORITY_QUEUE KEY_GENERIC implements PRIORITY_QUEUE KEY_GENER
 		System.arraycopy(heap, 0, input, 0, size);
 		return input;
 	}
-	
+
+#if KEYS_PRIMITIVE
+	/** Returns an array containing all of the elements in this PriorityQueue. */
+	@Override
+	public KEY_GENERIC_CLASS[] toArray(KEY_GENERIC_CLASS[] input) {
+		if(input == null || input.length < size)
+		{
+			input = new KEY_GENERIC_CLASS[size];
+		}
+		System.arraycopy(heap, 0, input, 0, size);
+		return input;
+	}
+#endif
+
 	@Override
 	public KEY_COMPARATOR KEY_SUPER_GENERIC comparator() { return c; }
 

--- a/drv/HeapPriorityQueue.drv
+++ b/drv/HeapPriorityQueue.drv
@@ -304,13 +304,12 @@ public class HEAP_PRIORITY_QUEUE KEY_GENERIC implements PRIORITY_QUEUE KEY_GENER
 
 #if KEYS_PRIMITIVE
 	/** Returns an array containing all of the elements in this PriorityQueue. */
+	@Deprecated
 	@Override
 	public KEY_GENERIC_CLASS[] toArray(KEY_GENERIC_CLASS[] input) {
-		if(input == null || input.length < size)
-		{
-			input = new KEY_GENERIC_CLASS[size];
-		}
-		System.arraycopy(heap, 0, input, 0, size);
+		if(input == null || input.length < size) input = new KEY_GENERIC_CLASS[size];
+		for(int i = 0;i<size;i++)
+			input[i] = KEY2OBJ(heap[i]);
 		return input;
 	}
 #endif

--- a/drv/PriorityQueue.drv
+++ b/drv/PriorityQueue.drv
@@ -59,6 +59,23 @@ public interface PRIORITY_QUEUE extends PriorityQueue<KEY_CLASS> {
 	 */
 
 	default KEY_GENERIC_TYPE LAST() { throw new UnsupportedOperationException(); }
+	
+	/** Returns the index element of the queue.
+	 * 
+ 	 * <p>This default implementation just throws an {@link UnsupportedOperationException}.
+ 	 * @see #peek()
+	 * @param index of the element.
+	 * @return the indexed element.
+	 * @throws NoSuchElementException if the index is not in the range
+	 */
+	
+	default KEY_GENERIC_TYPE PEEK(int index) { throw new UnsupportedOperationException(); }
+	
+	boolean REMOVE_KEY(KEY_GENERIC_TYPE x);
+	
+	KEY_GENERIC_TYPE[] TO_KEY_ARRAY();
+	
+	KEY_GENERIC_TYPE[] TO_KEY_ARRAY(KEY_GENERIC_TYPE[] input);
 
 	/** Returns the comparator associated with this priority queue, or null if it uses its elements' natural ordering.
 	 *
@@ -68,7 +85,7 @@ public interface PRIORITY_QUEUE extends PriorityQueue<KEY_CLASS> {
 	 */
 	@Override
 	KEY_COMPARATOR comparator();
-
+	
 	/** {@inheritDoc}
 	 * <p>This default implementation delegates to the corresponding type-specific method.
 	 * @deprecated Please use the corresponding type-specific method instead. */
@@ -96,4 +113,32 @@ public interface PRIORITY_QUEUE extends PriorityQueue<KEY_CLASS> {
 	@Deprecated
 	@Override
 	default KEY_GENERIC_CLASS last() { return KEY2OBJ(LAST()); }
+	
+	/** {@inheritDoc}
+	 * <p>This default implementation delegates to the corresponding type-specific method.
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
+	@Override
+	default KEY_GENERIC_CLASS peek(int index) { return KEY2OBJ(PEEK(index)); }
+	
+	/** {@inheritDoc}
+	 * <p>This default implementation delegates to the corresponding type-specific method.
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
+	@Override
+	default boolean remove(KEY_GENERIC_CLASS x) { return remove(x.KEY_VALUE()); }
+	
+	/** {@inheritDoc}
+	 * <p>This default implementation delegates to the corresponding type-specific method.
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
+	@Override
+	default KEY_GENERIC_CLASS[] toArray() { return toArray((KEY_GENERIC_CLASS[])null);}
+	
+	/** {@inheritDoc}
+	 * <p>This default implementation delegates to the corresponding type-specific method.
+	 * @deprecated Please use the corresponding type-specific method instead. */
+	@Deprecated
+	@Override
+	default KEY_GENERIC_CLASS[] toArray(KEY_GENERIC_CLASS[] input) { throw new UnsupportedOperationException(); }
 }

--- a/drv/PriorityQueue.drv
+++ b/drv/PriorityQueue.drv
@@ -59,7 +59,7 @@ public interface PRIORITY_QUEUE extends PriorityQueue<KEY_CLASS> {
 	 */
 
 	default KEY_GENERIC_TYPE LAST() { throw new UnsupportedOperationException(); }
-	
+
 	/** Returns the index element of the queue.
 	 * 
  	 * <p>This default implementation just throws an {@link UnsupportedOperationException}.
@@ -68,13 +68,13 @@ public interface PRIORITY_QUEUE extends PriorityQueue<KEY_CLASS> {
 	 * @return the indexed element.
 	 * @throws NoSuchElementException if the index is not in the range
 	 */
-	
+
 	default KEY_GENERIC_TYPE PEEK(int index) { throw new UnsupportedOperationException(); }
-	
+
 	boolean REMOVE_KEY(KEY_GENERIC_TYPE x);
-	
+
 	KEY_GENERIC_TYPE[] TO_KEY_ARRAY();
-	
+
 	KEY_GENERIC_TYPE[] TO_KEY_ARRAY(KEY_GENERIC_TYPE[] input);
 
 	/** Returns the comparator associated with this priority queue, or null if it uses its elements' natural ordering.
@@ -85,7 +85,7 @@ public interface PRIORITY_QUEUE extends PriorityQueue<KEY_CLASS> {
 	 */
 	@Override
 	KEY_COMPARATOR comparator();
-	
+
 	/** {@inheritDoc}
 	 * <p>This default implementation delegates to the corresponding type-specific method.
 	 * @deprecated Please use the corresponding type-specific method instead. */
@@ -113,28 +113,28 @@ public interface PRIORITY_QUEUE extends PriorityQueue<KEY_CLASS> {
 	@Deprecated
 	@Override
 	default KEY_GENERIC_CLASS last() { return KEY2OBJ(LAST()); }
-	
+
 	/** {@inheritDoc}
 	 * <p>This default implementation delegates to the corresponding type-specific method.
 	 * @deprecated Please use the corresponding type-specific method instead. */
 	@Deprecated
 	@Override
 	default KEY_GENERIC_CLASS peek(int index) { return KEY2OBJ(PEEK(index)); }
-	
+
 	/** {@inheritDoc}
 	 * <p>This default implementation delegates to the corresponding type-specific method.
 	 * @deprecated Please use the corresponding type-specific method instead. */
 	@Deprecated
 	@Override
 	default boolean remove(KEY_GENERIC_CLASS x) { return remove(x.KEY_VALUE()); }
-	
+
 	/** {@inheritDoc}
 	 * <p>This default implementation delegates to the corresponding type-specific method.
 	 * @deprecated Please use the corresponding type-specific method instead. */
 	@Deprecated
 	@Override
 	default KEY_GENERIC_CLASS[] toArray() { return toArray((KEY_GENERIC_CLASS[])null);}
-	
+
 	/** {@inheritDoc}
 	 * <p>This default implementation delegates to the corresponding type-specific method.
 	 * @deprecated Please use the corresponding type-specific method instead. */

--- a/drv/PriorityQueues.drv
+++ b/drv/PriorityQueues.drv
@@ -53,7 +53,24 @@ public final class PRIORITY_QUEUES {
 
 		@Override
 		public KEY_GENERIC_TYPE LAST() { synchronized(sync) { return q.LAST(); } }
+	
+		@Override
+		public KEY_GENERIC_TYPE PEEK(int index) { synchronized(sync) { return q.PEEK(index); } }
 
+		@Override
+		public boolean REMOVE_KEY(KEY_GENERIC_TYPE x) { synchronized(sync) { return q.REMOVE_KEY(x); } }
+
+		@Override
+		public KEY_GENERIC_TYPE[] TO_KEY_ARRAY() { synchronized(sync) { return q.TO_KEY_ARRAY(); } }
+
+		@Override
+		public KEY_GENERIC_TYPE[] TO_KEY_ARRAY(KEY_GENERIC_TYPE[] input) { synchronized(sync) { return q.TO_KEY_ARRAY(input); } }
+
+#if KEYS_PRIMITIVE
+		@Deprecated
+		@Override
+		public KEY_GENERIC_CLASS[] toArray(KEY_GENERIC_CLASS[] input) { synchronized(sync) { return q.toArray(input); } }
+#endif		
 		@Override
 		public boolean isEmpty() { synchronized(sync) { return q.isEmpty(); } }
 
@@ -62,7 +79,10 @@ public final class PRIORITY_QUEUES {
 
 		@Override
 		public void clear() { synchronized(sync) { q.clear(); } }
-
+		
+		@Override
+		public void trim() { synchronized(sync) { q.trim(); } }
+		
 		@Override
 		public void changed() { synchronized(sync) { q.changed(); } }
 
@@ -86,6 +106,10 @@ public final class PRIORITY_QUEUES {
 		@Deprecated
 		@Override
 		public KEY_CLASS last() { synchronized(sync) { return q.last(); } }
+
+		@Deprecated
+		@Override
+		public KEY_CLASS peek(int index) { synchronized(sync) { return q.peek(index); } }
 
 #endif
 		@Override

--- a/drv/PriorityQueues.drv
+++ b/drv/PriorityQueues.drv
@@ -53,7 +53,7 @@ public final class PRIORITY_QUEUES {
 
 		@Override
 		public KEY_GENERIC_TYPE LAST() { synchronized(sync) { return q.LAST(); } }
-	
+
 		@Override
 		public KEY_GENERIC_TYPE PEEK(int index) { synchronized(sync) { return q.PEEK(index); } }
 
@@ -79,10 +79,10 @@ public final class PRIORITY_QUEUES {
 
 		@Override
 		public void clear() { synchronized(sync) { q.clear(); } }
-		
+
 		@Override
 		public void trim() { synchronized(sync) { q.trim(); } }
-		
+
 		@Override
 		public void changed() { synchronized(sync) { q.changed(); } }
 

--- a/src/it/unimi/dsi/fastutil/PriorityQueue.java
+++ b/src/it/unimi/dsi/fastutil/PriorityQueue.java
@@ -75,7 +75,7 @@ public interface PriorityQueue<K> {
 	 */
 
 	void clear();
-	
+
 	/** Trims the underlying array so that it has exactly {@link #size()} elements. */
 	void trim();
 
@@ -103,26 +103,27 @@ public interface PriorityQueue<K> {
 	 * @return the indexed element.
 	 * @throws NoSuchElementException if the index is not in the range
 	 */
-	
+
 	default K peek(int index){ throw new UnsupportedOperationException(); }
-	
+
+	/*Removes a single instance of the specified element from this */
 	boolean remove(K value);
-	
-	
+
 	/** Notifies the queue that the {@linkplain #first() first} element has changed (optional operation).
 	 * <p>This default implementation just throws an {@link UnsupportedOperationException}. 
 	 */
 
 	default void changed() { throw new UnsupportedOperationException(); }
 
-
 	/** Returns the comparator associated with this queue, or {@code null} if it uses its elements' natural ordering.
 	 *
 	 * @return the comparator associated with this sorted set, or {@code null} if it uses its elements' natural ordering.
 	 */
 	Comparator<? super K> comparator();
-	
+
+	/** Returns an array containing all of the elements in this PriorityQueue. */
 	K[] toArray();
-	
+
+	/** Returns an array containing all of the elements in this PriorityQueue. */
 	K[] toArray(K[] input);
 }

--- a/src/it/unimi/dsi/fastutil/PriorityQueue.java
+++ b/src/it/unimi/dsi/fastutil/PriorityQueue.java
@@ -75,6 +75,9 @@ public interface PriorityQueue<K> {
 	 */
 
 	void clear();
+	
+	/** Trims the underlying array so that it has exactly {@link #size()} elements. */
+	void trim();
 
 	/** Returns the first element of the queue.
 	 *
@@ -92,7 +95,20 @@ public interface PriorityQueue<K> {
 	 */
 
 	default K last() { throw new UnsupportedOperationException(); }
-
+	
+	/** Returns the index element of the queue.
+	 * 
+ 	 * <p>This default implementation just throws an {@link UnsupportedOperationException}.
+	 * @param index of the element.
+	 * @return the indexed element.
+	 * @throws NoSuchElementException if the index is not in the range
+	 */
+	
+	default K peek(int index){ throw new UnsupportedOperationException(); }
+	
+	boolean remove(K value);
+	
+	
 	/** Notifies the queue that the {@linkplain #first() first} element has changed (optional operation).
 	 * <p>This default implementation just throws an {@link UnsupportedOperationException}. 
 	 */
@@ -105,4 +121,8 @@ public interface PriorityQueue<K> {
 	 * @return the comparator associated with this sorted set, or {@code null} if it uses its elements' natural ordering.
 	 */
 	Comparator<? super K> comparator();
+	
+	K[] toArray();
+	
+	K[] toArray(K[] input);
 }

--- a/src/it/unimi/dsi/fastutil/PriorityQueues.java
+++ b/src/it/unimi/dsi/fastutil/PriorityQueues.java
@@ -61,7 +61,7 @@ public class PriorityQueues {
 
 		@Override
 		public Object last() { throw new NoSuchElementException(); }
-		
+
 		@Override
 		public boolean remove(Object value) { return false; }
 
@@ -70,7 +70,7 @@ public class PriorityQueues {
 
 		@Override
 		public Comparator<?> comparator() { return null; }
-		
+
 		@Override
 		public void trim() { throw new NoSuchElementException(); }
 
@@ -139,7 +139,7 @@ public class PriorityQueues {
 
 		@Override
 		public K last() { synchronized(sync) { return q.last(); } }
-		
+
 		@Override
 		public K peek(int index) { synchronized(sync) { return q.peek(index); } }
 
@@ -154,6 +154,7 @@ public class PriorityQueues {
 
 		@Override
 		public void changed() { synchronized(sync) { q.changed(); } }
+
 		@Override
 		public void trim() { synchronized(sync) { q.trim(); } }
 
@@ -182,7 +183,6 @@ public class PriorityQueues {
 			synchronized(sync) { s.defaultWriteObject(); }
 		}
 	}
-
 
 	/** Returns a synchronized priority queue backed by the specified priority queue.
 	 *

--- a/src/it/unimi/dsi/fastutil/PriorityQueues.java
+++ b/src/it/unimi/dsi/fastutil/PriorityQueues.java
@@ -17,7 +17,6 @@ package it.unimi.dsi.fastutil;
  */
 
 import java.io.Serializable;
-
 import java.util.Comparator;
 import java.util.NoSuchElementException;
 
@@ -62,12 +61,27 @@ public class PriorityQueues {
 
 		@Override
 		public Object last() { throw new NoSuchElementException(); }
+		
+		@Override
+		public boolean remove(Object value) { return false; }
 
 		@Override
 		public void changed() { throw new NoSuchElementException(); }
 
 		@Override
 		public Comparator<?> comparator() { return null; }
+		
+		@Override
+		public void trim() { throw new NoSuchElementException(); }
+
+		@Override
+		public Object peek(int index) { throw new NoSuchElementException(); }
+
+		@Override
+		public Object[] toArray() { throw new NoSuchElementException(); }
+
+		@Override
+		public Object[] toArray(Object[] input) { throw new NoSuchElementException(); }
 
 		@Override
 		public Object clone() { return EMPTY_QUEUE; }
@@ -125,6 +139,9 @@ public class PriorityQueues {
 
 		@Override
 		public K last() { synchronized(sync) { return q.last(); } }
+		
+		@Override
+		public K peek(int index) { synchronized(sync) { return q.peek(index); } }
 
 		@Override
 		public boolean isEmpty() { synchronized(sync) { return q.isEmpty(); } }
@@ -137,9 +154,20 @@ public class PriorityQueues {
 
 		@Override
 		public void changed() { synchronized(sync) { q.changed(); } }
+		@Override
+		public void trim() { synchronized(sync) { q.trim(); } }
 
 		@Override
 		public Comparator <? super K> comparator() { synchronized(sync) { return q.comparator(); } }
+
+		@Override
+		public boolean remove(K value) { synchronized(sync) { return q.remove(value); } }
+
+		@Override
+		public K[] toArray() { synchronized(sync) { return q.toArray(); } }
+
+		@Override
+		public K[] toArray(K[] input) { synchronized(sync) { return q.toArray(input); } }
 
 		@Override
 		public String toString() { synchronized(sync) { return q.toString(); } }

--- a/test/it/unimi/dsi/fastutil/ints/IntArrayFIFOQueueTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntArrayFIFOQueueTest.java
@@ -1,5 +1,7 @@
 package it.unimi.dsi.fastutil.ints;
 
+import static org.junit.Assert.assertArrayEquals;
+
 /*
  * Copyright (C) 2017-2020 Sebastiano Vigna
  *
@@ -84,12 +86,57 @@ public class IntArrayFIFOQueueTest {
 			q.enqueue(i);
 			assertEquals(i, q.lastInt());
 		}
-		q.removeInt(50);
+		q.removeInt(40);
 		assertEquals(q.size(), 99);
 		for(int i = 0;i<99;i++) {
-			if(i >= 50) assertEquals(i + 1, q.dequeueInt());
+			if(i >= 40) assertEquals(i + 1, q.dequeueInt());
 			else assertEquals(i, q.dequeueInt());
 		}
+		q = new IntArrayFIFOQueue();
+		for(int i = 0; i < 100; i++) {
+			q.enqueue(i);
+			assertEquals(i, q.lastInt());
+		}
+		q.removeInt(60);
+		assertEquals(q.size(), 99);
+		for(int i = 0;i<99;i++) {
+			if(i >= 60) assertEquals(i + 1, q.dequeueInt());
+			else assertEquals(i, q.dequeueInt());
+		}
+		int[][] expectedResults = new int[][]{
+			{50, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			{50, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 41, 42, 43, 44, 45, 46, 47, 48, 49, 49, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}};
+		IntList index = IntArrayList.wrap(new int[]{0});
+		q = new IntArrayFIFOQueue(100) {
+			private static final long serialVersionUID = 1L;
+			@Override
+			public boolean removeInt(int x) {
+				if(super.removeInt(x))
+				{
+					assertArrayEquals(expectedResults[index.getInt(0)], array);
+					return true;
+				}
+				return false;
+			}
+		};
+		for(int i = 0; i < 75; i++) {
+			q.enqueue(i);
+		}
+		for(int i = 0; i < 50; i++) {
+			q.dequeueInt();
+		}
+		for(int i = 0; i < 50; i++) {
+			q.enqueue(i);
+		}
+		q.removeInt(60);
+		index.set(0, 1);
+		q.removeInt(40);
+		assertEquals(q.size(), 73);
+		for(int i = 0;i<73;i++) {
+			if(i >= 24) assertEquals(i - (i < 64 ? 24 : 23), q.dequeueInt());
+			else assertEquals(i + (i >= 10 ? 51 : 50), q.dequeueInt());
+		}
+		
 	}
 
 	@Test

--- a/test/it/unimi/dsi/fastutil/ints/IntArrayFIFOQueueTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntArrayFIFOQueueTest.java
@@ -143,22 +143,35 @@ public class IntArrayFIFOQueueTest {
 	public void testArray()
 	{
 		IntArrayFIFOQueue q = new IntArrayFIFOQueue();
+		Integer[] ref = new Integer[100];
+		Integer[] shiftArray = new Integer[100];
+		int[] primRef = new int[100];
+		int[] shiftPrimArray = new int[100];
 		for(int i = 0; i < 100; i++) {
 			q.enqueue(i);
 			assertEquals(i, q.lastInt());
+			ref[i] = Integer.valueOf(i);
+			primRef[i] = i;
+			shiftPrimArray[(i+80) % 100] = i;
+			shiftArray[(i+80) % 100] = Integer.valueOf(i);
 		}
-		int[] array = q.toIntArray();
-		int[] otherArray = q.toIntArray(new int[100]);
-		for(int i = 0;i<100;i++)
-		{
-			assertEquals(array[i], otherArray[i]);
-			assertEquals(array[i], q.peekInt(i));
+		assertArrayEquals(q.toArray(), ref);
+		assertArrayEquals(q.toArray(new Integer[100]), ref);
+		assertArrayEquals(q.toArray(null), ref);
+		assertArrayEquals(q.toIntArray(), primRef);
+		assertArrayEquals(q.toIntArray(new int[100]), primRef);
+		assertArrayEquals(q.toIntArray(null), primRef);
+		IntArrayFIFOQueue other = new IntArrayFIFOQueue(q.toIntArray());
+		for(int i = 0;i<100;i++) {
+			assertEquals(other.peekInt(i), primRef[i]);
 		}
-		IntArrayFIFOQueue other = new IntArrayFIFOQueue(array);
-		for(int i = 0;i<100;i++)
-		{
-			assertEquals(other.peekInt(i), q.peekInt(i));
+		for(int i = 0;i<20;i++) {
+			other.dequeueInt();
+			other.enqueue(i);
 		}
+		assertArrayEquals(other.toIntArray(), shiftPrimArray);
+		assertArrayEquals(other.toIntArray(new int[100]), shiftPrimArray);
+		assertArrayEquals(other.toArray(), shiftArray);
 	}
 
 	@Test

--- a/test/it/unimi/dsi/fastutil/ints/IntArrayFIFOQueueTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntArrayFIFOQueueTest.java
@@ -64,6 +64,57 @@ public class IntArrayFIFOQueueTest {
 	}
 
 	@Test
+	public void testPeek()
+	{
+		IntArrayFIFOQueue q = new IntArrayFIFOQueue();
+		for(int i = 0; i < 100; i++) {
+			q.enqueue(i);
+			assertEquals(i, q.lastInt());
+		}
+		for(int i = 0;i<100;i++)
+		{
+			assertEquals(i, q.peekInt(i));
+		}
+	}
+
+	@Test
+	public void removeTest() {
+		IntArrayFIFOQueue q = new IntArrayFIFOQueue();
+		for(int i = 0; i < 100; i++) {
+			q.enqueue(i);
+			assertEquals(i, q.lastInt());
+		}
+		q.removeInt(50);
+		assertEquals(q.size(), 99);
+		for(int i = 0;i<99;i++) {
+			if(i >= 50) assertEquals(i + 1, q.dequeueInt());
+			else assertEquals(i, q.dequeueInt());
+		}
+	}
+
+	@Test
+	public void testArray()
+	{
+		IntArrayFIFOQueue q = new IntArrayFIFOQueue();
+		for(int i = 0; i < 100; i++) {
+			q.enqueue(i);
+			assertEquals(i, q.lastInt());
+		}
+		int[] array = q.toIntArray();
+		int[] otherArray = q.toIntArray(new int[100]);
+		for(int i = 0;i<100;i++)
+		{
+			assertEquals(array[i], otherArray[i]);
+			assertEquals(array[i], q.peekInt(i));
+		}
+		IntArrayFIFOQueue other = new IntArrayFIFOQueue(array);
+		for(int i = 0;i<100;i++)
+		{
+			assertEquals(other.peekInt(i), q.peekInt(i));
+		}
+	}
+
+	@Test
 	public void testMix() {
 		IntArrayFIFOQueue q = new IntArrayFIFOQueue();
 		for(int i = 0, p = 0; i < 200; i++) {
@@ -158,7 +209,7 @@ public class IntArrayFIFOQueueTest {
 		assertEquals(1, q.dequeueInt());
 		assertEquals(0, q.dequeueInt());
 	}
-
+	
 	@SuppressWarnings("deprecation")
 	@Test
 	public void testImmediateReduce() {

--- a/test/it/unimi/dsi/fastutil/ints/IntArrayPriorityQueueTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntArrayPriorityQueueTest.java
@@ -29,6 +29,29 @@ import it.unimi.dsi.fastutil.io.BinIO;
 public class IntArrayPriorityQueueTest {
 
 	@Test
+	public void removeTest() {
+		IntArrayPriorityQueue q = new IntArrayPriorityQueue();
+		IntHeapPriorityQueue h = new IntHeapPriorityQueue();
+		for(int i = 0; i < 100; i++) {
+			q.enqueue(i);
+			h.enqueue(i);
+		}
+		q.removeInt(50);
+		h.removeInt(50);
+		assertEquals(q.size(), 99);
+		for(int i = 0;i<99;i++) {
+			if(i >= 50){
+				assertEquals(i + 1, q.dequeueInt());
+				assertEquals(i + 1, h.dequeueInt());
+			}
+			else {
+				assertEquals(i, q.dequeueInt());
+				assertEquals(i, h.dequeueInt());
+			}
+		}
+	}
+
+	@Test
 	public void testEnqueueDequeue() {
 		IntArrayPriorityQueue q = new IntArrayPriorityQueue();
 		IntHeapPriorityQueue h = new IntHeapPriorityQueue();

--- a/test/it/unimi/dsi/fastutil/ints/IntArrayPriorityQueueTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntArrayPriorityQueueTest.java
@@ -1,5 +1,6 @@
 package it.unimi.dsi.fastutil.ints;
 
+
 /*
  * Copyright (C) 2017-2020 Sebastiano Vigna
  *
@@ -16,6 +17,7 @@ package it.unimi.dsi.fastutil.ints;
  * limitations under the License.
  */
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
@@ -49,6 +51,35 @@ public class IntArrayPriorityQueueTest {
 				assertEquals(i, h.dequeueInt());
 			}
 		}
+	}
+
+	@Test
+	public void testToArray()
+	{
+		IntArrayPriorityQueue q = new IntArrayPriorityQueue();
+		IntHeapPriorityQueue h = new IntHeapPriorityQueue();
+		Integer[] ref = new Integer[100];
+		int[] primRef = new int[100];
+		for(int i = 0; i < 100; i++) {
+			q.enqueue(i);
+			h.enqueue(i);
+			ref[i] = Integer.valueOf(i);
+			primRef[i] = i;
+		}
+		Integer[] qArray = q.toArray();
+		assertArrayEquals(qArray, ref);
+		assertArrayEquals(qArray, q.toArray(new Integer[100]));
+		assertArrayEquals(qArray, q.toArray(null));
+		assertArrayEquals(qArray, h.toArray());
+		assertArrayEquals(qArray, h.toArray(new Integer[100]));
+		assertArrayEquals(qArray, h.toArray(null));
+		int[] qPrimArray = q.toIntArray();
+		assertArrayEquals(qPrimArray, primRef);
+		assertArrayEquals(qPrimArray, h.toIntArray(new int[100]));
+		assertArrayEquals(qPrimArray, h.toIntArray(null));
+		assertArrayEquals(qPrimArray, h.toIntArray());
+		assertArrayEquals(qPrimArray, h.toIntArray(new int[100]));
+		assertArrayEquals(qPrimArray, h.toIntArray(null));
 	}
 
 	@Test

--- a/test/it/unimi/dsi/fastutil/ints/IntArrayPriorityQueueTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntArrayPriorityQueueTest.java
@@ -87,7 +87,6 @@ public class IntArrayPriorityQueueTest {
 		}
 	}
 
-
 	@Test
 	public void testEnqueueDequeueComp() {
 		IntArrayPriorityQueue q = new IntArrayPriorityQueue(IntComparators.OPPOSITE_COMPARATOR);


### PR DESCRIPTION
A more deep improvement of PriorityQueues.
All new functions are implemented in all PriorityQueue implementations.

Also as suggested from incaseoftrouble i made this a dedicated patch.
So it gets implemented much more quickly instead of waiting longer.
Other parts of the patch will get transferred to dedicated patches.

Table of Contents:
- Added: Peek function for looking ahead on values.
- Added: trim function to interface.
- Added: (FIFOOnly) Constructor that supports arrays for loading/priming/wrapping.
- Added: toArray function. So data can be cloned without emptying the queue.
- Changed: (FIFOOnly) expand/shrink are made protected because they are usually the target of changes to prevent them on executing. Reduces the amount of overrides required.
- Added: Remove function so values can be removed out of the PriorityQueues. (Removes only one value)

Edit: Improvements to description
Note: Pull request is considered ready for review from my side.