### PR TITLE
Harden immutability of ImmutableList.

### DIFF
--- a/drv/ArrayList.drv
+++ b/drv/ArrayList.drv
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import java.util.RandomAccess;
 import java.util.NoSuchElementException;
 #if KEYS_REFERENCE
+import java.lang.reflect.Array;
 import java.util.Comparator;
 #endif
 
@@ -589,6 +590,27 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 		return modified;
 	}
 
+#endif
+
+#if KEYS_REFERENCE
+	@Override
+	public Object[] toArray() {
+		// A subtle part of the spec says the returned array must be Object[] exactly.
+		return Arrays.copyOf(a, size(), Object[].class);
+	}
+
+	SUPPRESS_WARNINGS_KEY_UNCHECKED
+	@Override
+	public KEY_GENERIC KEY_GENERIC_TYPE[] toArray(KEY_GENERIC_TYPE a[]) {
+		if (a == null || a.length < size()) {
+			a = KEY_GENERIC_ARRAY_CAST Array.newInstance(a.getClass().getComponentType(), size());
+		}
+		System.arraycopy(this.a, 0, a, 0, size());
+		if (a.length > size()) {
+			a[size()] = null;
+		}
+		return a;
+	}
 #endif
 
 	@Override

--- a/drv/ArrayList.drv
+++ b/drv/ArrayList.drv
@@ -835,7 +835,9 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 	SUPPRESS_WARNINGS_KEY_UNCHECKED
 	@Override
 	public KEY_GENERIC KEY_GENERIC_TYPE[] toArray(KEY_GENERIC_TYPE a[]) {
-		if (a == null || a.length < size()) {
+		if (a == null) {
+			a = KEY_GENERIC_ARRAY_CAST new Object[size()];
+		} else if (a.length < size()) {
 			a = KEY_GENERIC_ARRAY_CAST Array.newInstance(a.getClass().getComponentType(), size());
 		}
 		System.arraycopy(this.a, 0, a, 0, size());

--- a/drv/ImmutableList.drv
+++ b/drv/ImmutableList.drv
@@ -279,7 +279,9 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 	SUPPRESS_WARNINGS_KEY_UNCHECKED
 	@Override
 	public KEY_GENERIC KEY_GENERIC_TYPE[] toArray(KEY_GENERIC_TYPE a[]) {
-		if (a == null || a.length < size()) {
+		if (a == null) {
+			a = KEY_GENERIC_ARRAY_CAST new Object[size()];
+		} else if (a.length < size()) {
 			a = KEY_GENERIC_ARRAY_CAST Array.newInstance(a.getClass().getComponentType(), size());
 		}
 		System.arraycopy(this.a, 0, a, 0, size());

--- a/drv/ImmutableList.drv
+++ b/drv/ImmutableList.drv
@@ -293,16 +293,16 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 		ensureIndex(index);
 
 		return new KEY_LIST_ITERATOR KEY_GENERIC() {
-				int pos = index, last = -1;
+				int pos = index;
 
 				@Override
 				public boolean hasNext() { return pos < a.length; }
 				@Override
 				public boolean hasPrevious() { return pos > 0; }
 				@Override
-				public KEY_GENERIC_TYPE NEXT_KEY() { if (! hasNext()) throw new NoSuchElementException(); return a[last = pos++]; }
+				public KEY_GENERIC_TYPE NEXT_KEY() { if (! hasNext()) throw new NoSuchElementException(); return a[pos++]; }
 				@Override
-				public KEY_GENERIC_TYPE PREV_KEY() { if (! hasPrevious()) throw new NoSuchElementException(); return a[last = --pos]; }
+				public KEY_GENERIC_TYPE PREV_KEY() { if (! hasPrevious()) throw new NoSuchElementException(); return a[--pos]; }
 				@Override
 				public int nextIndex() { return pos; }
 				@Override
@@ -417,6 +417,11 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 			this.pos = myNewPos;
 			return new Spliterator(oldPos, retMax);
 		}
+	}
+
+	@Override
+	public KEY_SPLITERATOR KEY_GENERIC spliterator() {
+		return new Spliterator();
 	}
 
 	@Override

--- a/drv/ImmutableList.drv
+++ b/drv/ImmutableList.drv
@@ -48,6 +48,19 @@ import java.util.stream.Collector;
 
 public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements RandomAccess, Cloneable, java.io.Serializable {
 	private static final long serialVersionUID = 0L;
+	
+	SUPPRESS_WARNINGS_KEY_UNCHECKED_RAWTYPES
+	private static final IMMUTABLE_LIST EMPTY = new IMMUTABLE_LIST(ARRAYS.EMPTY_ARRAY);
+
+#if KEYS_PRIMITIVE
+#define _EMPTY_ARRAY ARRAYS.EMPTY_ARRAY
+#else
+	SUPPRESS_WARNINGS_KEY_UNCHECKED
+	private static final KEY_GENERIC KEY_GENERIC_TYPE[] emptyArray() {
+		return KEY_GENERIC_ARRAY_CAST ARRAYS.EMPTY_ARRAY;
+	}
+#define _EMPTY_ARRAY emptyArray()
+#endif
 
 	/** The backing array; all elements are part of this list. */
 	private final KEY_GENERIC_TYPE a[];
@@ -70,9 +83,9 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 
 	public IMMUTABLE_LIST(final Collection<? extends KEY_GENERIC_CLASS> c) {
 #if KEYS_PRIMITIVE
-		this(ITERATORS.unwrap(ITERATORS.AS_KEY_ITERATOR(c.iterator())));
+		this(c.isEmpty() ? _EMPTY_ARRAY : ITERATORS.unwrap( ITERATORS.AS_KEY_ITERATOR(c.iterator())));
 #else
-		this(ITERATORS.unwrap(c.iterator()));
+		this(c.isEmpty() ? _EMPTY_ARRAY : ITERATORS.unwrap(c.iterator()));
 #endif
 	}
 
@@ -80,19 +93,17 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 	 *
 	 * @param c a type-specific collection that will be used to fill the immutable list.
 	 */
-
 	public IMMUTABLE_LIST(final COLLECTION KEY_EXTENDS_GENERIC c) {
-		this(ITERATORS.unwrap(c.iterator()));
+		this(c.isEmpty() ? _EMPTY_ARRAY : ITERATORS.unwrap(c.iterator()));
 	}
 
 	/** Creates a new immutable list and fills it with a given type-specific list.
 	 *
 	 * @param l a type-specific list that will be used to fill the immutable list.
 	 */
-
 	SUPPRESS_WARNINGS_KEY_UNCHECKED
 	public IMMUTABLE_LIST(final LIST KEY_EXTENDS_GENERIC l) {
-		this(KEY_GENERIC_ARRAY_CAST new KEY_TYPE[l.size()]);
+		this(l.isEmpty() ? _EMPTY_ARRAY : KEY_GENERIC_ARRAY_CAST new KEY_TYPE[l.size()]);
 		l.getElements(0, a, 0, l.size());
 	}
 
@@ -102,7 +113,6 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 	 * @param offset the first element to use.
 	 * @param length the number of elements to use.
 	 */
-
 	SUPPRESS_WARNINGS_KEY_UNCHECKED
 	public IMMUTABLE_LIST(final KEY_GENERIC_TYPE a[], final int offset, final int length) {
 		this(KEY_GENERIC_ARRAY_CAST new KEY_TYPE[length]);
@@ -113,10 +123,18 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 	 *
 	 * @param i a type-specific iterator whose returned elements will fill the immutable list.
 	 */
-
 	public IMMUTABLE_LIST(final KEY_ITERATOR KEY_EXTENDS_GENERIC i) {
-		this(ITERATORS.unwrap(i));
+		this(i.hasNext() ? ITERATORS.unwrap(i) : _EMPTY_ARRAY);
 	}
+	
+	/**
+	 * Returns an empty immutable list.
+	 * @return an immutable list (possibly shared) that is empty.
+	 */
+	 SUPPRESS_WARNINGS_KEY_UNCHECKED
+	 public static KEY_GENERIC IMMUTABLE_LIST KEY_GENERIC of() {
+		return EMPTY;
+	 }
 
 	/** Creates an immutable list using a list of elements.
 	 *
@@ -125,10 +143,13 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 	 */
 	SAFE_VARARGS
 	public static KEY_GENERIC IMMUTABLE_LIST KEY_GENERIC of(final KEY_GENERIC_TYPE... init) {
-		return new IMMUTABLE_LIST KEY_GENERIC(init);
+		return init.length == 0 ? of() : new IMMUTABLE_LIST KEY_GENERIC(init);
 	}
 
 	private static KEY_GENERIC IMMUTABLE_LIST KEY_GENERIC convertTrustedToImmutableList(ARRAY_LIST KEY_GENERIC arrayList) {
+		if (arrayList.isEmpty()) {
+			return of();
+		}
 		KEY_GENERIC_TYPE backingArray[] = arrayList.elements();
 		if (arrayList.size() != backingArray.length) {
 			backingArray = Arrays.copyOf(backingArray, arrayList.size());
@@ -832,3 +853,5 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 		throw new UnsupportedOperationException();
 	}
 }
+
+#undef _EMPTY_ARRAY

--- a/drv/ImmutableList.drv
+++ b/drv/ImmutableList.drv
@@ -490,6 +490,28 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 	 */
 	@Override
 	@Deprecated
+	public final boolean addAll(final java.util.Collection<? extends KEY_GENERIC_CLASS> c) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public final boolean addAll(int index, final java.util.Collection<? extends KEY_GENERIC_CLASS> c) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
 	public final KEY_GENERIC_TYPE REMOVE_KEY(final int index) {
 		throw new UnsupportedOperationException();
 	}
@@ -504,6 +526,76 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 	public final boolean REMOVE(final KEY_TYPE k) {
 		throw new UnsupportedOperationException();
 	}
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public final boolean removeAll(final java.util.Collection<?> c) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public final boolean retainAll(final java.util.Collection<?> c) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public final boolean removeIf(final java.util.function.Predicate<? super KEY_GENERIC_CLASS> c) {
+		throw new UnsupportedOperationException();
+	}
+
+#if defined(JDK_PRIMITIVE_PREDICATE)
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public final boolean removeIf(final JDK_PRIMITIVE_PREDICATE c) {
+		throw new UnsupportedOperationException();
+	}
+#endif
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public final void replaceAll(final java.util.function.UnaryOperator<KEY_GENERIC_CLASS> operator) {
+		throw new UnsupportedOperationException();
+	}	
+
+#if defined(JDK_PRIMITIVE_UNARY_OPERATOR)
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public final void replaceAll(final JDK_PRIMITIVE_UNARY_OPERATOR operator) {
+		throw new UnsupportedOperationException();
+	}
+#endif
 
 #if KEYS_PRIMITIVE
 	/**
@@ -558,6 +650,72 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 	@Override
 	@Deprecated
 	public final KEY_GENERIC_CLASS set(final int index, final KEY_GENERIC_CLASS k) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public final boolean addAll(final COLLECTION c) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public final boolean addAll(final LIST c) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public final boolean addAll(final int index, final COLLECTION c) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public final boolean addAll(final int index, final LIST c) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public final boolean removeAll(final COLLECTION c) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public final boolean retainAll(final COLLECTION c) {
 		throw new UnsupportedOperationException();
 	}
 #endif

--- a/drv/ImmutableList.drv
+++ b/drv/ImmutableList.drv
@@ -50,7 +50,7 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 	private static final long serialVersionUID = 0L;
 
 	/** The backing array; all elements are part of this list. */
-	protected transient KEY_GENERIC_TYPE a[];
+	private final KEY_GENERIC_TYPE a[];
 
 	/** Creates a new immutable list using a given array.
 	 *

--- a/drv/ImmutableList.drv
+++ b/drv/ImmutableList.drv
@@ -304,7 +304,7 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 	 */
 	@Override
 	@Deprecated
-	public void add(final int index, final KEY_GENERIC_TYPE k) {
+	public final void add(final int index, final KEY_GENERIC_TYPE k) {
 		throw new UnsupportedOperationException();
 	}
 
@@ -315,7 +315,7 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 	 */
 	@Override
 	@Deprecated
-	public boolean add(final KEY_GENERIC_TYPE k) {
+	public final boolean add(final KEY_GENERIC_TYPE k) {
 		throw new UnsupportedOperationException();
 	}
 
@@ -326,7 +326,7 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 	 */
 	@Override
 	@Deprecated
-	public KEY_GENERIC_TYPE REMOVE_KEY(final int index) {
+	public final KEY_GENERIC_TYPE REMOVE_KEY(final int index) {
 		throw new UnsupportedOperationException();
 	}
 
@@ -337,73 +337,7 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 	 */
 	@Override
 	@Deprecated
-	public boolean REMOVE(final KEY_TYPE k) {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public KEY_GENERIC_TYPE set(final int index, final KEY_GENERIC_TYPE k) {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public void clear() {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public void size(final int size) {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public void removeElements(final int from, final int to) {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public void addElements(final int index, final KEY_GENERIC_TYPE a[], final int offset, final int length) {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public void setElements(final int index, final KEY_GENERIC_TYPE a[], final int offset, final int length) {
+	public final boolean REMOVE(final KEY_TYPE k) {
 		throw new UnsupportedOperationException();
 	}
 
@@ -415,7 +349,7 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 	 */
 	@Override
 	@Deprecated
-	public void sort(final KEY_COMPARATOR KEY_SUPER_GENERIC comp) {
+	public final void add(final int index, final KEY_GENERIC_CLASS k) {
 		throw new UnsupportedOperationException();
 	}
 
@@ -426,7 +360,40 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 	 */
 	@Override
 	@Deprecated
-	public void unstableSort(final KEY_COMPARATOR KEY_SUPER_GENERIC comp) {
+	public final boolean add(final KEY_GENERIC_CLASS k) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public final KEY_GENERIC_CLASS remove(final int index) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public final boolean remove(final Object k) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public final KEY_GENERIC_CLASS set(final int index, final KEY_GENERIC_CLASS k) {
 		throw new UnsupportedOperationException();
 	}
 #endif
@@ -438,7 +405,7 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 	 */
 	@Override
 	@Deprecated
-	public void sort(final java.util.Comparator<? super KEY_GENERIC_CLASS> comparator) {
+	public final KEY_GENERIC_TYPE set(final int index, final KEY_GENERIC_TYPE k) {
 		throw new UnsupportedOperationException();
 	}
 
@@ -449,7 +416,97 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 	 */
 	@Override
 	@Deprecated
-	public void unstableSort(final java.util.Comparator<? super KEY_GENERIC_CLASS> comparator) {
+	public final void clear() {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public final void size(final int size) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public final void removeElements(final int from, final int to) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public final void addElements(final int index, final KEY_GENERIC_TYPE a[], final int offset, final int length) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public final void setElements(final int index, final KEY_GENERIC_TYPE a[], final int offset, final int length) {
+		throw new UnsupportedOperationException();
+	}
+
+#if KEYS_PRIMITIVE
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public final void sort(final KEY_COMPARATOR KEY_SUPER_GENERIC comp) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public final void unstableSort(final KEY_COMPARATOR KEY_SUPER_GENERIC comp) {
+		throw new UnsupportedOperationException();
+	}
+#endif
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public final void sort(final java.util.Comparator<? super KEY_GENERIC_CLASS> comparator) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public final void unstableSort(final java.util.Comparator<? super KEY_GENERIC_CLASS> comparator) {
 		throw new UnsupportedOperationException();
 	}
 }

--- a/drv/ImmutableList.drv
+++ b/drv/ImmutableList.drv
@@ -23,7 +23,6 @@ import java.util.RandomAccess;
 import java.util.NoSuchElementException;
 #if KEYS_REFERENCE
 import java.lang.reflect.Array;
-import java.util.Arrays;
 import java.util.function.Consumer;
 import java.util.stream.Collector;
 #endif

--- a/drv/ImmutableList.drv
+++ b/drv/ImmutableList.drv
@@ -20,6 +20,10 @@ package PACKAGE;
 import java.util.Collection;
 import java.util.RandomAccess;
 import java.util.NoSuchElementException;
+#if KEYS_REFERENCE
+import java.lang.reflect.Array;
+import java.util.Arrays;
+#endif
 
 /** A type-specific array-based immutable list; provides some additional methods that use polymorphism to avoid (un)boxing.
  *
@@ -160,14 +164,39 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 	}
 
 #if KEYS_PRIMITIVE
+	@Override
+	public KEY_TYPE[] TO_KEY_ARRAY() {
+		return a.clone();
+	}
 
 	@Override
 	public KEY_TYPE[] toArray(KEY_TYPE a[]) {
-		if (a == null) a = new KEY_TYPE[this.a.length];
+		if (a == null || a.length < size()) a = new KEY_TYPE[this.a.length];
 		System.arraycopy(this.a, 0, a, 0, a.length);
 		return a;
 	}
+#else // KEYS_REFERENCE
+	@Override
+	public Object[] toArray() {
+		// A subtle part of the spec says the returned array must be Object[] exactly.
+		if (a.getClass().equals(Object[].class)) {
+			return a.clone();
+		}
+		return Arrays.copyOf(a, a.length, Object[].class);
+	}
 
+	SUPPRESS_WARNINGS_KEY_UNCHECKED
+	@Override
+	public KEY_GENERIC KEY_GENERIC_TYPE[] toArray(KEY_GENERIC_TYPE a[]) {
+		if (a == null || a.length < size()) {
+			a = KEY_GENERIC_ARRAY_CAST Array.newInstance(a.getClass().getComponentType(), size());
+		}
+		System.arraycopy(this.a, 0, a, 0, size());
+		if (a.length > size()) {
+			a[size()] = null;
+		}
+		return a;
+	}
 #endif
 
 	@Override
@@ -191,13 +220,11 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 				public int previousIndex() { return pos - 1; }
 				@Override
 				public void add(KEY_GENERIC_TYPE k) {
-					IMMUTABLE_LIST.this.add(pos++, k);
-					last = -1;
+					throw new UnsupportedOperationException();
 				}
 				@Override
 				public void set(KEY_GENERIC_TYPE k) {
-					if (last == -1) throw new IllegalStateException();
-					IMMUTABLE_LIST.this.set(last, k);
+					throw new UnsupportedOperationException();
 				}
 				@Override
 				public void remove() {
@@ -268,5 +295,161 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 	}
 #endif
 
+	// Overridden mutation methods to make unsupported.
 
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public void add(final int index, final KEY_GENERIC_TYPE k) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public boolean add(final KEY_GENERIC_TYPE k) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public KEY_GENERIC_TYPE REMOVE_KEY(final int index) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public boolean REMOVE(final KEY_TYPE k) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public KEY_GENERIC_TYPE set(final int index, final KEY_GENERIC_TYPE k) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public void clear() {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public void size(final int size) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public void removeElements(final int from, final int to) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public void addElements(final int index, final KEY_GENERIC_TYPE a[], final int offset, final int length) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public void setElements(final int index, final KEY_GENERIC_TYPE a[], final int offset, final int length) {
+		throw new UnsupportedOperationException();
+	}
+
+#if KEYS_PRIMITIVE
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public void sort(final KEY_COMPARATOR KEY_SUPER_GENERIC comp) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public void unstableSort(final KEY_COMPARATOR KEY_SUPER_GENERIC comp) {
+		throw new UnsupportedOperationException();
+	}
+#endif
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public void sort(final java.util.Comparator<? super KEY_GENERIC_CLASS> comparator) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Always throws {@link UnsupportedOperationException} as this is an immutable type.
+	 *
+	 * @deprecated
+	 */
+	@Override
+	@Deprecated
+	public void unstableSort(final java.util.Comparator<? super KEY_GENERIC_CLASS> comparator) {
+		throw new UnsupportedOperationException();
+	}
 }

--- a/drv/ImmutableList.drv
+++ b/drv/ImmutableList.drv
@@ -39,8 +39,7 @@ import java.util.stream.Collector;
  * Instances can be built using a variety of methods, but note that constructors using
  * an array will not make a defensive copy.
  *
- * <p>This class implements the bulk methods {@code removeElements()},
- * {@code addElements()} and {@code getElements()} using
+ * <p>This class implements the bulk method {@code getElements()} using
  * high-performance system calls (e.g., {@link
  * System#arraycopy(Object,int,Object,int,int) System.arraycopy()}) instead of
  * expensive loops.

--- a/drv/ImmutableList.drv
+++ b/drv/ImmutableList.drv
@@ -310,7 +310,7 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 				@Override
 				public void forEachRemaining(final METHOD_ARG_KEY_CONSUMER action) {
 					while (pos < a.length) {
-						action.accept(a[last = pos++]);
+						action.accept(a[pos++]);
 					}
 				}
 				@Override
@@ -335,7 +335,6 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 						n = remaining;
 						pos = 0;
 					}
-					last = pos;
 					return n;
 				}
 				@Override
@@ -348,7 +347,6 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 						n = remaining;
 						pos = a.length;
 					}
-					last = pos - 1;
 					return n;
 				}
 			};

--- a/drv/ImmutableList.drv
+++ b/drv/ImmutableList.drv
@@ -305,11 +305,7 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 				}
 				@Override
 				public void remove() {
-					if (last == -1) throw new IllegalStateException();
-					IMMUTABLE_LIST.this.REMOVE_KEY(last);
-					/* If the last operation was a next(), we are removing an element *before* us, and we must decrease pos correspondingly. */
-					if (last < pos) pos--;
-					last = -1;
+					throw new UnsupportedOperationException();
 				}
 				@Override
 				public int back(int n) {

--- a/test/it/unimi/dsi/fastutil/objects/ObjectArrayListTest.java
+++ b/test/it/unimi/dsi/fastutil/objects/ObjectArrayListTest.java
@@ -16,7 +16,10 @@
 
 package it.unimi.dsi.fastutil.objects;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -61,5 +64,40 @@ public class ObjectArrayListTest {
 	public void testOfSingleton() {
 		final ObjectArrayList<String> l = ObjectArrayList.of("0");
 		assertEquals(ObjectArrayList.wrap(new String[] { "0" }), l);
+	}
+
+	@Test
+	public void testToArray() {
+		final ObjectArrayList<String> l = ObjectArrayList.of("0", "1", "2");
+		assertArrayEquals(new Object[] {"0", "1", "2"}, l.toArray());
+	}
+
+	@Test
+	public void testCopyingToArray() {
+		final ObjectArrayList<String> l = ObjectArrayList.of("0", "1", "2");
+		Object[] out = new String[3];
+		Object[] newOut;
+		assertArrayEquals(new Object[] {"0", "1", "2"}, newOut = l.toArray(out));
+		assertSame(out, newOut);
+	}
+
+	@Test
+	public void testCopyingToArrayUndersized() {
+		final ObjectArrayList<String> l = ObjectArrayList.of("0", "1", "2");
+		Object[] out = new String[2];
+		Object[] newOut;
+		assertArrayEquals(new Object[] {"0", "1", "2"}, newOut = l.toArray(out));
+		assertNotSame(out, newOut);
+	}
+
+	@Test
+	public void testCopyingToArrayOversized() {
+		final ObjectArrayList<String> l = ObjectArrayList.of("0", "1", "2");
+		Object[] out = new String[5];
+		out[4] = "I should be replaced with null per spec.";
+		out[5] = "Not me though.";
+		Object[] newOut;
+		assertArrayEquals(new Object[] {"0", "1", "2", null, "Not me though."}, newOut = l.toArray(out));
+		assertSame(out, newOut);
 	}
 }


### PR DESCRIPTION
Harden immutability of ImmutableList.

This closes a few avenues that could have lead to mutating the supposed to be immutable list. In particular, the backing array was non-final and protected (now private and final), and mutations could still happen through the iterator.

Adds the cult-favorite optimization of sharing a single empty instance if given empty arguments to the static constructor.

Also add fast toArray for object based ImmutableList and ArrayList.