### PR TITLE
Clean up some of the new "of()" static factory methods.

### DIFF
--- a/drv/ArrayList.drv
+++ b/drv/ArrayList.drv
@@ -289,15 +289,15 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 
 	/** Creates an array list using a list of elements.
 	 *
-	 * @param init a list of elements that will be used to initialize the list.
-	 * @return a new array list containing the given elements.
+	 * @param init a the array the will become the new backing array of the array list
+	 * @return a new array list backed by the given array
+	 * @see #wrap
 	 */
-
-	@SafeVarargs
+	// NOT @SafeVarargs. Since we are taking the array as our backing array, then passing
+	// an Integer[] when the generic is inferred Object (and thus Object[]) will not be safe.
 	public static KEY_GENERIC ARRAY_LIST KEY_GENERIC of(final KEY_GENERIC_TYPE... init) {
 		return wrap(init);
 	}
-
 
 	/** Ensures that this array list can contain the given number of entries without resizing.
 	 *

--- a/drv/ArrayList.drv
+++ b/drv/ArrayList.drv
@@ -287,14 +287,15 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 		return new ARRAY_LIST KEY_GENERIC_DIAMOND();
 	}
 
-	/** Creates an array list using a list of elements.
+	/** Creates an array list using an array of elements.
 	 *
 	 * @param init a the array the will become the new backing array of the array list
 	 * @return a new array list backed by the given array
 	 * @see #wrap
 	 */
-	// NOT @SafeVarargs. Since we are taking the array as our backing array, then passing
-	// an Integer[] when the generic is inferred Object (and thus Object[]) will not be safe.
+	// NOT @SafeVarargs. Since we are taking the array as our backing array, then, for example,
+	// passing an Integer[] when the generic is inferred Object (and thus cast to Object[]) will
+	// not be safe.
 	public static KEY_GENERIC ARRAY_LIST KEY_GENERIC of(final KEY_GENERIC_TYPE... init) {
 		return wrap(init);
 	}

--- a/drv/ArrayList.drv
+++ b/drv/ArrayList.drv
@@ -281,7 +281,11 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 	public static KEY_GENERIC ARRAY_LIST KEY_GENERIC wrap(final KEY_GENERIC_TYPE a[]) {
 		return wrap(a, a.length);
 	}
-
+	
+	/** Creates a new empty array list */
+	public static KEY_GENERIC ARRAY_LIST KEY_GENERIC of() {
+		return new ARRAY_LIST KEY_GENERIC_DIAMOND();
+	}
 
 	/** Creates an array list using a list of elements.
 	 *

--- a/drv/ArraySet.drv
+++ b/drv/ArraySet.drv
@@ -113,6 +113,44 @@ public class ARRAY_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implements j
 		if (size > a.length) throw new IllegalArgumentException("The provided size (" + size + ") is larger than or equal to the array size (" + a.length + ")");
 	}
 
+	// The 0 and 1 arg overloads allow us to skip the temporary hash set creation. 
+
+	/** Creates a new empty array set. */
+	public static KEY_GENERIC ARRAY_SET KEY_GENERIC of() {
+		return ofUnchecked();
+	}
+
+	/** Creates a new array set using the element given.
+	 *
+	 * @param element the element that the returned set will contain.
+	 */
+	public static KEY_GENERIC ARRAY_SET KEY_GENERIC of(final KEY_GENERIC_TYPE a) {
+		return ofUnchecked(a);
+	}
+
+	/** Creates a new array set using a list of elements.
+	 *
+	 * <p>Unlike the array accepting constructors, this method will throw if duplicate elements
+	 * are encountered. This adds a non-trivial validation burden. Use {@link #ofUnchecked} if you
+	 * know your input has no duplicates, which will skip this validation.
+	 *
+	 * @param a the backing array of the returned array set.
+	 * @throws IllegalArgumentException if a duplicate entry was encountered.
+	 */
+	@SafeVarargs
+	public static KEY_GENERIC ARRAY_SET KEY_GENERIC of(final KEY_GENERIC_TYPE... a) {
+		// Will throw on duplicate entry for us.
+		OPEN_HASH_SET.of(a);
+		return ofUnchecked(a);
+	}
+
+	/** Creates a new empty array set. */
+	public static KEY_GENERIC ARRAY_SET KEY_GENERIC ofUnchecked() {
+		return new ARRAY_SET KEY_GENERIC_DIAMOND();
+	}
+
+	// No 1 element overload; we want the temporary array constructed for us in the varargs overload
+
 	/** Creates a new array set using a list of elements.
 	 *
 	 * <p>It is the responsibility of the caller to ensure that the elements of {@code a} are distinct.
@@ -120,7 +158,7 @@ public class ARRAY_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implements j
 	 * @param a the backing array of the returned array set.
 	 */
 	@SafeVarargs
-	public static KEY_GENERIC ARRAY_SET KEY_GENERIC of(final KEY_GENERIC_TYPE... a) {
+	public static KEY_GENERIC ARRAY_SET KEY_GENERIC ofUnchecked(final KEY_GENERIC_TYPE... a) {
 		return new ARRAY_SET KEY_GENERIC(a);
 	}
 

--- a/drv/ArraySet.drv
+++ b/drv/ArraySet.drv
@@ -128,24 +128,25 @@ public class ARRAY_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implements j
 		return ofUnchecked(a);
 	}
 
-	/** Creates a new array set using a list of elements.
+	/** Creates a new array set using an array of elements.
 	 *
 	 * <p>Unlike the array accepting constructors, this method will throw if duplicate elements
 	 * are encountered. This adds a non-trivial validation burden. Use {@link #ofUnchecked} if you
 	 * know your input has no duplicates, which will skip this validation.
 	 *
 	 * @param a the backing array of the returned array set.
-	 * @throws IllegalArgumentException if a duplicate entry was encountered.
+	 * @throws IllegalArgumentException if there were duplicate entries.
 	 */
