### PR TITLE
Make the email a little cleaner in @author tags.

### DIFF
--- a/drv/BigSpliterators.drv
+++ b/drv/BigSpliterators.drv
@@ -27,7 +27,7 @@ import java.util.function.Consumer;
  * Since the {@link java.util.Spliterator} interface already natively works in long indexes, most of the
  * utility methods reside in the regular {@code Spliterators} class.
  *
- * @author C. Sean Young &lt;csyoung@google.com&gt;
+ * @author C. Sean Young (csyoung@google.com)
  *
  * @since 8.5.0
  */

--- a/drv/Spliterator.drv
+++ b/drv/Spliterator.drv
@@ -24,7 +24,7 @@ import java.util.function.Consumer;
 /** A type-specific {@link Spliterator}; provides an additional methods to avoid (un)boxing, and
  * the possibility to skip elements.
  *
- * @author C. Sean Young &lt;csyoung@google.com&gt;
+ * @author C. Sean Young (csyoung@google.com)
  * @see Spliterator
  * @since 8.5.0
  */

--- a/drv/Spliterators.drv
+++ b/drv/Spliterators.drv
@@ -29,7 +29,7 @@ import WIDENED_PACKAGE.WIDENED_SPLITERATORS;
 
 /** A class providing static methods and objects that do useful things with type-specific spliterators.
  *
- * @author C. Sean Young &lt;csyoung@google.com&gt;
+ * @author C. Sean Young (csyoung@google.com)
  * @see java.util.Spliterators
  * @since 8.5.0
  */


### PR DESCRIPTION
It was hard to read escaped angle brackets.

Purely vanity I know, but it really did look ugly in source even though it looked fine in the HTML files.