### PR TITLE
Fix concat'ed spliterators reporting SORTED or DISTINCT when not safe

### DIFF
--- a/drv/Spliterators.drv
+++ b/drv/Spliterators.drv
@@ -1170,6 +1170,11 @@ public final class SPLITERATORS {
 				current &= a[curOffset++].characteristics();
 				--curLength;
 			}
+			if (length > 1) {
+				// Neither SORTED nor DISTINCT "combine". Two combined spliterators with these characteristics may not have it.
+				// Example, {1, 2, 3} and {1, 4, 5}, both SORTED and DISTINCT, concat to {1, 2, 3, 1, 4, 5}, which isn't.
+				current &= ~(Spliterator.SORTED | Spliterator.DISTINCT); 
+			}
 			return current == ~0 ? EMPTY_CHARACTERISTICS : current;
 		}
 

--- a/drv/Spliterators.drv
+++ b/drv/Spliterators.drv
@@ -1129,6 +1129,10 @@ public final class SPLITERATORS {
 
 	private static class SpliteratorConcatenator KEY_GENERIC implements KEY_SPLITERATOR KEY_GENERIC {
 		private static final int EMPTY_CHARACTERISTICS = Spliterator.SIZED | Spliterator.SUBSIZED;
+		// Neither SORTED nor DISTINCT "combine". Two combined spliterators with these characteristics may not have it.
+		// Example, {1, 2} and {1, 3}, both SORTED and DISTINCT, concat to {1, 2, 1, 3}, which isn't.
+		private static final int CHARACTERISTICS_NOT_SUPPORTED_WHILE_MULTIPLE = Spliterator.SORTED | Spliterator.DISTINCT;
+			
 		final KEY_SPLITERATOR KEY_EXTENDS_GENERIC a[];
 		// Unlike the other classes in this file, length represents remaining, NOT the high mark for offset.
 		int offset, length;
@@ -1161,25 +1165,26 @@ public final class SPLITERATORS {
 			return result;
 		}
 
-		/** Compute the intersection of all contained spliterators' characteristics */
+		/** Compute the intersection of all contained spliterators' characteristics. */
 		private int computeCharacteristics() {
+			if (length <= 0) {
+				return EMPTY_CHARACTERISTICS;
+			}
 			int current = ~0;
 			int curLength = length;
 			int curOffset = offset;
+			if (curLength > 1) {
+				current &= ~CHARACTERISTICS_NOT_SUPPORTED_WHILE_MULTIPLE; 
+			}
 			while (curLength > 0) {
 				current &= a[curOffset++].characteristics();
 				--curLength;
 			}
-			if (length > 1) {
-				// Neither SORTED nor DISTINCT "combine". Two combined spliterators with these characteristics may not have it.
-				// Example, {1, 2, 3} and {1, 4, 5}, both SORTED and DISTINCT, concat to {1, 2, 3, 1, 4, 5}, which isn't.
-				current &= ~(Spliterator.SORTED | Spliterator.DISTINCT); 
-			}
-			return current == ~0 ? EMPTY_CHARACTERISTICS : current;
+			return current;
 		}
 
 		private void advanceNextSpliterator() {
-			if (length == 0) {
+			if (length <= 0) {
 				throw new AssertionError("advanceNextSpliterator() called with none remaining");
 			}
 			++offset;
@@ -1238,6 +1243,14 @@ public final class SPLITERATORS {
 		@Override
 		public int characteristics() {
 			return characteristics;
+		}
+
+		@Override
+		public KEY_COMPARATOR getComparator() {
+			if (length == 1 && ((characteristics & Spliterator.SORTED) != 0) ) {
+				return a[offset].getComparator();
+			}
+			throw new IllegalStateException();
 		}
 
 		@Override

--- a/drv/Spliterators.drv
+++ b/drv/Spliterators.drv
@@ -1245,10 +1245,15 @@ public final class SPLITERATORS {
 			return characteristics;
 		}
 
+		SUPPRESS_WARNINGS_KEY_UNCHECKED
 		@Override
-		public KEY_COMPARATOR getComparator() {
+		public KEY_COMPARATOR KEY_SUPER_GENERIC getComparator() {
 			if (length == 1 && ((characteristics & Spliterator.SORTED) != 0) ) {
+#if KEYS_REFERENCE
+				return (KEY_COMPARATOR KEY_SUPER_GENERIC) a[offset].getComparator();
+#else
 				return a[offset].getComparator();
+#endif
 			}
 			throw new IllegalStateException();
 		}

--- a/test/it/unimi/dsi/fastutil/ints/IntSpliteratorsTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntSpliteratorsTest.java
@@ -3,6 +3,7 @@ package it.unimi.dsi.fastutil.ints;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
 
 import java.util.Spliterator;
 import java.util.stream.IntStream;
@@ -193,6 +194,8 @@ public class IntSpliteratorsTest {
 		assertTrue((concat.characteristics() & Spliterator.SORTED) != 0);
 		assertTrue((concat.characteristics() & Spliterator.DISTINCT) != 0);
 		assertTrue((concat.characteristics() & Spliterator.SIZED) != 0);
+		// Null for natural ordering, as opposed to IllegalStateException thrown for not being sorted.
+		assertNull(concat.getComparator());
 	}
 
 	@Test

--- a/test/it/unimi/dsi/fastutil/ints/IntSpliteratorsTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntSpliteratorsTest.java
@@ -2,6 +2,8 @@ package it.unimi.dsi.fastutil.ints;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import java.util.Spliterator;
 import java.util.stream.IntStream;
@@ -163,6 +165,24 @@ public class IntSpliteratorsTest {
 		final IntStream concatStream = StreamSupport.intStream(concatSpliterator, useSplits.booleanValue());
 		final int[] actualConcat = concatStream.toArray();
 		assertArrayEquals(expectedAfterSkipping, actualConcat);
+	}
+	
+	@Test
+	public void testConcatSpliteratorNotSortedOrDistinctPreserved() {
+		IntSortedSet s1 = new IntRBTreeSet(new int[] {1, 2, 3});
+		IntSortedSet s2 = new IntRBTreeSet(new int[] {1, 3, 4});
+		IntSpliterator split1 = s1.spliterator();
+		IntSpliterator split2 = s2.spliterator();
+		assertTrue((split1.characteristics() & Spliterator.SORTED) != 0);
+		assertTrue((split2.characteristics() & Spliterator.SORTED) != 0);
+		assertTrue((split1.characteristics() & Spliterator.DISTINCT) != 0);
+		assertTrue((split2.characteristics() & Spliterator.DISTINCT) != 0);
+		assertTrue((split1.characteristics() & Spliterator.SIZED) != 0);
+		assertTrue((split2.characteristics() & Spliterator.SIZED) != 0);
+		IntSpliterator concat = IntSpliterators.concat(split1, split2);
+		assertTrue((concat.characteristics() & Spliterator.SORTED) == 0);
+		assertTrue((concat.characteristics() & Spliterator.DISTINCT) == 0);
+		assertTrue((concat.characteristics() & Spliterator.SIZED) != 0);
 	}
 
 	@Test

--- a/test/it/unimi/dsi/fastutil/ints/IntSpliteratorsTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntSpliteratorsTest.java
@@ -182,6 +182,17 @@ public class IntSpliteratorsTest {
 		IntSpliterator concat = IntSpliterators.concat(split1, split2);
 		assertTrue((concat.characteristics() & Spliterator.SORTED) == 0);
 		assertTrue((concat.characteristics() & Spliterator.DISTINCT) == 0);
+		// SIZED is preserved though.
+		assertTrue((concat.characteristics() & Spliterator.SIZED) != 0);
+	}
+	
+	@Test
+	public void testConcatSpliteratorSortedAndDistinctPreservedIfOnlyOne() {
+		IntSortedSet s1 = new IntRBTreeSet(new int[] {1, 2, 3});
+		IntSpliterator split1 = s1.spliterator();
+		IntSpliterator concat = IntSpliterators.concat(split1);
+		assertTrue((concat.characteristics() & Spliterator.SORTED) != 0);
+		assertTrue((concat.characteristics() & Spliterator.DISTINCT) != 0);
 		assertTrue((concat.characteristics() & Spliterator.SIZED) != 0);
 	}
 

--- a/test/it/unimi/dsi/fastutil/ints/IntSpliteratorsTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntSpliteratorsTest.java
@@ -3,7 +3,6 @@ package it.unimi.dsi.fastutil.ints;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
 
 import java.util.Spliterator;
 import java.util.stream.IntStream;


### PR DESCRIPTION
Fixes https://github.com/vigna/fastutil/issues/190

Given the niche use of Spliterators.concat, I would be fine with this going into a 8.5.1 and not hold up the 8.5.0 release for it.