### PR TITLE
Update object based bulk operation methods to use type specific

### DIFF
--- a/drv/AbstractCollection.drv
+++ b/drv/AbstractCollection.drv
@@ -18,6 +18,7 @@
 package PACKAGE;
 
 import java.util.AbstractCollection;
+import java.util.Collection;
 
 /** An abstract class providing basic methods for collections implementing a type-specific interface.
  *
@@ -134,12 +135,38 @@ public abstract class ABSTRACT_COLLECTION KEY_GENERIC extends AbstractCollection
 			if (add(i.NEXT_KEY())) retVal = true;
 		return retVal;
 	}
+	
+	/** {@inheritDoc}
+	 *
+	 * <p>This implementation delegates to the type-specific version if given a type-specific
+	 * collection, otherwise is uses the implementation from {@link AbstractCollection}.
+	 */
+	@Override
+	public boolean addAll(final Collection<? extends KEY_CLASS> c) {
+		if (c instanceof COLLECTION) {
+			return addAll((COLLECTION) c);
+		}
+		return super.addAll(c);
+	}
 
 	@Override
 	public boolean containsAll(final COLLECTION c) {
 		for(final KEY_ITERATOR i = c.iterator(); i.hasNext();)
 			if (! contains(i.NEXT_KEY())) return false;
 		return true;
+	}
+	
+	/** {@inheritDoc}
+	 *
+	 * <p>This implementation delegates to the type-specific version if given a type-specific
+	 * collection, otherwise is uses the implementation from {@link AbstractCollection}.
+	 */
+	@Override
+	public boolean containsAll(final Collection<?> c) {
+		if (c instanceof COLLECTION) {
+			return containsAll((COLLECTION) c);
+		}
+		return super.containsAll(c);
 	}
 
 	@Override
@@ -148,6 +175,19 @@ public abstract class ABSTRACT_COLLECTION KEY_GENERIC extends AbstractCollection
 		for(final KEY_ITERATOR i = c.iterator(); i.hasNext();)
 			if (rem(i.NEXT_KEY())) retVal = true;
 		return retVal;
+	}
+
+	/** {@inheritDoc}
+	 *
+	 * <p>This implementation delegates to the type-specific version if given a type-specific
+	 * collection, otherwise is uses the implementation from {@link AbstractCollection}.
+	 */
+	@Override
+	public boolean removeAll(final Collection<?> c) {
+		if (c instanceof COLLECTION) {
+			return removeAll((COLLECTION) c);
+		}
+		return super.removeAll(c);
 	}
 
 	@Override
@@ -159,6 +199,19 @@ public abstract class ABSTRACT_COLLECTION KEY_GENERIC extends AbstractCollection
 				retVal = true;
 			}
 		return retVal;
+	}
+
+	/** {@inheritDoc}
+	 *
+	 * <p>This implementation delegates to the type-specific version if given a type-specific
+	 * collection, otherwise is uses the implementation from {@link AbstractCollection}.
+	 */
+	@Override
+	public boolean retainAll(final Collection<?> c) {
+		if (c instanceof COLLECTION) {
+			return retainAll((COLLECTION) c);
+		}
+		return super.retainAll(c);
 	}
 #endif
 

--- a/drv/AbstractList.drv
+++ b/drv/AbstractList.drv
@@ -96,6 +96,11 @@ public abstract class ABSTRACT_LIST KEY_GENERIC extends ABSTRACT_COLLECTION KEY_
 	/** Adds all of the elements in the specified collection to this list (optional operation). */
 	@Override
 	public boolean addAll(int index, final Collection<? extends KEY_GENERIC_CLASS> c) {
+#if KEYS_PRIMITIVE
+		if (c instanceof COLLECTION) {
+			return addAll(index, (COLLECTION) c);
+		}
+#endif
 		ensureIndex(index);
 		final Iterator<? extends KEY_GENERIC_CLASS> i = c.iterator();
 		final boolean retVal = i.hasNext();

--- a/drv/AbstractSet.drv
+++ b/drv/AbstractSet.drv
@@ -41,6 +41,11 @@ public abstract class ABSTRACT_SET KEY_GENERIC extends ABSTRACT_COLLECTION KEY_G
 
 		Set<?> s = (Set<?>) o;
 		if (s.size() != size()) return false;
+#if KEYS_PRIMITIVE
+		if (s instanceof SET) {
+			return containsAll((SET) s);
+		}
+#endif
 		return containsAll(s);
 	}
 

