### PR TITLE
Add some @apiNotes to places they should have been.

### DIFF
--- a/drv/BigList.drv
+++ b/drv/BigList.drv
@@ -27,7 +27,7 @@ import it.unimi.dsi.fastutil.Size64;
 
 /** A type-specific {@link BigList}; provides some additional methods that use polymorphism to avoid (un)boxing.
  *
- * <p>Additionally, this interface strengthens {@link #iterator()}, {@link #listIterator()},
+ * Additionally, this interface strengthens {@link #iterator()}, {@link #listIterator()},
  * {@link #listIterator(long)} and {@link #subList(long,long)}.
  *
  * <p>Besides polymorphic methods, this interfaces specifies methods to copy into an array or remove contiguous

--- a/drv/IndirectPriorityQueue.drv
+++ b/drv/IndirectPriorityQueue.drv
@@ -28,7 +28,7 @@ public interface INDIRECT_PRIORITY_QUEUE extends IndirectPriorityQueue<KEY_CLASS
 
 	/** Returns the type-specific comparator associated with this queue.
 	 *
-	 * <p>Note that this specification strengthens the one given in {@link IndirectPriorityQueue}.
+	 * @apiNote Note that this specification strengthens the one given in {@link IndirectPriorityQueue}.
 	 *
 	 * @return the comparator associated with this queue.
 	 * @see IndirectPriorityQueue#comparator()

--- a/drv/Iterable.drv
+++ b/drv/Iterable.drv
@@ -59,7 +59,7 @@ public interface KEY_ITERABLE KEY_GENERIC extends Iterable<KEY_GENERIC_CLASS> {
 
 	/** Returns a type-specific iterator.
 	 *
-	 * <p>Note that this specification strengthens the one given in {@link Iterable#iterator()}.
+	 * @apiNote Note that this specification strengthens the one given in {@link Iterable#iterator()}.
 	 *
 	 * @return a type-specific iterator.
 	 * @see Iterable#iterator()
@@ -117,7 +117,7 @@ public interface KEY_ITERABLE KEY_GENERIC extends Iterable<KEY_GENERIC_CLASS> {
 
 	/** Returns a type-specific spliterator on the elements of this iterable.
 	 *
-	 * <p>Note that this specification strengthens the one given in
+	 * @apiNote Note that this specification strengthens the one given in
 	 * {@link java.lang.Iterable#spliterator()}.
 	 *
 	 * @return a type-specific spliterator on the elements of this iterable.

--- a/drv/List.drv
+++ b/drv/List.drv
@@ -513,6 +513,8 @@ public interface LIST KEY_GENERIC extends List<KEY_GENERIC_CLASS>, COLLECTION KE
 
 	/** Sorts this list using a sort assured to be stable.
 	 *
+	 * <p>Pass {@code null} to sort using natural ordering.
+	 *
 	 * <p>Unless a subclass specifies otherwise, the results of the method if the list is
 	 * concurrently modified during the sort are unspecified.
 	 *
@@ -539,6 +541,8 @@ public interface LIST KEY_GENERIC extends List<KEY_GENERIC_CLASS>, COLLECTION KE
 	/** Sorts this list using a sort not assured to be stable.
 	 * This differs from {@link List#sort(java.util.Comparator)} in that the results are
 	 * not assured to be stable, but may be a bit faster.
+	 *
+	 * <p>Pass {@code null} to sort using natural ordering.
 	 *
 	 * <p>Unless a subclass specifies otherwise, the results of the method if the list is
 	 * concurrently modified during the sort are unspecified.

--- a/drv/Map.drv
+++ b/drv/Map.drv
@@ -150,7 +150,7 @@ public interface MAP KEY_VALUE_GENERIC extends FUNCTION KEY_VALUE_GENERIC, Map<K
 
 #if KEYS_PRIMITIVE || VALUES_PRIMITIVE
 	/** Returns a set view of the mappings contained in this map.
-	 *  <p>Note that this specification strengthens the one given in {@link Map#entrySet()}.
+	 *  @apiNote Note that this specification strengthens the one given in {@link Map#entrySet()}.
 	 *
 	 * @return a set view of the mappings contained in this map.
 	 * @see Map#entrySet()
@@ -164,7 +164,7 @@ public interface MAP KEY_VALUE_GENERIC extends FUNCTION KEY_VALUE_GENERIC, Map<K
 	}
 #else
 	/** Returns a set view of the mappings contained in this map.
-	 *  <p>Note that this specification strengthens the one given in {@link Map#entrySet()}.
+	 *  @apiNote Note that this specification strengthens the one given in {@link Map#entrySet()}.
 	 *
 	 * @return a set view of the mappings contained in this map.
 	 * @see Map#entrySet()
@@ -221,7 +221,7 @@ public interface MAP KEY_VALUE_GENERIC extends FUNCTION KEY_VALUE_GENERIC, Map<K
 	}
 
 	/** {@inheritDoc}
-	 * <p>Note that this specification strengthens the one given in {@link Map#keySet()}.
+	 * @apiNote Note that this specification strengthens the one given in {@link Map#keySet()}.
 	 * @return a set view of the keys contained in this map.
 	 * @see Map#keySet()
 	 */
