### PR TITLE
Make forEachTYPE instead of overloading forEach for primitive collections

### DIFF
--- a/drv/AbstractBigList.drv
+++ b/drv/AbstractBigList.drv
@@ -247,13 +247,13 @@ public abstract class ABSTRACT_BIG_LIST KEY_GENERIC extends ABSTRACT_COLLECTION 
 	 * to using the iterator based loop implementation from the superinterface.
 	 */
 	 @Override
-	 public void forEach(final METHOD_ARG_KEY_CONSUMER action) {
+	 public void FOREACH_KEY(final METHOD_ARG_KEY_CONSUMER action) {
 	 	if (this instanceof java.util.RandomAccess) {
 	 		for (long i = 0, max = size64(); i < max; ++i) {
 	 			action.accept(GET_KEY(i));
 			}
 		} else {
-			super.forEach(action);
+			super.FOREACH_KEY(action);
 		}
 	}
 

--- a/drv/AbstractCollection.drv
+++ b/drv/AbstractCollection.drv
@@ -135,17 +135,6 @@ public abstract class ABSTRACT_COLLECTION KEY_GENERIC extends AbstractCollection
 		return toArray(a);
 	}
 
-#if defined JDK_PRIMITIVE_KEY_CONSUMER && !KEY_WIDENED
-	/** {@inheritDoc}
-	 *
-	 * @apiNote This exists to actually make final what should be considered final in the interface.
-	 */
-	@Override
-	public final void forEach(final KEY_CONSUMER action) {
-		COLLECTION.super.forEach(action);
-	}
-#endif
-
 	@Override
 	public boolean addAll(final COLLECTION c) {
 		boolean retVal = false;

--- a/drv/AbstractIterator.drv
+++ b/drv/AbstractIterator.drv
@@ -24,10 +24,6 @@ package PACKAGE;
  */
 
 @Deprecated
-#if defined JDK_PRIMITIVE_KEY_CONSUMER && !KEY_WIDENED
-public abstract class KEY_ABSTRACT_ITERATOR KEY_GENERIC extends ITERATORS.IteratorDisambiguationMethodFinalShim KEY_GENERIC implements KEY_ITERATOR KEY_GENERIC {
-#else
 public abstract class KEY_ABSTRACT_ITERATOR KEY_GENERIC implements KEY_ITERATOR KEY_GENERIC {
-#endif
 	protected KEY_ABSTRACT_ITERATOR() {}
 }

--- a/drv/AbstractList.drv
+++ b/drv/AbstractList.drv
@@ -245,13 +245,13 @@ public abstract class ABSTRACT_LIST KEY_GENERIC extends ABSTRACT_COLLECTION KEY_
 	 * to using the iterator based loop implementation from the superinterface.
 	 */
 	 @Override
-	 public void forEach(final METHOD_ARG_KEY_CONSUMER action) {
+	 public void FOREACH_KEY(final METHOD_ARG_KEY_CONSUMER action) {
 	 	if (this instanceof java.util.RandomAccess) {
 	 		for (int i = 0, max = size(); i < max; ++i) {
 	 			action.accept(GET_KEY(i));
 			}
 		} else {
-			LIST.super.forEach(action);
+			LIST.super.FOREACH_KEY(action);
 		}
 	}
 

--- a/drv/ArrayList.drv
+++ b/drv/ArrayList.drv
@@ -761,7 +761,7 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 	}
 
 	@Override
-	public void forEach(final METHOD_ARG_KEY_CONSUMER action) {
+	public void FOREACH_KEY(final METHOD_ARG_KEY_CONSUMER action) {
 		for (int i = 0; i < size; ++i) {
 			action.accept(a[i]);
 		}

--- a/drv/ArrayMap.drv
+++ b/drv/ArrayMap.drv
@@ -537,7 +537,7 @@ public class ARRAY_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENERIC 
 
 		@Override
 		SUPPRESS_WARNINGS_KEY_UNCHECKED
-		public void forEach(METHOD_ARG_KEY_CONSUMER action) {
+		public void FOREACH_KEY(METHOD_ARG_KEY_CONSUMER action) {
 			// Hoist containing class field ref into local
 			for (int i = 0, max = size; i < max; ++i) {
 				action.accept(KEY_GENERIC_CAST key[i]);
@@ -653,7 +653,7 @@ public class ARRAY_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENERIC 
 
 		@Override
 		SUPPRESS_WARNINGS_VALUE_UNCHECKED
-		public void forEach(METHOD_ARG_VALUE_CONSUMER action) {
+		public void FOREACH_VALUE(METHOD_ARG_VALUE_CONSUMER action) {
 			// Hoist containing class field ref into local
 			for (int i = 0, max = size; i < max; ++i) {
 				action.accept(VALUE_GENERIC_CAST value[i]);

--- a/drv/BigArrayBigList.drv
+++ b/drv/BigArrayBigList.drv
@@ -741,7 +741,7 @@ public class BIG_ARRAY_BIG_LIST KEY_GENERIC extends ABSTRACT_BIG_LIST KEY_GENERI
 	}
 
 	@Override
-	public void forEach(final METHOD_ARG_KEY_CONSUMER action) {
+	public void FOREACH_KEY(final METHOD_ARG_KEY_CONSUMER action) {
 		for (long i = 0; i < size; ++i) {
 			action.accept(BigArrays.get(a, i));
 		}

--- a/drv/BigListIterators.drv
+++ b/drv/BigListIterators.drv
@@ -308,9 +308,6 @@ public final class BIG_LIST_ITERATORS {
 	 * them (or alternatively, override the abstract methods as final).
 	 */
 	public static abstract class AbstractIndexBasedBigIterator KEY_GENERIC
-#if defined JDK_PRIMITIVE_KEY_CONSUMER && !KEY_WIDENED
-			extends ITERATORS.IteratorDisambiguationMethodFinalShim
-#endif
 			implements KEY_ITERATOR KEY_GENERIC {
 		/** The minimum pos can be, and is the logical start of the "range".
 		 * Usually set to the initialPos unless it is a ListIterator, in which case it can vary.

--- a/drv/Collections.drv
+++ b/drv/Collections.drv
@@ -131,7 +131,7 @@ public final class COLLECTIONS {
 		public KEY_TYPE[] TO_KEY_ARRAY(KEY_TYPE[] a) { return a; }
 
 		@Override
-		public void forEach(final METHOD_ARG_KEY_CONSUMER action) { }
+		public void FOREACH_KEY(final METHOD_ARG_KEY_CONSUMER action) { }
 
 		@Override
 		public boolean containsAll(final COLLECTION c) { return c.isEmpty(); }
@@ -280,7 +280,7 @@ public final class COLLECTIONS {
 		public java.util.stream.Stream <KEY_GENERIC_CLASS> parallelStream() { return collection.parallelStream(); }
 
 		@Override
-		public void forEach(final METHOD_ARG_KEY_CONSUMER action) { synchronized(sync) { collection.forEach(action); } }
+		public void FOREACH_KEY(final METHOD_ARG_KEY_CONSUMER action) { synchronized(sync) { collection.FOREACH_KEY(action); } }
 
 		@Override
 		public boolean addAll(final Collection<? extends KEY_GENERIC_CLASS> c) { synchronized(sync) { return collection.addAll(c); } }
@@ -389,7 +389,7 @@ public final class COLLECTIONS {
 		public Object[] toArray() { return collection.toArray(); }
 
 		@Override
-		public void forEach(final METHOD_ARG_KEY_CONSUMER action) { collection.forEach(action); }
+		public void FOREACH_KEY(final METHOD_ARG_KEY_CONSUMER action) { collection.FOREACH_KEY(action); }
 
 		@Override
 		public boolean containsAll(Collection<?> c) { return collection.containsAll(c); }

--- a/drv/ImmutableList.drv
+++ b/drv/ImmutableList.drv
@@ -243,7 +243,7 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 	}
 
 	@Override
-	public void forEach(final METHOD_ARG_KEY_CONSUMER action) {
+	public void FOREACH_KEY(final METHOD_ARG_KEY_CONSUMER action) {
 		for (int i = 0; i < a.length; ++i) {
 			action.accept(a[i]);
 		}

--- a/drv/Iterable.drv
+++ b/drv/Iterable.drv
@@ -191,31 +191,7 @@ public interface KEY_ITERABLE KEY_GENERIC extends Iterable<KEY_GENERIC_CLASS> {
 		iterator().forEachRemaining(action);
 	}
 
-#if defined JDK_PRIMITIVE_KEY_CONSUMER
-#if !KEY_WIDENED
-	// Because our primitive Consumer interface extends both the JDK's primitive
-	// and object Consumer interfaces, calling this method with it would be ambiguous.
-	// This overload exists to pass it to the proper primitive overload.
-	/**
-	 * Performs the given action for each element of this type-specific {@link java.lang.Iterable}
-	 * until all elements have been processed or the action throws an exception.
-	 *
-	 * <p><b>WARNING:</b> Overriding this is almost always a mistake, as this
-	 * overload only exists to disambiguate. Instead override the {@code forEach()} overload
-	 * that uses the JDK's primitive consumer type (e.g. {@link java.util.function.IntConsumer}).
-	 * <br>If Java supported final default methods, this would be one, but sadly it does not.
-	 * <p>If you checked and are overriding the version with {@code java.util.function.XConsumer}, and
-	 * still see this warning, then your IDE is incorrectly conflating this method with the proper
-	 * method to override, and you can safely ignore this message.
-	 *
-	 * @param action the action to be performed for each element.
-	 * @see java.lang.Iterable#forEach(java.util.function.Consumer)
-	 * @since 8.5.0
-	 */
-	default void FOREACH_KEY(final KEY_CONSUMER action) {
-		FOREACH_KEY((JDK_PRIMITIVE_KEY_CONSUMER) action);
-	}
-#else
+#if defined JDK_PRIMITIVE_KEY_CONSUMER && KEY_WIDENED 
 	/**
 	 * Performs the given action for each element of this type-specific {@link java.lang.Iterable},
 	 * performing widening primitive casts, until all elements have been processed or the action
@@ -227,17 +203,15 @@ public interface KEY_ITERABLE KEY_GENERIC extends Iterable<KEY_GENERIC_CLASS> {
 	 * @deprecated This method performs a widening primitive cast for each element, when a type-specific
 	 *   consumer could avoid this. This is inconsistent with how the primitive {@code Iterator} class is defined.
 	 *   This method has been redefined to be implemented in terms of the type-specific overload
-	 *   (e.g. {@code forEach(ShortConsumer)} for {@code short}s) and now that method should be used or overridden
+	 *   (e.g. {@code forEachShort(ShortConsumer)} for {@code short}s) and now that method should be used or overridden
 	 *   instead of this one. This method now only remains for backwards compatibility purposes.
 	 */
 	@Deprecated
-	default void FOREACH_KEY(final JDK_PRIMITIVE_KEY_CONSUMER action) {
+	default void forEach(final JDK_PRIMITIVE_KEY_CONSUMER action) {
 		Objects.requireNonNull(action);
 		FOREACH_KEY(action instanceof KEY_CONSUMER ? (KEY_CONSUMER)action : (KEY_CONSUMER)action::accept);
 	}
 #endif
-#endif
-
 
 	/** {@inheritDoc}
 	 * @deprecated Please use the corresponding type-specific method instead. */

--- a/drv/Iterable.drv
+++ b/drv/Iterable.drv
@@ -186,7 +186,7 @@ public interface KEY_ITERABLE KEY_GENERIC extends Iterable<KEY_GENERIC_CLASS> {
 	 * @see java.lang.Iterable#forEach(java.util.function.Consumer)
 	 * @since 8.0.0
 	 */
-	default void forEach(final METHOD_ARG_KEY_CONSUMER action) {
+	default void FOREACH_KEY(final METHOD_ARG_KEY_CONSUMER action) {
 		Objects.requireNonNull(action);
 		iterator().forEachRemaining(action);
 	}
@@ -212,8 +212,8 @@ public interface KEY_ITERABLE KEY_GENERIC extends Iterable<KEY_GENERIC_CLASS> {
 	 * @see java.lang.Iterable#forEach(java.util.function.Consumer)
 	 * @since 8.5.0
 	 */
-	default void forEach(final KEY_CONSUMER action) {
-		forEach((JDK_PRIMITIVE_KEY_CONSUMER) action);
+	default void FOREACH_KEY(final KEY_CONSUMER action) {
+		FOREACH_KEY((JDK_PRIMITIVE_KEY_CONSUMER) action);
 	}
 #else
 	/**
@@ -231,9 +231,9 @@ public interface KEY_ITERABLE KEY_GENERIC extends Iterable<KEY_GENERIC_CLASS> {
 	 *   instead of this one. This method now only remains for backwards compatibility purposes.
 	 */
 	@Deprecated
-	default void forEach(final JDK_PRIMITIVE_KEY_CONSUMER action) {
+	default void FOREACH_KEY(final JDK_PRIMITIVE_KEY_CONSUMER action) {
 		Objects.requireNonNull(action);
-		forEach(action instanceof KEY_CONSUMER ? (KEY_CONSUMER)action : (KEY_CONSUMER)action::accept);
+		FOREACH_KEY(action instanceof KEY_CONSUMER ? (KEY_CONSUMER)action : (KEY_CONSUMER)action::accept);
 	}
 #endif
 #endif
@@ -247,7 +247,7 @@ public interface KEY_ITERABLE KEY_GENERIC extends Iterable<KEY_GENERIC_CLASS> {
 		Objects.requireNonNull(action);
 		// The instanceof and cast is required for performance. Without it, calls routed through this
 		// overload using a primitive consumer would go through the slow lambda.
-		forEach(action instanceof METHOD_ARG_KEY_CONSUMER ? (METHOD_ARG_KEY_CONSUMER)action : (KEY_CONSUMER) action::accept);
+		FOREACH_KEY(action instanceof METHOD_ARG_KEY_CONSUMER ? (METHOD_ARG_KEY_CONSUMER)action : (KEY_CONSUMER) action::accept);
 	}
 #endif
 

--- a/drv/Lists.drv
+++ b/drv/Lists.drv
@@ -361,7 +361,7 @@ public final class LISTS {
 #if KEYS_PRIMITIVE
 
 		@Override
-		public void forEach(final METHOD_ARG_KEY_CONSUMER action) {	action.accept(element); }
+		public void FOREACH_KEY(final METHOD_ARG_KEY_CONSUMER action) {	action.accept(element); }
 
 		@Override
 		public boolean addAll(LIST c) { throw new UnsupportedOperationException(); }

--- a/drv/OpenHashBigSet.drv
+++ b/drv/OpenHashBigSet.drv
@@ -804,7 +804,7 @@ public class OPEN_HASH_BIG_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC impl
 	}
 
 	@Override
-	public void forEach(final METHOD_ARG_KEY_CONSUMER action) {
+	public void FOREACH_KEY(final METHOD_ARG_KEY_CONSUMER action) {
 		if (containsNull) {
 			action.accept(KEY_NULL);
 		}

--- a/drv/OpenHashMap.drv
+++ b/drv/OpenHashMap.drv
@@ -2388,7 +2388,7 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 
 		/** {@inheritDoc} */
 		@Override
-		public void forEach(final METHOD_ARG_KEY_CONSUMER consumer) {
+		public void FOREACH_KEY(final METHOD_ARG_KEY_CONSUMER consumer) {
 			if (containsNullKey) consumer.accept(key[n]);
 			for(int pos = n; pos-- != 0;) {
 				final KEY_GENERIC_TYPE k = key[pos];
@@ -2536,7 +2536,7 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 
 				/** {@inheritDoc} */
 				@Override
-				public void forEach(final METHOD_ARG_VALUE_CONSUMER consumer) {
+				public void FOREACH_VALUE(final METHOD_ARG_VALUE_CONSUMER consumer) {
 					if (containsNullKey) consumer.accept(value[n]);
 					for(int pos = n; pos-- != 0;)
 						if (! KEY_IS_NULL(key[pos])) consumer.accept(value[pos]);

--- a/drv/OpenHashSet.drv
+++ b/drv/OpenHashSet.drv
@@ -1526,7 +1526,7 @@ public class OPEN_HASH_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implemen
 	}
 
 	@Override
-	public void forEach(final METHOD_ARG_KEY_CONSUMER action) {
+	public void FOREACH_KEY(final METHOD_ARG_KEY_CONSUMER action) {
 		int curr;
 		int next = first;
 		while (next != -1) {
@@ -1794,7 +1794,7 @@ public class OPEN_HASH_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implemen
 	}
 
 	@Override
-	public void forEach(final METHOD_ARG_KEY_CONSUMER action) {
+	public void FOREACH_KEY(final METHOD_ARG_KEY_CONSUMER action) {
 		if (containsNull) {
 			action.accept(key[n]);
 		}

--- a/drv/Sets.drv
+++ b/drv/Sets.drv
@@ -141,7 +141,7 @@ public final class SETS {
 #if KEYS_PRIMITIVE
 
 		@Override
-		public void forEach(final METHOD_ARG_KEY_CONSUMER action) {	action.accept(element); }
+		public void FOREACH_KEY(final METHOD_ARG_KEY_CONSUMER action) {	action.accept(element); }
 
 		@Override
 		public boolean addAll(final COLLECTION c) { throw new UnsupportedOperationException(); }

--- a/gencsource.sh
+++ b/gencsource.sh
@@ -591,6 +591,7 @@ fi)\
 "#define PREV_KEY previous${TYPE_STD[$k]}\n"\
 "#define NEXT_KEY_WIDENED next${TYPE_STD[$wk]}\n"\
 "#define PREV_KEY_WIDENED previous${TYPE_STD[$wk]}\n"\
+"#define FOREACH_KEY forEach${TYPE_STD[$k]}\n"\
 "#define KEY_WIDENED_ITERATOR_METHOD ${TYPE_LC[$wk]}Iterator\n"\
 "#define KEY_WIDENED_SPLITERATOR_METHOD ${TYPE_LC[$wk]}Spliterator\n"\
 "#define KEY_WIDENED_STREAM_METHOD ${TYPE_LC[$wk]}Stream\n"\

--- a/gencsource.sh
+++ b/gencsource.sh
@@ -591,7 +591,6 @@ fi)\
 "#define PREV_KEY previous${TYPE_STD[$k]}\n"\
 "#define NEXT_KEY_WIDENED next${TYPE_STD[$wk]}\n"\
 "#define PREV_KEY_WIDENED previous${TYPE_STD[$wk]}\n"\
-"#define FOREACH_KEY forEach${TYPE_STD[$k]}\n"\
 "#define KEY_WIDENED_ITERATOR_METHOD ${TYPE_LC[$wk]}Iterator\n"\
 "#define KEY_WIDENED_SPLITERATOR_METHOD ${TYPE_LC[$wk]}Spliterator\n"\
 "#define KEY_WIDENED_STREAM_METHOD ${TYPE_LC[$wk]}Stream\n"\
@@ -632,9 +631,11 @@ fi)\
 "#if KEYS_REFERENCE\n"\
 "#define MAP_TO_KEY map\n"\
 "#define MAP_TO_KEY_WIDENED map\n"\
+"#define FOREACH_KEY forEach\n"\
 "#else\n"\
 "#define MAP_TO_KEY mapTo${TYPE_CAP2[$k]}\n"\
 "#define MAP_TO_KEY_WIDENED mapTo${TYPE_CAP2[$wk]}\n"\
+"#define FOREACH_KEY forEach${TYPE_STD[$k]}\n"\
 "#endif\n"\
 \
 \
@@ -653,6 +654,11 @@ fi)\
 "#define PAIR_RIGHT right${TYPE_STD[$v]}\n"\
 "#define PAIR_SECOND second${TYPE_STD[$v]}\n"\
 "#define PAIR_VALUE value${TYPE_STD[$v]}\n"\
+"#if VALUES_REFERENCE\n"\
+"#define FOREACH_VALUE forEach\n"\
+"#else\n"\
+"#define FOREACH_VALUE forEach${TYPE_STD[$v]}\n"\
+"#endif\n"\
 \
 \
 "/* Methods (keys/values) */\n"\

--- a/test/it/unimi/dsi/fastutil/ints/Int2IntMapGenericTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/Int2IntMapGenericTest.java
@@ -706,7 +706,7 @@ public abstract class Int2IntMapGenericTest<M extends Int2IntMap> {
 			m.put(i, i);
 		}
 		final IntOpenHashSet s = new IntOpenHashSet();
-		m.keySet().forEach((java.util.function.IntConsumer) s::add);
+		m.keySet().forEachInt((java.util.function.IntConsumer)s::add);
 		assertEquals(s, m.keySet());
 	}
 
@@ -1258,7 +1258,7 @@ public abstract class Int2IntMapGenericTest<M extends Int2IntMap> {
 			m.put(i, i);
 		}
 		final IntOpenHashSet s = new IntOpenHashSet();
-		m.values().forEach((java.util.function.IntConsumer) s::add);
+		m.values().forEachInt((java.util.function.IntConsumer)s::add);
 		assertEquals(s, new IntOpenHashSet(m.values()));
 	}
 

--- a/test/it/unimi/dsi/fastutil/ints/Int2ObjectMapGenericTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/Int2ObjectMapGenericTest.java
@@ -665,7 +665,7 @@ public abstract class Int2ObjectMapGenericTest<M extends Int2ObjectMap<Integer>>
 			m.put(i, Integer.valueOf(i));
 		}
 		final IntOpenHashSet s = new IntOpenHashSet();
-		m.keySet().forEach((java.util.function.IntConsumer) s::add);
+		m.keySet().forEachInt((java.util.function.IntConsumer)s::add);
 		assertEquals(s, m.keySet());
 	}
 

--- a/test/it/unimi/dsi/fastutil/ints/IntArrayListTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntArrayListTest.java
@@ -307,6 +307,14 @@ public class IntArrayListTest {
 	}
 
 	@Test
+	public void testForEach() {
+		final IntArrayList baseList = IntArrayList.of(0, 1, 2, 3, 72, 5, 6);
+		int[] m = {1};
+		baseList.forEachInt(i -> m[0] += i);
+		assertEquals(baseList.intStream().sum(), m[0]);
+	}
+
+	@Test
 	public void testLegacyMainMethodTests() throws Exception {
 		MainRunner.callMainIfExists(IntArrayList.class, "test", /*num=*/"500", /*seed=*/"939384");
 	}


### PR DESCRIPTION
Rename the forEach(TYPEConsumer) methods to forEachTYPE(TYPEConsumer) for primitive TYPEs.

This solves an ambiguity when calling forEach with a lambda requiring casting the lambda to solve.
By happenstance it wasn't an issue for int, long, and double collections due to Fastutil's consumer being both an object and primitive consumer, solving the ambiguity. However, it was an issue for byte, short, char, and float collections.

This also means we can remove the messy "don't override this" disambiguation overrides that int, long, and double Iterables had, and cleans up all the cruft associated with it.

Note this only fixes it for type specific `Iterable`s, not for the `Spliterator`s. However, as Spliterators are rarely used "raw", this isn't as big of an issue. Perhaps can be a future cleanup.