--- a/test/it/unimi/dsi/fastutil/ints/IntArrayListTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntArrayListTest.java
@@ -51,6 +51,26 @@ public class IntArrayListTest {
 	}
 
 	@Test
+	public void testAddAll() {
+		IntArrayList l = IntArrayList.wrap(new int[] { 0, 1 });
+		l.addAll(IntArrayList.wrap(new int[] { 2, 3 } ));
+		assertEquals(IntArrayList.wrap(new int[] { 0, 1, 2, 3 }), l);
+		// Test object based lists still work too.
+		l.addAll(java.util.Arrays.asList(4, 5));
+		assertEquals(IntArrayList.wrap(new int[] { 0, 1, 2, 3, 4, 5 }), l);
+	}
+
+	@Test
+	public void testAddAllAtIndex() {
+		IntArrayList l = IntArrayList.wrap(new int[] { 0, 3 });
+		l.addAll(1, IntArrayList.wrap(new int[] { 1, 2 } ));
+		assertEquals(IntArrayList.wrap(new int[] { 0, 1, 2, 3 }), l);
+		// Test object based lists still work too.
+		l.addAll(2, java.util.Arrays.asList(4, 5));
+		assertEquals(IntArrayList.wrap(new int[] { 0, 1, 4, 5, 2, 3 }), l);
+	}
+
+	@Test
 	public void testRemoveAll() {
 		IntArrayList l = IntArrayList.wrap(new int[] { 0, 1, 1, 2 });
 		l.removeAll(IntSets.singleton(1));

--- a/test/it/unimi/dsi/fastutil/ints/IntOpenHashSetTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntOpenHashSetTest.java
@@ -59,6 +59,26 @@ public class IntOpenHashSetTest {
 	}
 
 	@Test
+	public void testEqualsSameType() {
+		final IntOpenHashSet s = new IntOpenHashSet(new int[] { 1, 2, 3 });
+		assertTrue(s.equals(new IntOpenHashSet(new int[] { 1, 2, 3 })));
+	}
+
+	@SuppressWarnings("unlikely-arg-type")
+	@Test
+	public void testEqualsIntSetType() {
+		final IntOpenHashSet s = new IntOpenHashSet(new int[] { 1, 2, 3 });
+		assertTrue(s.equals(new IntArraySet(new int[] { 1, 2, 3 })));
+	}
+
+	@SuppressWarnings({ "boxing", "unlikely-arg-type" })
+	@Test
+	public void testEqualsObjectSet() {
+		final IntOpenHashSet s = new IntOpenHashSet(new int[] { 1, 2, 3 });
+		assertTrue(s.equals(new ObjectOpenHashSet<>(new Integer[] { 1, 2, 3 })));
+	}
+
+	@Test
 	public void testInfiniteLoop1() {
 		final IntOpenHashSet set = new IntOpenHashSet();
 		set.add(1);


### PR DESCRIPTION
Update object based, boxing bulk operation methods to use the fast type-specific version if possible.

AbstractCollection.addAll
                  .containsAll
                  .removeAll
                  .retainAll
AbstractList.addAll(int, Collection)
AbstractSet.equals

Will now delegate to the fast, type-specific method if given an type-specific collection as their input.

This is a slight behavior change. If there are any user subclasses of AbstractCollection/AbstractList that have implemented their type specific bulk methods as calling the object based ones (despite that being strongly dis-recommended) without overriding the boxed versions being overridden too, this will now cause an infinite recursion.