@@ -230,7 +230,7 @@ public interface MAP KEY_VALUE_GENERIC extends FUNCTION KEY_VALUE_GENERIC, Map<K
 	SET KEY_GENERIC keySet();
 
 	/** {@inheritDoc}
-	 *  <p>Note that this specification strengthens the one given in {@link Map#values()}.
+	 * @apiNote Note that this specification strengthens the one given in {@link Map#values()}.
 	 * @return a set view of the values contained in this map.
 	 * @see Map#values()
 	 */

--- a/drv/PriorityQueue.drv
+++ b/drv/PriorityQueue.drv
@@ -62,7 +62,7 @@ public interface PRIORITY_QUEUE extends PriorityQueue<KEY_CLASS> {
 
 	/** Returns the comparator associated with this priority queue, or null if it uses its elements' natural ordering.
 	 *
-	 * <p>Note that this specification strengthens the one given in {@link PriorityQueue#comparator()}.
+	 * @apiNote Note that this specification strengthens the one given in {@link PriorityQueue#comparator()}.
 	 * @see PriorityQueue#comparator()
 	 * @return the comparator associated with this priority queue.
 	 */

--- a/drv/Set.drv
+++ b/drv/Set.drv
@@ -43,7 +43,7 @@ public interface SET KEY_GENERIC extends COLLECTION KEY_GENERIC, Set<KEY_GENERIC
 	/**
 	 * {@inheritDoc}
 	 *
-	 * <p>This specification strengthens the one given in
+	 * @apiNote This specification strengthens the one given in
 	 * {@link java.util.Collection#spliterator()}, which was already
 	 * strengthened in the corresponding type-specific class,
 	 * but was weakened by the fact that this interface extends {@link Set}.
@@ -61,7 +61,7 @@ public interface SET KEY_GENERIC extends COLLECTION KEY_GENERIC, Set<KEY_GENERIC
 #if KEYS_PRIMITIVE
 	/** Removes an element from this set.
 	 *
-	 * <p>Note that the corresponding method of a type-specific collection is {@code rem()}.
+	 * @apiNote Note that the corresponding method of a type-specific collection is {@code rem()}.
 	 * This unfortunate situation is caused by the clash
 	 * with the similarly named index-based method in the {@link java.util.List} interface.
 	 *

--- a/drv/SortedMap.drv
+++ b/drv/SortedMap.drv
@@ -44,7 +44,7 @@ public interface SORTED_MAP KEY_VALUE_GENERIC extends MAP KEY_VALUE_GENERIC, Sor
 
 	/** Returns a view of the portion of this sorted map whose keys range from {@code fromKey}, inclusive, to {@code toKey}, exclusive.
 	 *
-	 * <p>Note that this specification strengthens the one given in {@link SortedMap#subMap(Object,Object)}.
+	 * @apiNote Note that this specification strengthens the one given in {@link SortedMap#subMap(Object,Object)}.
 	 *
 	 * @see SortedMap#subMap(Object,Object)
 	 */
@@ -55,7 +55,7 @@ public interface SORTED_MAP KEY_VALUE_GENERIC extends MAP KEY_VALUE_GENERIC, Sor
 
 	/** Returns a view of the portion of this sorted map whose keys are strictly less than {@code toKey}.
 	 *
-	 * <p>Note that this specification strengthens the one given in {@link SortedMap#headMap(Object)}.
+	 * @apiNote Note that this specification strengthens the one given in {@link SortedMap#headMap(Object)}.
 	 *
 	 * @see SortedMap#headMap(Object)
 	 */
@@ -66,7 +66,7 @@ public interface SORTED_MAP KEY_VALUE_GENERIC extends MAP KEY_VALUE_GENERIC, Sor
 
 	/** Returns a view of the portion of this sorted map whose keys are greater than or equal to {@code fromKey}.
 	 *
-	 * <p>Note that this specification strengthens the one given in {@link SortedMap#tailMap(Object)}.
+	 * @apiNote Note that this specification strengthens the one given in {@link SortedMap#tailMap(Object)}.
 	 *
 	 * @see SortedMap#tailMap(Object)
 	 */
@@ -88,7 +88,7 @@ public interface SORTED_MAP KEY_VALUE_GENERIC extends MAP KEY_VALUE_GENERIC, Sor
 	KEY_GENERIC_TYPE LAST_KEY();
 
 	/** {@inheritDoc}
-	 * <p>Note that this specification strengthens the one given in {@link SortedMap#subMap(Object,Object)}.
+	 * @apiNote Note that this specification strengthens the one given in {@link SortedMap#subMap(Object,Object)}.
 	 * @deprecated Please use the corresponding type-specific method instead.
 	 */
 	@Deprecated
@@ -98,7 +98,7 @@ public interface SORTED_MAP KEY_VALUE_GENERIC extends MAP KEY_VALUE_GENERIC, Sor
 	}
 
 	/** {@inheritDoc}
-	 * <p>Note that this specification strengthens the one given in {@link SortedMap#headMap(Object)}.
+	 * @apiNote Note that this specification strengthens the one given in {@link SortedMap#headMap(Object)}.
 	 * @deprecated Please use the corresponding type-specific method instead.
 	 */
 	@Deprecated