-	// NOT @SafeVarargs. Since we are taking the array as our backing array, then passing
-	// an Integer[] when the generic is inferred Object (and thus Object[]) will not be safe.
+	// NOT @SafeVarargs. Since we are taking the array as our backing array, then, for example,
+	// passing an Integer[] when the generic is inferred Object (and thus cast to Object[]) will
+	// not be safe.
 	public static KEY_GENERIC ARRAY_SET KEY_GENERIC of(final KEY_GENERIC_TYPE... a) {
 		if (a.length == 2) {
 			if (KEY_EQUALS(a[0], a[1])) {
 				throw new IllegalArgumentException("Duplicate element: " + a[1]);
 			}
-		} else {
-			// Will throw on duplicate entry for us.
+		} else if (a.length > 2) {
+			// Will throw on a duplicate entry for us.
 			OPEN_HASH_SET.of(a);
 		}
 		return ofUnchecked(a);
@@ -158,14 +159,15 @@ public class ARRAY_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implements j
 
 	// No 1 element overload; we want the temporary array constructed for us in the varargs overload
 
-	/** Creates a new array set using a list of elements.
+	/** Creates a new array set using an array of elements.
 	 *
 	 * <p>It is the responsibility of the caller to ensure that the elements of {@code a} are distinct.
 	 *
 	 * @param a the backing array of the returned array set.
 	 */
-	// NOT @SafeVarargs. Since we are taking the array as our backing array, then passing
-	// an Integer[] when the generic is inferred Object (and thus Object[]) will not be safe.
+	// NOT @SafeVarargs. Since we are taking the array as our backing array, then, for example,
+	// passing an Integer[] when the generic is inferred Object (and thus cast to Object[]) will
+	// not be safe.
 	public static KEY_GENERIC ARRAY_SET KEY_GENERIC ofUnchecked(final KEY_GENERIC_TYPE... a) {
 		return new ARRAY_SET KEY_GENERIC(a);
 	}

--- a/drv/ArraySet.drv
+++ b/drv/ArraySet.drv
@@ -137,10 +137,17 @@ public class ARRAY_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implements j
 	 * @param a the backing array of the returned array set.
 	 * @throws IllegalArgumentException if a duplicate entry was encountered.
 	 */
-	@SafeVarargs
+	// NOT @SafeVarargs. Since we are taking the array as our backing array, then passing
+	// an Integer[] when the generic is inferred Object (and thus Object[]) will not be safe.
 	public static KEY_GENERIC ARRAY_SET KEY_GENERIC of(final KEY_GENERIC_TYPE... a) {
-		// Will throw on duplicate entry for us.
-		OPEN_HASH_SET.of(a);
+		if (a.length == 2) {
+			if (KEY_EQUALS(a[0], a[1])) {
+				throw new IllegalArgumentException("Duplicate element: " + a[1]);
+			}
+		} else {
+			// Will throw on duplicate entry for us.
+			OPEN_HASH_SET.of(a);
+		}
 		return ofUnchecked(a);
 	}
 
@@ -157,7 +164,8 @@ public class ARRAY_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implements j
 	 *
 	 * @param a the backing array of the returned array set.
 	 */
-	@SafeVarargs
+	// NOT @SafeVarargs. Since we are taking the array as our backing array, then passing
+	// an Integer[] when the generic is inferred Object (and thus Object[]) will not be safe.
 	public static KEY_GENERIC ARRAY_SET KEY_GENERIC ofUnchecked(final KEY_GENERIC_TYPE... a) {
 		return new ARRAY_SET KEY_GENERIC(a);
 	}

--- a/drv/ArraySet.drv
+++ b/drv/ArraySet.drv
@@ -38,7 +38,7 @@ public class ARRAY_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implements j
 
 	/** Creates a new array set using the given backing array. The resulting set will have as many elements as the array.
 	 *
-	 * <p>It is responsibility of the caller that the elements of {@code a} are distinct.
+	 * <p>It is the responsibility of the caller to ensure that the elements of {@code a} are distinct.
 	 *
 	 * @param a the backing array.
 	 */
@@ -102,7 +102,7 @@ public class ARRAY_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implements j
 
 	/** Creates a new array set using the given backing array and the given number of elements of the array.
 	 *
-	 * <p>It is responsibility of the caller that the first {@code size} elements of {@code a} are distinct.
+	 * <p>It is the responsibility of the caller to ensure that the first {@code size} elements of {@code a} are distinct.
 	 *
 	 * @param a the backing array.
 	 * @param size the number of valid elements in {@code a}.
@@ -111,6 +111,17 @@ public class ARRAY_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implements j
 		this.a = a;
 		this.size = size;
 		if (size > a.length) throw new IllegalArgumentException("The provided size (" + size + ") is larger than or equal to the array size (" + a.length + ")");
+	}
+
+	/** Creates a new array set using a list of elements.
+	 *
+	 * <p>It is the responsibility of the caller to ensure that the elements of {@code a} are distinct.
+	 *
+	 * @param a the backing array of the returned array set.
+	 */
+	@SafeVarargs
+	public static KEY_GENERIC ARRAY_SET KEY_GENERIC of(final KEY_GENERIC_TYPE... a) {
+		return new ARRAY_SET KEY_GENERIC(a);
 	}
 
 	private int findKey(final KEY_TYPE o) {

--- a/drv/List.drv
+++ b/drv/List.drv
@@ -359,7 +359,7 @@ public interface LIST KEY_GENERIC extends List<KEY_GENERIC_CLASS>, COLLECTION KE
 				// fall through
 		}
 		// Will copy, but that is the only way we assure immutability.
-		// ArrayList.wrap() and ArrayList.of() will not make a defensive copy.
+		// ArrayList.wrap() and ArrayList.of() will not make a defensive copy if you want that.
 		return LISTS.unmodifiable(new ARRAY_LIST KEY_GENERIC_DIAMOND(elements));
 	}
 

