### PR TITLE
Deprecate the fact that shorted functors extend widened ones.

### DIFF
--- a/drv/Consumer.drv
+++ b/drv/Consumer.drv
@@ -20,13 +20,36 @@ package PACKAGE;
 import java.util.Objects;
 import java.util.function.Consumer;
 
+#if KEY_CLASS_Float
+/** A type-specific {@link Consumer}; provides methods to consume a primitive type both as object
+ * and as primitive.
+ *
+ * <p><b>WARNING</b>, the fact that this interface extends {@link java.util.function.DoubleConsumer} should
+ * be considered deprecated. It will be removed as a superinterface in a future release.
+ * Using this as a {@code DoubleConsumer} results in checked narrowing casts.
+ *
+ * @see Consumer
+ * @since 8.0.0
+ */
+#elif KEY_WIDENED
+/** A type-specific {@link Consumer}; provides methods to consume a primitive type both as object
+ * and as primitive.
+ *
+ * <p><b>WARNING</b>, the fact that this interface extends {@link java.util.function.IntConsumer} should
+ * be considered deprecated. It will be removed as a superinterface in a future release.
+ * Using this as a {@code IntConsumer} results in checked narrowing casts.
+ *
+ * @see Consumer
+ * @since 8.0.0
+ */
+#else
 /** A type-specific {@link Consumer}; provides methods to consume a primitive type both as object
  * and as primitive.
  *
  * @see Consumer
  * @since 8.0.0
  */
-
+#endif
 @FunctionalInterface
 #ifdef JDK_PRIMITIVE_KEY_CONSUMER
 public interface KEY_CONSUMER KEY_GENERIC extends Consumer<KEY_GENERIC_CLASS>, JDK_PRIMITIVE_KEY_CONSUMER {

--- a/drv/Predicate.drv
+++ b/drv/Predicate.drv
@@ -19,14 +19,36 @@ package PACKAGE;
 
 import java.util.Objects;
 import java.util.function.Predicate;
-
+#if KEY_CLASS_Float
+/** A type-specific {@link Predicate}; provides methods to test a primitive type both as object
+ * and as primitive.
+ *
+ * <p><b>WARNING</b>, the fact that this interface extends {@link java.util.function.DoublePredicate} should
+ * be considered deprecated. It will be removed as a superinterface in a future release.
+ * Using this as a {@code DoublePredicate} results in checked narrowing casts.
+ *
+ * @see Predicate
+ * @since 8.5.0
+ */
+#elif KEY_WIDENED
+/** A type-specific {@link Predicate}; provides methods to test a primitive type both as object
+ * and as primitive.
+ *
+ * <p><b>WARNING</b>, the fact that this interface extends {@link java.util.function.IntPredicate} should
+ * be considered deprecated. It will be removed as a superinterface in a future release.
+ * Using this as a {@code IntPredicate} results in checked narrowing casts.
+ *
+ * @see Predicate
+ * @since 8.5.0
+ */
+#else
 /** A type-specific {@link Predicate}; provides methods to test a primitive type both as object
  * and as primitive.
  *
  * @see Predicate
  * @since 8.5.0
  */
-
+#endif
 @FunctionalInterface
 #ifdef JDK_PRIMITIVE_PREDICATE
 public interface KEY_PREDICATE KEY_GENERIC extends Predicate<KEY_GENERIC_CLASS>, JDK_PRIMITIVE_PREDICATE {


### PR DESCRIPTION
So deprecate the fact that, for example, ByteConsumer extends java.util.function.IntConsumer.

This fact has lead to some need some unfortunate extra overloads to avoid ambiguity.
These overloads were already marked deprecated, so when we remove the widened
superinterface we should also remove these methods.

Example of a deprecated method that should be co-removed is
ByteIterable.forEach(java.util.function.IntConsumer).