@@ -108,7 +108,7 @@ public interface SORTED_MAP KEY_VALUE_GENERIC extends MAP KEY_VALUE_GENERIC, Sor
 	}
 
 	/** {@inheritDoc}
-	 * <p>Note that this specification strengthens the one given in {@link SortedMap#tailMap(Object)}.
+	 * @apiNote Note that this specification strengthens the one given in {@link SortedMap#tailMap(Object)}.
 	 * @deprecated Please use the corresponding type-specific method instead.
 	 */
 	@Deprecated
@@ -163,7 +163,8 @@ public interface SORTED_MAP KEY_VALUE_GENERIC extends MAP KEY_VALUE_GENERIC, Sor
 
 #if KEYS_PRIMITIVE || VALUES_PRIMITIVE
 	/** Returns a sorted-set view of the mappings contained in this map.
-	 *  <p>Note that this specification strengthens the one given in the
+	 * 
+	 * @apiNoteNote that this specification strengthens the one given in the
 	 *  corresponding type-specific unsorted map.
 	 *
 	 * @return a sorted-set view of the mappings contained in this map.
@@ -179,7 +180,8 @@ public interface SORTED_MAP KEY_VALUE_GENERIC extends MAP KEY_VALUE_GENERIC, Sor
 	}
 #else
 	/** Returns a sorted-set view of the mappings contained in this map.
-	 *  <p>Note that this specification strengthens the one given in the
+	 *
+	 * @apiNote Note that this specification strengthens the one given in the
 	 *  corresponding type-specific unsorted map.
 	 *
 	 * @return a sorted-set view of the mappings contained in this map.
@@ -194,7 +196,8 @@ public interface SORTED_MAP KEY_VALUE_GENERIC extends MAP KEY_VALUE_GENERIC, Sor
 #endif
 
 	/** Returns a type-specific sorted-set view of the mappings contained in this map.
-	 * <p>Note that this specification strengthens the one given in the
+	 * 
+	 * @apiNote Note that this specification strengthens the one given in the
 	 * corresponding type-specific unsorted map.
 	 *
 	 * @return a type-specific sorted-set view of the mappings contained in this map.
@@ -205,7 +208,8 @@ public interface SORTED_MAP KEY_VALUE_GENERIC extends MAP KEY_VALUE_GENERIC, Sor
 	ObjectSortedSet<MAP.Entry KEY_VALUE_GENERIC> ENTRYSET();
 
 	/** Returns a type-specific sorted-set view of the keys contained in this map.
-	 *  <p>Note that this specification strengthens the one given in the
+	 * 
+	 * @apiNote Note that this specification strengthens the one given in the
 	 *  corresponding type-specific unsorted map.
 	 *
 	 * @return a sorted-set view of the keys contained in this map.
@@ -216,7 +220,8 @@ public interface SORTED_MAP KEY_VALUE_GENERIC extends MAP KEY_VALUE_GENERIC, Sor
 	SORTED_SET KEY_GENERIC keySet();
 
 	/** Returns a type-specific set view of the values contained in this map.
-	 * <p>Note that this specification strengthens the one given in {@link Map#values()},
+	 * 
+	 * @apiNote Note that this specification strengthens the one given in {@link Map#values()},
 	 * which was already strengthened in the corresponding type-specific class,
 	 * but was weakened by the fact that this interface extends {@link SortedMap}.
 	 *
@@ -229,7 +234,7 @@ public interface SORTED_MAP KEY_VALUE_GENERIC extends MAP KEY_VALUE_GENERIC, Sor
 
 	/** Returns the comparator associated with this sorted set, or null if it uses its keys' natural ordering.
 	 *
-	 *  <p>Note that this specification strengthens the one given in {@link SortedMap#comparator()}.
+	 *  @apiNote Note that this specification strengthens the one given in {@link SortedMap#comparator()}.
 	 *
 	 * @see SortedMap#comparator()
 	 */