--- a/drv/List.drv
+++ b/drv/List.drv
@@ -315,15 +315,52 @@ public interface LIST KEY_GENERIC extends List<KEY_GENERIC_CLASS>, COLLECTION KE
 
 #endif
 
-	/** Creates an array list using a list of elements.
-	 *
-	 * @param init a list of elements that will be used to initialize the list.
-	 * @return a new array list containing the given elements.
-	 */
+	/** Returns an immutable empty list. */
+	SUPPRESS_WARNINGS_KEY_RAWTYPES
+	public static KEY_GENERIC LIST KEY_GENERIC of() {
+		return LISTS.EMPTY_LIST;
+	}
 
+	/** Returns an immutable list with the element given. */
+	public static KEY_GENERIC LIST KEY_GENERIC of(final KEY_GENERIC_TYPE e) {
+		return LISTS.singleton(e);
+	}
+
+	/** Returns an immutable list with the elements given. */
+	public static KEY_GENERIC LIST KEY_GENERIC of(final KEY_GENERIC_TYPE e1, final KEY_GENERIC_TYPE e2) {
+		final ARRAY_LIST KEY_GENERIC innerList = new ARRAY_LIST KEY_GENERIC_DIAMOND(2);
+		innerList.add(e1);
+		innerList.add(e2);
+		return LISTS.unmodifiable(innerList);
+	}
+
+	/** Returns an immutable list with the elements given. */
+	public static KEY_GENERIC LIST KEY_GENERIC of(final KEY_GENERIC_TYPE e1, final KEY_GENERIC_TYPE e2, final KEY_GENERIC_TYPE e3) {
+		final ARRAY_LIST KEY_GENERIC innerList = new ARRAY_LIST KEY_GENERIC_DIAMOND(3);
+		innerList.add(e1);
+		innerList.add(e2);
+		innerList.add(e3);
+		return LISTS.unmodifiable(innerList);
+	}
+
+	/** Returns an immutable list with the elements given. */
 	@SafeVarargs
-	public static KEY_GENERIC LIST KEY_GENERIC of(final KEY_GENERIC_TYPE... init) {
-		return ARRAY_LIST.wrap(init);
+	public static KEY_GENERIC LIST KEY_GENERIC of(final KEY_GENERIC_TYPE... elements) {
+		switch(elements.length) {
+			case 0:
+				return of();
+			case 1:
+				return of(elements[0]);
+			case 2:
+				return of(elements[0], elements[1]);
+			case 3:
+				return of(elements[0], elements[1], elements[2]);
+			default:
+				// fall through
+		}
+		// Will copy, but that is the only way we assure immutability.
+		// ArrayList.wrap() and ArrayList.of() will not make a defensive copy.
+		return LISTS.unmodifiable(new ARRAY_LIST KEY_GENERIC_DIAMOND(elements));
 	}
 
 #if defined(KEY_COMPARATOR) && KEYS_PRIMITIVE

--- a/drv/OpenHashSet.drv
+++ b/drv/OpenHashSet.drv
@@ -572,9 +572,12 @@ public class OPEN_HASH_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implemen
 	/** Creates a new hash set with {@link Hash#DEFAULT_LOAD_FACTOR} as load factor
 	 * using a list of elements.
 	 *
+	 * <p>Note: Like the array accepting constructors, and unlike the Java platform's
+	 * {@code Set.of(...)} method, this function will deduplicate the inputs instead
+	 * of throwing if duplicate entries are found.
+	 *
 	 * @param a a list of elements that will be used to initialize the new hash set.
 	 */
-
 	@SafeVarargs
 	public static KEY_GENERIC OPEN_HASH_SET KEY_GENERIC of(final KEY_GENERIC_TYPE... a) {
 		return new OPEN_HASH_SET KEY_GENERIC(a, DEFAULT_LOAD_FACTOR);

--- a/drv/OpenHashSet.drv
+++ b/drv/OpenHashSet.drv
@@ -569,18 +569,37 @@ public class OPEN_HASH_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implemen
 		this(a, DEFAULT_LOAD_FACTOR);
 	}
 
+	/** Creates new empty hash set. */
+	public static KEY_GENERIC OPEN_HASH_SET KEY_GENERIC of() {
+		return new OPEN_HASH_SET KEY_GENERIC_DIAMOND();
+	}
+	
+	/** Creates a new hash set with {@link Hash#DEFAULT_LOAD_FACTOR} as load factor
+	 * using the given element.
+	 *
+	 * @param element the element that the returned set will contain.
+	 */
+	public static KEY_GENERIC OPEN_HASH_SET KEY_GENERIC of(final KEY_GENERIC_TYPE element) {
+		OPEN_HASH_SET KEY_GENERIC result = new OPEN_HASH_SET KEY_GENERIC_DIAMOND(1, DEFAULT_LOAD_FACTOR);
+		result.add(element);
+		return result;
+	}
+
 	/** Creates a new hash set with {@link Hash#DEFAULT_LOAD_FACTOR} as load factor
 	 * using a list of elements.
 	 *
-	 * <p>Note: Like the array accepting constructors, and unlike the Java platform's
-	 * {@code Set.of(...)} method, this function will deduplicate the inputs instead
-	 * of throwing if duplicate entries are found.
-	 *
 	 * @param a a list of elements that will be used to initialize the new hash set.
+	 * @throws IllegalArgumentException if a duplicate entry was encountered.
 	 */
 	@SafeVarargs
 	public static KEY_GENERIC OPEN_HASH_SET KEY_GENERIC of(final KEY_GENERIC_TYPE... a) {
-		return new OPEN_HASH_SET KEY_GENERIC(a, DEFAULT_LOAD_FACTOR);
+		OPEN_HASH_SET KEY_GENERIC result = new OPEN_HASH_SET KEY_GENERIC_DIAMOND(a.length, DEFAULT_LOAD_FACTOR);
+		for (KEY_GENERIC_TYPE element : a) {
+			if (!result.add(element)) {
+				throw new IllegalArgumentException("Duplicate element " + a);
+			}
+		}
+		return result; 
 	}
 #endif
 

--- a/drv/OpenHashSet.drv
+++ b/drv/OpenHashSet.drv
@@ -590,13 +590,33 @@ public class OPEN_HASH_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implemen
 	 *
 	 * @param e1 the first element
 	 * @param e2 the second element
-	 * @throws IllegalArgumentException if a duplicate entry was encountered.
+	 * @throws IllegalArgumentException if there were duplicate entries.
 	 */
 	public static KEY_GENERIC OPEN_HASH_SET KEY_GENERIC of(final KEY_GENERIC_TYPE e1, final KEY_GENERIC_TYPE e2) {
 		OPEN_HASH_SET KEY_GENERIC result = new OPEN_HASH_SET KEY_GENERIC_DIAMOND(2, DEFAULT_LOAD_FACTOR);
 		result.add(e1);
 		if (!result.add(e2)) {
 			throw new IllegalArgumentException("Duplicate element: " + e2);
+		}
+		return result;
+	}
+
+	/** Creates a new hash set with {@link Hash#DEFAULT_LOAD_FACTOR} as load factor
+	 * using the elements given.
+	 *
+	 * @param e1 the first element
+	 * @param e2 the second element
+	 * @param e3 the third element
+	 * @throws IllegalArgumentException if there were duplicate entries.
+	 */
+	public static KEY_GENERIC OPEN_HASH_SET KEY_GENERIC of(final KEY_GENERIC_TYPE e1, final KEY_GENERIC_TYPE e2, final KEY_GENERIC_TYPE e3) {
+		OPEN_HASH_SET KEY_GENERIC result = new OPEN_HASH_SET KEY_GENERIC_DIAMOND(3, DEFAULT_LOAD_FACTOR);
+		result.add(e1);
+		if (!result.add(e2)) {
+			throw new IllegalArgumentException("Duplicate element: " + e2);
+		}
+		if (!result.add(e3)) {
+			throw new IllegalArgumentException("Duplicate element: " + e3);
 		}
 		return result;
 	}

--- a/drv/OpenHashSet.drv
+++ b/drv/OpenHashSet.drv
@@ -586,6 +586,22 @@ public class OPEN_HASH_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implemen
 	}
 
 	/** Creates a new hash set with {@link Hash#DEFAULT_LOAD_FACTOR} as load factor
+	 * using the elements given.
+	 *
+	 * @param e1 the first element
+	 * @param e2 the second element
+	 * @throws IllegalArgumentException if a duplicate entry was encountered.
+	 */
+	public static KEY_GENERIC OPEN_HASH_SET KEY_GENERIC of(final KEY_GENERIC_TYPE e1, final KEY_GENERIC_TYPE e2) {
+		OPEN_HASH_SET KEY_GENERIC result = new OPEN_HASH_SET KEY_GENERIC_DIAMOND(2, DEFAULT_LOAD_FACTOR);
+		result.add(e1);
+		if (!result.add(e2)) {
+			throw new IllegalArgumentException("Duplicate element: " + e2);
+		}
+		return result;
+	}
+
+	/** Creates a new hash set with {@link Hash#DEFAULT_LOAD_FACTOR} as load factor
 	 * using a list of elements.
 	 *
 	 * @param a a list of elements that will be used to initialize the new hash set.
@@ -596,7 +612,7 @@ public class OPEN_HASH_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implemen
 		OPEN_HASH_SET KEY_GENERIC result = new OPEN_HASH_SET KEY_GENERIC_DIAMOND(a.length, DEFAULT_LOAD_FACTOR);
 		for (KEY_GENERIC_TYPE element : a) {
 			if (!result.add(element)) {
-				throw new IllegalArgumentException("Duplicate element " + a);
+				throw new IllegalArgumentException("Duplicate element " + element);
 			}
 		}
 		return result; 

--- a/drv/Set.drv
+++ b/drv/Set.drv
@@ -98,7 +98,7 @@ public interface SET KEY_GENERIC extends COLLECTION KEY_GENERIC, Set<KEY_GENERIC
 
 
 	/** Returns an immutable empty set. */
-	SUPPRESS_WARNINGS_KEY_RAWTYPES
+	SUPPRESS_WARNINGS_KEY_UNCHECKED
 	public static KEY_GENERIC SET KEY_GENERIC of() {
 		return SETS.EMPTY_SET;
 	}