--- a/drv/SortedSet.drv
+++ b/drv/SortedSet.drv
@@ -67,7 +67,7 @@ public interface SORTED_SET KEY_GENERIC extends SET KEY_GENERIC, SortedSet<KEY_G
 	 * <p>This method returns a parameterised bidirectional iterator. The iterator
 	 * can be moreover safely cast to a type-specific iterator.
 	 *
-	 * <p>This specification strengthens the one given in the corresponding type-specific
+	 * @apiNote This specification strengthens the one given in the corresponding type-specific
 	 * {@link Collection}.
 	 *
 	 * @return a bidirectional iterator on the element in this set.

--- a/drv/Spliterator.drv
+++ b/drv/Spliterator.drv
@@ -140,7 +140,7 @@ public interface KEY_SPLITERATOR KEY_GENERIC extends Spliterator<KEY_GENERIC_CLA
 	/**
 	  * {@inheritDoc}
 	  *
-	  * <p>Note that this specification strengthens the one given in {@link Spliterator#trySplit()}.
+	  * @apiNote Note that this specification strengthens the one given in {@link Spliterator#trySplit()}.
 	  */
 	@Override
 	KEY_SPLITERATOR KEY_GENERIC trySplit();
@@ -149,7 +149,7 @@ public interface KEY_SPLITERATOR KEY_GENERIC extends Spliterator<KEY_GENERIC_CLA
 	/**
 	  * {@inheritDoc}
 	  *
-	  * <p>Note that this specification strengthens the one given in {@link Spliterator#getComparator()}.
+	  * @apiNote Note that this specification strengthens the one given in {@link Spliterator#getComparator()}.
 	  */
 	@Override
 	default KEY_COMPARATOR KEY_SUPER_GENERIC getComparator() {


### PR DESCRIPTION
Also, one unrelated change to List.sort it wouldn't always mention that `null` comparator means natural order for the Object based Lists.