@@ -111,6 +111,8 @@ public interface SET KEY_GENERIC extends COLLECTION KEY_GENERIC, Set<KEY_GENERIC
 	/**
 	 * Returns an immutable set with the elements given.
 	 *
+	 * @param e1 the first element
+	 * @param e2 the second element
 	 * @throws IllegalArgumentException if there were duplicate entries.
 	 */
 	public static KEY_GENERIC SET KEY_GENERIC of(KEY_GENERIC_TYPE e1, KEY_GENERIC_TYPE e2) {
@@ -125,6 +127,9 @@ public interface SET KEY_GENERIC extends COLLECTION KEY_GENERIC, Set<KEY_GENERIC
 	/**
 	 * Returns an immutable set with the elements given.
 	 *
+	 * @param e1 the first element
+	 * @param e2 the second element
+	 * @param e3 the third element
 	 * @throws IllegalArgumentException if there were duplicate entries.
 	 */
 	public static KEY_GENERIC SET KEY_GENERIC of(KEY_GENERIC_TYPE e1, KEY_GENERIC_TYPE e2, KEY_GENERIC_TYPE e3) {

--- a/drv/Set.drv
+++ b/drv/Set.drv
@@ -96,14 +96,79 @@ public interface SET KEY_GENERIC extends COLLECTION KEY_GENERIC, Set<KEY_GENERIC
 
 #endif
 
-	/** Creates a new set using a list of elements.
-	 *
-	 * @param a a list of elements that will be used to initialize the new set.
-	 */
 
+	/** Returns an immutable empty set. */
+	SUPPRESS_WARNINGS_KEY_RAWTYPES
+	public static KEY_GENERIC SET KEY_GENERIC of() {
+		return SETS.EMPTY_SET;
+	}
+
+	/** Returns an immutable set with the element given. */
+	public static KEY_GENERIC SET KEY_GENERIC of(KEY_GENERIC_TYPE e) {
+		return SETS.singleton(e);
+	}
+
+	/**
+	 * Returns an immutable set with the elements given.
+	 *
+	 * @throws IllegalArgumentException if there were duplicate entries.
+	 */
+	public static KEY_GENERIC SET KEY_GENERIC of(KEY_GENERIC_TYPE e1, KEY_GENERIC_TYPE e2) {
+		ARRAY_SET KEY_GENERIC innerSet = new ARRAY_SET KEY_GENERIC_DIAMOND(2);
+		innerSet.add(e1);
+		if (!innerSet.add(e2)) {
+			throw new IllegalArgumentException("Duplicate element: " + e2);
+		}
+		return SETS.unmodifiable(innerSet);
+	}
+
+	/**
+	 * Returns an immutable set with the elements given.
+	 *
+	 * @throws IllegalArgumentException if there were duplicate entries.
+	 */
+	public static KEY_GENERIC SET KEY_GENERIC of(KEY_GENERIC_TYPE e1, KEY_GENERIC_TYPE e2, KEY_GENERIC_TYPE e3) {
+		ARRAY_SET KEY_GENERIC innerSet = new ARRAY_SET KEY_GENERIC_DIAMOND(3);
+		innerSet.add(e1);
+		if (!innerSet.add(e2)) {
+			throw new IllegalArgumentException("Duplicate element: " + e2);
+		}
+		if (!innerSet.add(e3)) {
+			throw new IllegalArgumentException("Duplicate element: " + e3);
+		}
+		return SETS.unmodifiable(innerSet);
+	}
+
+	/**
+	 * Returns an immutable list with the elements given.
+	 *
+	 * @param elements the list of elements that will be in the final set
+	 * @throws IllegalArgumentException if there are any duplicate entries
+	 */
 	@SafeVarargs
-	public static KEY_GENERIC SET KEY_GENERIC of(final KEY_GENERIC_TYPE... a) {
-		return new OPEN_HASH_SET KEY_GENERIC(a);
+	public static KEY_GENERIC SET KEY_GENERIC of(KEY_GENERIC_TYPE... elements) {
+		switch(elements.length) {
+			case 0:
+				return of();
+			case 1:
+				return of(elements[0]);
+			case 2:
+				return of(elements[0], elements[1]);
+			case 3:
+				return of(elements[0], elements[1], elements[2]);
+			default:
+				// fall through
+		}
+		// Will copy, but that is the only way we assure immutability.
+		SET KEY_GENERIC innerSet = elements.length <= SETS.ARRAY_SET_CUTOFF ?
+			new ARRAY_SET KEY_GENERIC_DIAMOND(elements.length) :
+			new OPEN_HASH_SET KEY_GENERIC_DIAMOND(elements.length, 1.0f);
+		for (KEY_GENERIC_TYPE element : elements) {
+			if (!innerSet.add(element)) {
+				throw new IllegalArgumentException("Duplicate element: " + element);
+			}
+		}
+		return SETS.unmodifiable(innerSet);
 	}
 
 }

--- a/drv/Sets.drv
+++ b/drv/Sets.drv
@@ -29,6 +29,9 @@ public final class SETS {
 
 	private SETS() {}
 
+	/** The maximum size to choose ArraySet over OpenHashSet for utilites that automatically choose. */
+	static final int ARRAY_SET_CUTOFF = 4;
+
 	/** An immutable class representing the empty set and implementing a type-specific set interface.
 	 *
 	 * <p>This class may be useful to implement your own in case you subclass
@@ -76,7 +79,6 @@ public final class SETS {
 		return EMPTY_SET;
 	}
 #endif
-
 
 	/** An immutable class representing a type-specific singleton set.
 	 *

--- a/test/it/unimi/dsi/fastutil/ints/IntArrayListTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntArrayListTest.java
@@ -133,4 +133,16 @@ public class IntArrayListTest {
 		final IntArrayList l = IntArrayList.of(0, 1, 2);
 		assertEquals(IntArrayList.wrap(new int[] { 0, 1, 2 }), l);
 	}
+
+	@Test
+	public void testOfEmpty() {
+		final IntArrayList l = IntArrayList.of();
+		assertTrue(l.isEmpty());
+	}
+
+	@Test
+	public void testOfSingleton() {
+		final IntArrayList l = IntArrayList.of(0);
+		assertEquals(IntArrayList.wrap(new int[] { 0 }), l);
+	}
 }

--- a/test/it/unimi/dsi/fastutil/ints/IntArraySetTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntArraySetTest.java
@@ -133,4 +133,10 @@ public class IntArraySetTest {
 		assertFalse(iterator.hasNext());
 		assertEquals(new IntArraySet(new int[] { 42, 44 }), set);
 	}
+
+	@Test
+	public void testOf() {
+		final IntArraySet l = IntArraySet.of(0, 1, 2);
+		assertEquals(new IntArraySet(new int[] { 0, 1, 2 }), l);
+	}
 }

--- a/test/it/unimi/dsi/fastutil/ints/IntArraySetTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntArraySetTest.java
@@ -136,7 +136,49 @@ public class IntArraySetTest {
 
 	@Test
 	public void testOf() {
-		final IntArraySet l = IntArraySet.of(0, 1, 2);
-		assertEquals(new IntArraySet(new int[] { 0, 1, 2 }), l);
+		final IntArraySet s = IntArraySet.of(0, 1, 2);
+		assertEquals(new IntArraySet(new int[] { 0, 1, 2 }), s);
+	}
+
+	@Test
+	public void testOfEmpty() {
+		final IntArraySet s = IntArraySet.of();
+		assertTrue(s.isEmpty());
+	}
+
+	@Test
+	public void testOfSingleton() {
+		final IntArraySet s = IntArraySet.of(0);
+		assertEquals(new IntArraySet(new int[] { 0 }), s);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testOfDuplicateThrows() {
+		IntArraySet.of(0, 0);
+	}
+
+	@Test
+	public void testOfUnchecked() {
+		final IntArraySet s = IntArraySet.ofUnchecked(0, 1, 2);
+		assertEquals(new IntArraySet(new int[] { 0, 1, 2 }), s);
+	}
+
+	@Test
+	public void testOfUncheckedEmpty() {
+		final IntArraySet s = IntArraySet.ofUnchecked();
+		assertTrue(s.isEmpty());
+	}
+
+	@Test
+	public void testOfUnchekedSingleton() {
+		final IntArraySet s = IntArraySet.ofUnchecked(0);
+		assertEquals(new IntArraySet(new int[] { 0 }), s);
+	}
+
+	@Test
+	public void testOfUnchekedDuplicatesNotDetected() {
+		// A IntArraySet in an invalid state that by spec we aren't checking for in this method.
+		final IntArraySet s = IntArraySet.ofUnchecked(0, 0);
+		assertEquals(new IntArraySet(new int[] { 0 , 0 }), s);
 	}
 }

--- a/test/it/unimi/dsi/fastutil/ints/IntListTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntListTest.java
@@ -1,0 +1,64 @@
+package it.unimi.dsi.fastutil.ints;
+
+import static org.junit.Assert.assertEquals;
+
+/*
+ * Copyright (C) 2017-2020 Sebastiano Vigna
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.RandomAccess;
+
+import org.junit.Test;
+
+public class IntListTest {
+	@Test
+	public void testOf() {
+		final IntList l = IntList.of(0, 1, 2);
+		assertEquals(IntArrayList.wrap(new int[] { 0, 1, 2 }), l);
+	}
+
+	@Test
+	public void testOfEmpty() {
+		final IntList l = IntList.of();
+		assertTrue(l.isEmpty());
+	}
+
+	@Test
+	public void testOfSingleton() {
+		final IntList l = IntList.of(0);
+		assertEquals(IntArrayList.wrap(new int[] { 0 }), l);
+	}
+
+	@Test
+	public void testOfPair() {
+		final IntList l = IntList.of(0, 1);
+		assertEquals(IntArrayList.wrap(new int[] { 0, 1 }), l);
+	}
+	
+	@Test
+	public void testOfTriplet() {
+		final IntList l = IntList.of(0, 1, 2);
+		assertEquals(IntArrayList.wrap(new int[] { 0, 1, 2 }), l);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testOfImmutable() {
+		final IntList l = IntList.of(0, 1, 2);
+		l.add(3);
+	}
+}

--- a/test/it/unimi/dsi/fastutil/ints/IntOpenHashSetTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntOpenHashSetTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 
 import it.unimi.dsi.fastutil.Hash;
 import it.unimi.dsi.fastutil.HashCommon;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 
 @SuppressWarnings("rawtypes")
@@ -284,6 +285,23 @@ public class IntOpenHashSetTest {
 	public void testOf() {
 		final IntOpenHashSet s = IntOpenHashSet.of(0, 1, 2);
 		assertEquals(new IntOpenHashSet(new int[] { 0, 1, 2 }), s);
+	}
+
+	@Test
+	public void testOfEmpty() {
+		final IntOpenHashSet s = IntOpenHashSet.of();
+		assertTrue(s.isEmpty());
+	}
+
+	@Test
+	public void testOfSingleton() {
+		final IntOpenHashSet s = IntOpenHashSet.of(0);
+		assertEquals(new IntOpenHashSet(new int[] { 0 }), s);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testOfDuplicateThrows() {
+		IntOpenHashSet.of(0, 0);
 	}
 
 	@SuppressWarnings("boxing")

--- a/test/it/unimi/dsi/fastutil/ints/IntSetTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntSetTest.java
@@ -1,0 +1,68 @@
+package it.unimi.dsi.fastutil.ints;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/*
+ * Copyright (C) 2017-2020 Sebastiano Vigna
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class IntSetTest {
+	@Test
+	public void testOf() {
+		final IntSet s = IntSet.of(0, 1, 2, 3);
+		assertEquals(new IntOpenHashSet(new int[] { 0, 1, 2, 3 }), s);
+	}
+
+	@Test
+	public void testOfEmpty() {
+		final IntSet s = IntSet.of();
+		assertTrue(s.isEmpty());
+	}
+
+	@Test
+	public void testOfSingleton() {
+		final IntSet s = IntSet.of(0);
+		assertEquals(new IntOpenHashSet(new int[] { 0 }), s);
+	}
+
+	@Test
+	public void testOfPair() {
+		final IntSet s = IntSet.of(0, 1);
+		assertEquals(new IntOpenHashSet(new int[] { 0, 1 }), s);
+	}
+
+	@Test
+	public void testOfTriplet() {
+		final IntSet s = IntSet.of(0, 1, 2);
+		assertEquals(new IntOpenHashSet(new int[] { 0, 1, 2 }), s);
+	}	
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testOfDuplicateThrows() {
+		IntSet.of(0, 0, 0, 0);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testOfImmutable() {
+		final IntSet l = IntSet.of(0, 1, 2);
+		l.add(3);
+	}
+}

--- a/test/it/unimi/dsi/fastutil/objects/ObjectArrayListTest.java
+++ b/test/it/unimi/dsi/fastutil/objects/ObjectArrayListTest.java
@@ -45,4 +45,10 @@ public class ObjectArrayListTest {
 		final ObjectArrayList<Integer> l = new ObjectArrayList<>();
 		l.size(100);
 	}
+
+	@Test
+	public void testOf() {
+		final ObjectArrayList<String> l = ObjectArrayList.of("0", "1", "2");
+		assertEquals(ObjectArrayList.wrap(new String[] { "0", "1", "2" }), l);
+	}
 }

--- a/test/it/unimi/dsi/fastutil/objects/ObjectArrayListTest.java
+++ b/test/it/unimi/dsi/fastutil/objects/ObjectArrayListTest.java
@@ -51,4 +51,16 @@ public class ObjectArrayListTest {
 		final ObjectArrayList<String> l = ObjectArrayList.of("0", "1", "2");
 		assertEquals(ObjectArrayList.wrap(new String[] { "0", "1", "2" }), l);
 	}
+
+	@Test
+	public void testOfEmpty() {
+		final ObjectArrayList<String> l = ObjectArrayList.of();
+		assertTrue(l.isEmpty());
+	}
+
+	@Test
+	public void testOfSingleton() {
+		final ObjectArrayList<String> l = ObjectArrayList.of("0");
+		assertEquals(ObjectArrayList.wrap(new String[] { "0" }), l);
+	}
 }

--- a/test/it/unimi/dsi/fastutil/objects/ObjectArraySetTest.java
+++ b/test/it/unimi/dsi/fastutil/objects/ObjectArraySetTest.java
@@ -130,4 +130,10 @@ public class ObjectArraySetTest {
 		assertFalse(iterator.hasNext());
 		assertEquals(new ObjectArraySet<Integer>(new Integer[] { 42, 44 }), set);
 	}
+
+	@Test
+	public void testOf() {
+		final ObjectArraySet<String> l = ObjectArraySet.of("0", "1", "2");
+		assertEquals(new ObjectArraySet<>(new String[] { "0", "1", "2" }), l);
+	}
 }

--- a/test/it/unimi/dsi/fastutil/objects/ObjectArraySetTest.java
+++ b/test/it/unimi/dsi/fastutil/objects/ObjectArraySetTest.java
@@ -136,4 +136,46 @@ public class ObjectArraySetTest {
 		final ObjectArraySet<String> l = ObjectArraySet.of("0", "1", "2");
 		assertEquals(new ObjectArraySet<>(new String[] { "0", "1", "2" }), l);
 	}
+
+	@Test
+	public void testOfEmpty() {
+		final ObjectArraySet<String> l = ObjectArraySet.of();
+		assertTrue(l.isEmpty());
+	}
+
+	@Test
+	public void testOfSingleton() {
+		final ObjectArraySet<String> l = ObjectArraySet.of("0");
+		assertEquals(new ObjectArraySet<>(new String[] { "0" }), l);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testOfDuplicateThrows() {
+		ObjectArraySet.of("0", "0");
+	}
+
+	@Test
+	public void testOfUnchecked() {
+		final ObjectArraySet<String> l = ObjectArraySet.ofUnchecked("0", "1", "2");
+		assertEquals(new ObjectArraySet<>(new String[] { "0", "1", "2" }), l);
+	}
+
+	@Test
+	public void testOfUncheckedEmpty() {
+		final ObjectArraySet<String> l = ObjectArraySet.ofUnchecked();
+		assertTrue(l.isEmpty());
+	}
+
+	@Test
+	public void testOfUnchekedSingleton() {
+		final ObjectArraySet<String> l = ObjectArraySet.ofUnchecked("0");
+		assertEquals(new ObjectArraySet<>(new String[] { "0" }), l);
+	}
+
+	@Test
+	public void testOfUnchekedDuplicatesNotDetected() {
+		// A ObjectArraySet in an invalid state that by spec we aren't checking for in this method.
+		final ObjectArraySet<String> l = ObjectArraySet.ofUnchecked("0", "0");
+		assertEquals(new ObjectArraySet<>(new String[] { "0" , "0" }), l);
+	}
 }

--- a/test/it/unimi/dsi/fastutil/objects/ObjectListTest.java
+++ b/test/it/unimi/dsi/fastutil/objects/ObjectListTest.java
@@ -1,0 +1,64 @@
+package it.unimi.dsi.fastutil.objects;
+
+import static org.junit.Assert.assertEquals;
+
+/*
+ * Copyright (C) 2017-2020 Sebastiano Vigna
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.RandomAccess;
+
+import org.junit.Test;
+
+public class ObjectListTest {
+	@Test
+	public void testOf() {
+		final ObjectList<String> l = ObjectList.of("0", "1", "2");
+		assertEquals(ObjectArrayList.wrap(new String[] { "0", "1", "2" }), l);
+	}
+
+	@Test
+	public void testOfEmpty() {
+		final ObjectList<String> l = ObjectList.of();
+		assertTrue(l.isEmpty());
+	}
+
+	@Test
+	public void testOfSingleton() {
+		final ObjectList<String> l = ObjectList.of("0");
+		assertEquals(ObjectArrayList.wrap(new String[] { "0" }), l);
+	}
+
+	@Test
+	public void testOfPair() {
+		final ObjectList<String> l = ObjectList.of("0", "1");
+		assertEquals(ObjectArrayList.wrap(new String[] { "0", "1" }), l);
+	}
+	
+	@Test
+	public void testOfTriplet() {
+		final ObjectList<String> l = ObjectList.of("0", "1", "2");
+		assertEquals(ObjectArrayList.wrap(new String[] { "0", "1", "2" }), l);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testOfImmutable() {
+		final ObjectList<String> l = ObjectList.of("0", "1", "2");
+		l.add("3");
+	}
+}

--- a/test/it/unimi/dsi/fastutil/objects/ObjectOpenHashSetTest.java
+++ b/test/it/unimi/dsi/fastutil/objects/ObjectOpenHashSetTest.java
@@ -83,6 +83,23 @@ public class ObjectOpenHashSetTest {
 		assertEquals(new LongOpenHashSet(new long[] { 0, 1, 2 }), s);
 	}
 
+	@Test
+	public void testOfEmpty() {
+		final ObjectOpenHashSet<Long> s = ObjectOpenHashSet.of();
+		assertTrue(s.isEmpty());
+	}
+
+	@Test
+	public void testOfSingleton() {
+		final ObjectOpenHashSet<Long> s = ObjectOpenHashSet.of(Long.valueOf(0));
+		assertEquals(new LongOpenHashSet(new long[] { 0 }), s);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testOfDuplicateThrows() {
+		ObjectOpenHashSet.of(Long.valueOf(0), Long.valueOf(0));
+	}
+
 	private static java.util.Random r = new java.util.Random(0);
 
 	private static Object genKey() {

--- a/test/it/unimi/dsi/fastutil/objects/ObjectOpenHashSetTest.java
+++ b/test/it/unimi/dsi/fastutil/objects/ObjectOpenHashSetTest.java
@@ -79,8 +79,8 @@ public class ObjectOpenHashSetTest {
 
 	@Test
 	public void testOf() {
-		final ObjectOpenHashSet<Long> s = ObjectOpenHashSet.of(Long.valueOf(0), Long.valueOf(1), Long.valueOf(2));
-		assertEquals(new LongOpenHashSet(new long[] { 0, 1, 2 }), s);
+		final ObjectOpenHashSet<Long> s = ObjectOpenHashSet.of(0l, 1l, 2l, 3l);
+		assertEquals(new LongOpenHashSet(new long[] { 0, 1, 2, 3 }), s);
 	}
 
 	@Test
@@ -91,8 +91,20 @@ public class ObjectOpenHashSetTest {
 
 	@Test
 	public void testOfSingleton() {
-		final ObjectOpenHashSet<Long> s = ObjectOpenHashSet.of(Long.valueOf(0));
+		final ObjectOpenHashSet<Long> s = ObjectOpenHashSet.of(0l);
 		assertEquals(new LongOpenHashSet(new long[] { 0 }), s);
+	}
+
+	@Test
+	public void testOfPair() {
+		final ObjectOpenHashSet<Long> s = ObjectOpenHashSet.of(0l, 1l);
+		assertEquals(new LongOpenHashSet(new long[] { 0, 1 }), s);
+	}
+
+	@Test
+	public void testOfTriplet() {
+		final ObjectOpenHashSet<Long> s = ObjectOpenHashSet.of(0l, 1l, 2l);
+		assertEquals(new LongOpenHashSet(new long[] { 0, 1, 2 }), s);
 	}
 
 	@Test(expected = IllegalArgumentException.class)

--- a/test/it/unimi/dsi/fastutil/objects/ObjectSetTest.java
+++ b/test/it/unimi/dsi/fastutil/objects/ObjectSetTest.java
@@ -1,0 +1,68 @@
+package it.unimi.dsi.fastutil.objects;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/*
+ * Copyright (C) 2017-2020 Sebastiano Vigna
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class ObjectSetTest {
+	@Test
+	public void testOf() {
+		final ObjectSet<String> s = ObjectSet.of("0", "1", "2", "3");
+		assertEquals(new ObjectOpenHashSet<String>(new String[] { "0", "1", "2", "3" }), s);
+	}
+
+	@Test
+	public void testOfEmpty() {
+		final ObjectSet<String> s = ObjectSet.of();
+		assertTrue(s.isEmpty());
+	}
+
+	@Test
+	public void testOfSingleton() {
+		final ObjectSet<String> s = ObjectSet.of("0");
+		assertEquals(new ObjectOpenHashSet<String>(new String[] { "0" }), s);
+	}
+
+	@Test
+	public void testOfPair() {
+		final ObjectSet<String> s = ObjectSet.of("0", "1");
+		assertEquals(new ObjectOpenHashSet<String>(new String[] { "0", "1" }), s);
+	}
+
+	@Test
+	public void testOfTriplet() {
+		final ObjectSet<String> s = ObjectSet.of("0", "1", "2");
+		assertEquals(new ObjectOpenHashSet<String>(new String[] { "0", "1", "2" }), s);
+	}	
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testOfDuplicateThrows() {
+		ObjectSet.of("0", "0", "0", "0");
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testOfImmutable() {
+		final ObjectSet<String> l = ObjectSet.of("0", "1", "2");
+		l.add("3");
+	}
+}


### PR DESCRIPTION
Clean up the of methods()

- Make the `of` methods in the root `List` and `Set` interfaces return immutable collections (like the platform does)
- Validate that duplicate entries to the "of" method of sets throws (like the platform does)
  
Because of this validation, it is now worth it to have overloads of 0 and 1 element, which skip the temporary array and validation (0 and 1 element sets can never have duplication).

In the spirit of ArraySet's "just trust me" API of working raw arrays unvalidated, an it has an offshoot `ofUnchecked` that takes the elements as is and does no validation, like the array accepting constructors do.