### PR TITLE
Fix removeIf ambiguity

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,16 @@
 
 - New immutable array-based lists and associated List.of() methods.
 
+- Type specific versions of Predicate have been added.
+  Methods that take predicates (mainly Collection.removeIf) have been
+  updated to have an overload that takes that.
+  A consequence of this change is that removeIf(IntPredicate) on
+  ByteCollection, ShortCollection, and CharCollection have been deprecated
+  in favor of removeIf(Byte/Short/CharPredicate), which does not do widening casts.
+  If you have an implementation of ByteCollection, ShortCollection, or CharCollection
+  that implements removeIf(IntPredicate), you should update it to instead override
+  removeIf(Byte/Short/CharPredicate).
+
 8.4.4
 
 - Renamed andThen/compose methods for type-specific functions

--- a/drv/AbstractCollection.drv
+++ b/drv/AbstractCollection.drv
@@ -146,6 +146,17 @@ public abstract class ABSTRACT_COLLECTION KEY_GENERIC extends AbstractCollection
 	}
 #endif
 
+#if defined JDK_PRIMITIVE_KEY_PREDICATE && !KEY_WIDENED
+	/** {@inheritDoc}
+	 *
+	 * @apiNote This exists to actually make final what should be considered final in the interface.
+	 */
+	@Override
+	public final boolean removeIf(final KEY_PREDICATE filter) {
+		return COLLECTION.super.removeIf(filter);
+	}
+#endif
+
 	@Override
 	public boolean addAll(final COLLECTION c) {
 		boolean retVal = false;

--- a/drv/Collection.drv
+++ b/drv/Collection.drv
@@ -269,16 +269,58 @@ public interface COLLECTION KEY_GENERIC extends Collection<KEY_GENERIC_CLASS>, K
 	 */
 	boolean removeAll(COLLECTION c);
 
-#ifdef JDK_PRIMITIVE_PREDICATE
+#if defined JDK_PRIMITIVE_PREDICATE || KEY_CLASS_Boolean
 	/** {@inheritDoc}
 	 * @deprecated Please use the corresponding type-specific method instead.
 	 */
 	@Deprecated
 	@Override
 	default boolean removeIf(final java.util.function.Predicate<? super KEY_GENERIC_CLASS> filter) {
-		return removeIf((JDK_PRIMITIVE_PREDICATE) key -> filter.test(KEY2OBJ(KEY_NARROWING(key))));
+		return removeIf(
+			filter instanceof METHOD_ARG_PREDICATE ?
+				((METHOD_ARG_PREDICATE) filter) :
+				(METHOD_ARG_PREDICATE) key -> filter.test(KEY2OBJ(KEY_NARROWING(key))));
 	}
 
+#if KEY_WIDENED || KEY_CLASS_Boolean
+#ifdef JDK_PRIMITIVE_PREDICATE
+	/** Remove from this collection all elements which satisfy the given predicate.
+	 *
+	 * @param filter a predicate which returns {@code true} for elements to be
+	 *        removed.
+	 * @see Collection#removeIf(java.util.function.Predicate)
+	 * @return {@code true} if any elements were removed.
+	 * @deprecated Please use the corresponding type-specific method instead. This method
+	 *   performs a widening primitive cast for each element, when a type-specific consumer
+	 *   could avoid this.
+	 */
+	@Deprecated
+	@SuppressWarnings("overloads")
+	default boolean removeIf(final JDK_PRIMITIVE_PREDICATE filter) {
+		return removeIf(filter instanceof KEY_PREDICATE ? (KEY_PREDICATE) filter : (KEY_PREDICATE) filter::test);
+	}
+#endif
+
+	/** Remove from this collection all elements which satisfy the given predicate.
+	 *
+	 * @param filter a predicate which returns {@code true} for elements to be
+	 *        removed.
+	 * @see Collection#removeIf(java.util.function.Predicate)
+	 * @return {@code true} if any elements were removed.
+	 */
+	default boolean removeIf(final KEY_PREDICATE filter) {
+		java.util.Objects.requireNonNull(filter);
+		boolean removed = false;
+		final KEY_ITERATOR each = iterator();
+		while (each.hasNext()) {
+			if (filter.test(each.NEXT_KEY())) {
+				each.remove();
+				removed = true;
+			}
+		}
+		return removed;
+	}
+#else // !KEY_WIDENED
 	/** Remove from this collection all elements which satisfy the given predicate.
 	 *
 	 * @param filter a predicate which returns {@code true} for elements to be
@@ -299,6 +341,30 @@ public interface COLLECTION KEY_GENERIC extends Collection<KEY_GENERIC_CLASS>, K
 		}
 		return removed;
 	}
+	
+	// Because our primitive Predicate interface extends both the JDK's primitive
+	// and object Predicate interfaces, calling this method with it would be ambiguous.
+	// This overload exists to pass it to the proper primitive overload.
+
+	/** Remove from this collection all elements which satisfy the given predicate.
+	 *
+	 * <p><b>WARNING:</b> Overriding this is almost always a mistake, as this
+	 * overload only exists to disambiguate. Instead override the {@code removeIf()} overload
+	 * that uses the JDK's primitive predicate type (e.g. {@link java.util.function.IntPredicate}).
+	 * <br>If Java supported final default methods, this would be one, but sadly it does not.
+	 * <p>If you checked and are overriding the version with {@code java.util.function.XPredicate}, and
+	 * still see this warning, then your IDE is incorrectly conflating this method with the proper
+	 * method to override, and you can safely ignore this message.
+	 *
+	 * @param filter a predicate which returns {@code true} for elements to be
+	 *        removed.
+	 * @see Collection#removeIf(java.util.function.Predicate)
+	 * @return {@code true} if any elements were removed.
+	 */
+	default boolean removeIf(final KEY_PREDICATE filter) {
+		return removeIf((JDK_PRIMITIVE_PREDICATE) filter);
+	}
+#endif
 #endif
 
 	/** Retains in this collection only elements from the given type-specific collection.

--- a/drv/Collections.drv
+++ b/drv/Collections.drv
@@ -110,7 +110,7 @@ public final class COLLECTIONS {
 		@Override
 		public boolean retainAll(final Collection<?> c) { throw new UnsupportedOperationException(); }
 
-#if defined JDK_PRIMITIVE_PREDICATE && KEYS_PRIMITIVE
+#if (defined JDK_PRIMITIVE_PREDICATE || KEY_CLASS_Boolean) && KEYS_PRIMITIVE
 		@Deprecated
 #endif
 		@Override
@@ -145,13 +145,11 @@ public final class COLLECTIONS {
 		@Override
 		public boolean retainAll(final COLLECTION c) { throw new UnsupportedOperationException(); }
 
-#if defined JDK_PRIMITIVE_PREDICATE
 		@Override
-		public boolean removeIf(final JDK_PRIMITIVE_PREDICATE filter) {
+		public boolean removeIf(final METHOD_ARG_PREDICATE filter) {
 			Objects.requireNonNull(filter);
 			return false;
 		}
-#endif
 
 #if defined JDK_PRIMITIVE_ITERATOR && SMALL_TYPES && KEY_WIDENED
 		@Override

--- a/drv/Iterators.drv
+++ b/drv/Iterators.drv
@@ -829,49 +829,55 @@ public final class ITERATORS {
 		if (i instanceof KEY_LIST_ITERATOR) return (KEY_LIST_ITERATOR KEY_GENERIC)i;
 		return new ListIteratorWrapper KEY_GENERIC_DIAMOND(i);
 	}
-
-#ifdef JDK_PRIMITIVE_PREDICATE
-	public static boolean any(final KEY_ITERATOR iterator, final JDK_PRIMITIVE_PREDICATE predicate) {
-#else
-	public static KEY_GENERIC boolean any(final KEY_ITERATOR KEY_GENERIC iterator, final java.util.function.Predicate<? super KEY_GENERIC_CLASS> predicate) {
-#endif
+	
+	public static KEY_GENERIC boolean any(final KEY_ITERATOR KEY_GENERIC iterator, final METHOD_ARG_PREDICATE predicate) {
 		return indexOf(iterator, predicate) != -1;
 	}
-
-#ifdef JDK_PRIMITIVE_PREDICATE
-	public static boolean all(final KEY_ITERATOR iterator, final JDK_PRIMITIVE_PREDICATE predicate) {
-#else
-	public static KEY_GENERIC boolean all(final KEY_ITERATOR KEY_GENERIC iterator, final java.util.function.Predicate<? super KEY_GENERIC_CLASS> predicate) {
+#if defined JDK_PRIMITIVE_PREDICATE && KEY_WIDENED
+	/**
+	 * @deprecated Use the type specific version instead which doesn't perform a widening cast.
+	 */
+	@Deprecated
+	public static KEY_GENERIC boolean any(final KEY_ITERATOR KEY_GENERIC iterator, final JDK_PRIMITIVE_PREDICATE predicate) {
+		return any(iterator, predicate instanceof METHOD_ARG_PREDICATE ? (METHOD_ARG_PREDICATE) predicate : (METHOD_ARG_PREDICATE) predicate::test);
+	}
 #endif
-		Objects.requireNonNull(predicate);
 
+	public static KEY_GENERIC boolean all(final KEY_ITERATOR KEY_GENERIC iterator, final METHOD_ARG_PREDICATE predicate) {
+		Objects.requireNonNull(predicate);
 		do {
 			if (!iterator.hasNext()) return true;
-#if KEY_CLASS_Boolean
-		} while (predicate.test(Boolean.valueOf(iterator.nextBoolean())));
-#else
 		} while (predicate.test(iterator.NEXT_KEY()));
-#endif
 		return false;
 	}
-
-#ifdef JDK_PRIMITIVE_PREDICATE
-	public static int indexOf(final KEY_ITERATOR iterator, final JDK_PRIMITIVE_PREDICATE predicate) {
-#else
-	public static KEY_GENERIC int indexOf(final KEY_ITERATOR KEY_GENERIC iterator, final java.util.function.Predicate<? super KEY_GENERIC_CLASS> predicate) {
+#if defined JDK_PRIMITIVE_PREDICATE && KEY_WIDENED
+	/**
+	 * @deprecated Use the type specific version instead which doesn't perform a widening cast.
+	 */
+	@Deprecated
+	public static KEY_GENERIC boolean all(final KEY_ITERATOR KEY_GENERIC iterator, final JDK_PRIMITIVE_PREDICATE predicate) {
+		return all(iterator, predicate instanceof METHOD_ARG_PREDICATE ? (METHOD_ARG_PREDICATE) predicate : (METHOD_ARG_PREDICATE) predicate::test);
+	}
 #endif
+
+	public static KEY_GENERIC int indexOf(final KEY_ITERATOR KEY_GENERIC iterator, final METHOD_ARG_PREDICATE predicate) {
 		Objects.requireNonNull(predicate);
 
 		for (int i = 0; iterator.hasNext(); ++i) {
-#if KEY_CLASS_Boolean
-			if (predicate.test(Boolean.valueOf(iterator.nextBoolean()))) return i;
-#else
 			if (predicate.test(iterator.NEXT_KEY())) return i;
-#endif
 		}
 
 		return -1;
 	}
+#if defined JDK_PRIMITIVE_PREDICATE && KEY_WIDENED
+	/**
+	 * @deprecated Use the type specific version instead which doesn't perform a widening cast.
+	 */
+	@Deprecated
+	public static KEY_GENERIC int indexOf(final KEY_ITERATOR KEY_GENERIC iterator, final JDK_PRIMITIVE_PREDICATE predicate) {
+		return indexOf(iterator, predicate instanceof METHOD_ARG_PREDICATE ? (METHOD_ARG_PREDICATE) predicate : (METHOD_ARG_PREDICATE) predicate::test);
+	}
+#endif
 
 #if defined JDK_PRIMITIVE_KEY_CONSUMER && !KEY_WIDENED
 	/** Shim to make final the methods that only exist to disambiguate. */

--- a/drv/Lists.drv
+++ b/drv/Lists.drv
@@ -346,7 +346,7 @@ public final class LISTS {
 		@Override
 		public boolean retainAll(final Collection<?> c) { throw new UnsupportedOperationException(); }
 
-#if defined JDK_PRIMITIVE_PREDICATE && KEYS_PRIMITIVE
+#if (defined JDK_PRIMITIVE_PREDICATE || KEY_CLASS_Boolean) && KEYS_PRIMITIVE
 		@Deprecated
 #endif
 		@Override
@@ -388,7 +388,7 @@ public final class LISTS {
 
 #if defined JDK_PRIMITIVE_PREDICATE
 		@Override
-		public boolean removeIf(final JDK_PRIMITIVE_PREDICATE filter) { throw new UnsupportedOperationException(); }
+		public boolean removeIf(final METHOD_ARG_PREDICATE filter) { throw new UnsupportedOperationException(); }
 #endif
 
 #if defined JDK_PRIMITIVE_ITERATOR && SMALL_TYPES && KEY_WIDENED

--- a/drv/Predicate.drv
+++ b/drv/Predicate.drv
@@ -96,6 +96,7 @@ public interface KEY_PREDICATE KEY_GENERIC extends Predicate<KEY_GENERIC_CLASS> 
 		return Predicate.super.and(other);
 	}
 
+	@Override
 	/** {@inheritDoc} */
 	default KEY_PREDICATE negate() {
 		return t -> ! test(t);

--- a/drv/Sets.drv
+++ b/drv/Sets.drv
@@ -137,7 +137,7 @@ public final class SETS {
 		@Override
 		public boolean retainAll(final Collection<?> c) { throw new UnsupportedOperationException(); }
 
-#if defined JDK_PRIMITIVE_PREDICATE && KEYS_PRIMITIVE
+#if (defined JDK_PRIMITIVE_PREDICATE || KEY_CLASS_Boolean) && KEYS_PRIMITIVE
 		@Deprecated
 #endif
 		@Override
@@ -159,7 +159,7 @@ public final class SETS {
 
 #if defined JDK_PRIMITIVE_PREDICATE
 		@Override
-		public boolean removeIf(final JDK_PRIMITIVE_PREDICATE filter) { throw new UnsupportedOperationException(); }
+		public boolean removeIf(final METHOD_ARG_PREDICATE filter) { throw new UnsupportedOperationException(); }
 #endif
 
 #if defined JDK_PRIMITIVE_ITERATOR && SMALL_TYPES && KEY_WIDENED

--- a/gencsource.sh
+++ b/gencsource.sh
@@ -430,14 +430,12 @@ fi)\
 "#define METHOD_ARG_VALUE_CONSUMER JDK_PRIMITIVE_VALUE_CONSUMER\n"\
 "#endif\n"\
 \
-"#if (!defined JDK_PRIMITIVE_PREDICATE || KEYS_REFERENCE) && !KEY_CLASS_Boolean\n"\
-"#define METHOD_ARG_PREDICATE java.util.function.Predicate<? super KEY_GENERIC_CLASS>\n"\
-"#else\n"\
-"#if KEY_WIDENED || KEY_CLASS_Boolean\n"\
-"#define METHOD_ARG_PREDICATE KEY_PREDICATE\n"\
+"#if KEYS_REFERENCE\n"\
+"#define METHOD_ARG_PREDICATE java.util.function.Predicate <? super KEY_GENERIC_CLASS>\n"\
+"#elif !defined JDK_PRIMITIVE_KEY_CONSUMER || KEY_WIDENED || KEY_CLASS_Boolean\n"\
+"#define METHOD_ARG_PREDICATE KEY_PREDICATE KEY_SUPER_GENERIC\n"\
 "#else\n"\
 "#define METHOD_ARG_PREDICATE JDK_PRIMITIVE_PREDICATE\n"\
-"#endif\n"\
 "#endif\n"\
 \
 "#if !defined JDK_PRIMITIVE_UNARY_OPERATOR || KEYS_REFERENCE\n"\

--- a/gencsource.sh
+++ b/gencsource.sh
@@ -438,10 +438,14 @@ fi)\
 "#define METHOD_ARG_VALUE_CONSUMER JDK_PRIMITIVE_VALUE_CONSUMER\n"\
 "#endif\n"\
 \
-"#if !defined JDK_PRIMITIVE_PREDICATE || KEYS_REFERENCE\n"\
+"#if (!defined JDK_PRIMITIVE_PREDICATE || KEYS_REFERENCE) && !KEY_CLASS_Boolean\n"\
 "#define METHOD_ARG_PREDICATE java.util.function.Predicate<? super KEY_GENERIC_CLASS>\n"\
 "#else\n"\
+"#if KEY_WIDENED || KEY_CLASS_Boolean\n"\
+"#define METHOD_ARG_PREDICATE KEY_PREDICATE\n"\
+"#else\n"\
 "#define METHOD_ARG_PREDICATE JDK_PRIMITIVE_PREDICATE\n"\
+"#endif\n"\
 "#endif\n"\
 \
 "#if !defined JDK_PRIMITIVE_UNARY_OPERATOR || KEYS_REFERENCE\n"\

--- a/test/it/unimi/dsi/fastutil/ints/IntArrayListTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntArrayListTest.java
@@ -250,6 +250,13 @@ public class IntArrayListTest {
 	}
 
 	@Test
+	public void testRemoveIf() {
+		final IntArrayList l = IntArrayList.of(1,2,3,4,5,6);
+		l.removeIf(i -> i % 2 == 0);
+		assertEquals(IntArrayList.of(1,3,5), l);
+	}
+
+	@Test
 	public void testOf() {
 		final IntArrayList l = IntArrayList.of(0, 1, 2);
 		assertEquals(IntArrayList.wrap(new int[] { 0, 1, 2 }), l);

--- a/test/it/unimi/dsi/fastutil/objects/ObjectArrayListTest.java
+++ b/test/it/unimi/dsi/fastutil/objects/ObjectArrayListTest.java
@@ -51,6 +51,13 @@ public class ObjectArrayListTest {
 	}
 
 	@Test
+	public void testRemoveIf() {
+		final ObjectArrayList<Integer> l = ObjectArrayList.of(1,2,3,4,5,6);
+		l.removeIf(i -> i % 2 == 0);
+		assertEquals(ObjectArrayList.of(1,3,5), l);
+	}
+
+	@Test
 	public void testOf() {
 		final ObjectArrayList<String> l = ObjectArrayList.of("0", "1", "2");
 		assertEquals(ObjectArrayList.wrap(new String[] { "0", "1", "2" }), l);

--- a/test/it/unimi/dsi/fastutil/shorts/ShortArrayListTest.java
+++ b/test/it/unimi/dsi/fastutil/shorts/ShortArrayListTest.java
@@ -1,0 +1,285 @@
+package it.unimi.dsi.fastutil.shorts;
+
+/*
+ * Copyright (C) 2017-2020 Sebastiano Vigna
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+
+import org.junit.Test;
+
+import it.unimi.dsi.fastutil.MainRunner;
+
+public class ShortArrayListTest {
+
+	@SuppressWarnings("unlikely-arg-type")
+	@Test
+	public void testEmptyListIsDifferentFromEmptySet() {
+		assertFalse(ShortLists.EMPTY_LIST.equals(ShortSets.EMPTY_SET));
+		assertFalse(ShortSets.EMPTY_SET.equals(ShortLists.EMPTY_LIST));
+	}
+
+	@SuppressWarnings("deprecation")
+	@Test
+	public void testNullInContains() {
+		assertFalse(new ShortArrayList().contains(null));
+	}
+	
+	// Here because Java int -> short literal logic annoyingly only handles variable assignment, not method parameters.
+	private static short s(int i) {
+		return it.unimi.dsi.fastutil.SafeMath.safeIntToShort(i);
+	}
+
+	@Test
+	public void testAddUsingIteratorToTheFirstPosition() {
+		final ShortArrayList list = new ShortArrayList();
+		list.add(s(24));
+		final ShortListIterator it = list.listIterator();
+		it.add(s(42));
+		assertTrue(it.hasNext());
+		assertEquals(ShortArrayList.wrap(new short[] { 42, 24 }), list);
+	}
+
+	@Test
+	public void testAddUsingIterator() {
+		final ShortArrayList list = new ShortArrayList();
+		list.add(s(24));
+		list.add(s(42));
+		final ShortListIterator it = list.listIterator(1);
+		it.add(s(86));
+		assertTrue(it.hasNext());
+		assertEquals(ShortArrayList.wrap(new short[] { 24, 86, 42}), list);
+	}
+
+	@Test
+	public void testAddUsingSublistIterator() {
+		final ShortArrayList list = new ShortArrayList();
+		list.add(s(24));
+		list.add(s(42));
+		final ShortList sublist = list.subList(1,2);
+		final ShortListIterator it = sublist.listIterator();
+		it.add(s(86));
+		assertTrue(it.hasNext());
+		assertEquals(ShortArrayList.wrap(new short[] { 86, 42 }), sublist);
+		assertEquals(ShortArrayList.wrap(new short[] { 24, 86, 42 }), list);
+	}
+
+	@Test
+	public void testAddUsingSubSublistIterator() {
+		final ShortArrayList list = new ShortArrayList();
+		list.add(s(24));
+		list.add(s(86));
+		list.add(s(42));
+		final ShortList sublist = list.subList(1,3);
+		assertEquals(ShortArrayList.wrap(new short[] { 86, 42 }), sublist);
+		final ShortList subsublist = sublist.subList(0,1);
+		assertEquals(ShortArrayList.wrap(new short[] { 86 }), subsublist);
+		final ShortListIterator it = subsublist.listIterator();
+		assertTrue(it.hasNext());
+		it.add(s(126));
+		assertTrue(it.hasNext());
+		assertEquals(ShortArrayList.wrap(new short[] { 126, 86 }), subsublist);
+		assertEquals(ShortArrayList.wrap(new short[] { 126, 86, 42 }), sublist);
+		assertEquals(ShortArrayList.wrap(new short[] { 24, 126, 86, 42 }), list);
+	}
+
+	@Test
+	public void testRemoveUsingIterator() {
+		final ShortArrayList list = new ShortArrayList();
+		list.add(s(24));
+		list.add(s(42));
+		final ShortListIterator it = list.listIterator(1);
+		assertEquals(42, it.nextShort());
+		it.remove();
+		assertFalse(it.hasNext());
+		assertEquals(ShortArrayList.wrap(new short[] { 24 }), list);
+	}
+
+	@Test
+	public void testRemoveUsingSublistIterator() {
+		final ShortArrayList list = new ShortArrayList();
+		list.add(s(24));
+		list.add(s(86));
+		list.add(s(42));
+		final ShortList sublist = list.subList(1,3);
+		final ShortListIterator it = sublist.listIterator();
+		assertEquals(86, it.nextShort());
+		it.remove();
+		assertTrue(it.hasNext());
+		assertEquals(ShortArrayList.wrap(new short[] { 42 }), sublist);
+		assertEquals(ShortArrayList.wrap(new short[] { 24, 42 }), list);
+	}
+
+
+	@Test
+	public void testRemoveUsingSubSublistIterator() {
+		final ShortArrayList list = new ShortArrayList();
+		list.add(s(24));
+		list.add(s(126));
+		list.add(s(86));
+		list.add(s(42));
+		final ShortList sublist = list.subList(1,3);
+		assertEquals(ShortArrayList.wrap(new short[] { 126, 86 }), sublist);
+		final ShortList subsublist = sublist.subList(0,1);
+		assertEquals(ShortArrayList.wrap(new short[] { 126 }), subsublist);
+		final ShortListIterator it = subsublist.listIterator();
+		assertTrue(it.hasNext());
+		assertEquals(126, it.nextShort());
+		it.remove();
+		assertFalse(it.hasNext());
+		assertEquals(ShortArrayList.wrap(new short[] { }), subsublist);
+		assertEquals(ShortArrayList.wrap(new short[] { 86 }), sublist);
+		assertEquals(ShortArrayList.wrap(new short[] { 24, 86, 42 }), list);
+	}
+
+	public void testAddAll() {
+		final ShortArrayList l = ShortArrayList.wrap(new short[] { 0, 1 });
+		l.addAll(ShortArrayList.wrap(new short[] { 2, 3 } ));
+		assertEquals(ShortArrayList.wrap(new short[] { 0, 1, 2, 3 }), l);
+		// Test object based lists still work too.
+		l.addAll(java.util.Arrays.asList(s(4), s(5)));
+		assertEquals(ShortArrayList.wrap(new short[] { 0, 1, 2, 3, 4, 5 }), l);
+	}
+
+	@Test
+	public void testAddAllAtIndex() {
+		final ShortArrayList l = ShortArrayList.wrap(new short[] { 0, 3 });
+		l.addAll(1, ShortArrayList.wrap(new short[] { 1, 2 } ));
+		assertEquals(ShortArrayList.wrap(new short[] { 0, 1, 2, 3 }), l);
+		// Test object based lists still work too.
+		l.addAll(2, java.util.Arrays.asList(s(4), s(5)));
+		assertEquals(ShortArrayList.wrap(new short[] { 0, 1, 4, 5, 2, 3 }), l);
+	}
+
+	@Test
+	public void testRemoveAll() {
+		ShortArrayList l = ShortArrayList.wrap(new short[] { 0, 1, 1, 2 });
+		l.removeAll(ShortSets.singleton((short)1));
+		assertEquals(ShortArrayList.wrap(new short[] { 0, 2 }), l);
+
+		l = ShortArrayList.wrap(new short[] { 0, 1, 1, 2 });
+		l.removeAll(Collections.singleton(s(1)));
+		assertEquals(ShortArrayList.wrap(new short[] { 0, 2 }), l);
+	}
+
+	@Test
+	public void testClearSublist() {
+		ShortArrayList l = ShortArrayList.wrap(new short[] { 0, 1, 1, 2 });
+		ShortList sublist = l.subList(1,3);
+		sublist.clear();
+		assertEquals(ShortArrayList.wrap(new short[] { }), sublist);
+		assertEquals(ShortArrayList.wrap(new short[] { 0, 2 }), l);
+	}
+
+	public void testSort() {
+		final ShortArrayList l = ShortArrayList.wrap(new short[] { 4, 2, 1, 3 });
+		l.sort(null);
+		assertEquals(ShortArrayList.wrap(new short[] { 1, 2, 3, 4 }), l);
+	}
+
+	@Test
+	public void testDefaultConstructors() {
+		ShortArrayList l;
+
+		l = new ShortArrayList();
+		for(int i = 0; i < ShortArrayList.DEFAULT_INITIAL_CAPACITY + 2; i++) l.add(s(0));
+
+		l = new ShortArrayList();
+		l.addElements(0, new short[ShortArrayList.DEFAULT_INITIAL_CAPACITY], 0, ShortArrayList.DEFAULT_INITIAL_CAPACITY);
+
+		l = new ShortArrayList();
+		l.addElements(0, new short[2 * ShortArrayList.DEFAULT_INITIAL_CAPACITY], 0, 2 * ShortArrayList.DEFAULT_INITIAL_CAPACITY);
+
+		l = new ShortArrayList(0);
+		for(int i = 0; i < ShortArrayList.DEFAULT_INITIAL_CAPACITY + 2; i++) l.add(s(0));
+
+		l = new ShortArrayList(0);
+		l.addElements(0, new short[ShortArrayList.DEFAULT_INITIAL_CAPACITY], 0, ShortArrayList.DEFAULT_INITIAL_CAPACITY);
+
+		l = new ShortArrayList(0);
+		l.addElements(0, new short[2 * ShortArrayList.DEFAULT_INITIAL_CAPACITY], 0, 2 * ShortArrayList.DEFAULT_INITIAL_CAPACITY);
+
+		l = new ShortArrayList(2 * ShortArrayList.DEFAULT_INITIAL_CAPACITY );
+		for(int i = 0; i < 3 * ShortArrayList.DEFAULT_INITIAL_CAPACITY; i++) l.add(s(0));
+
+		l = new ShortArrayList(2 * ShortArrayList.DEFAULT_INITIAL_CAPACITY );
+		l.addElements(0, new short[3 * ShortArrayList.DEFAULT_INITIAL_CAPACITY]);
+
+		l = new ShortArrayList(2 * ShortArrayList.DEFAULT_INITIAL_CAPACITY );
+		l.addElements(0, new short[3 * ShortArrayList.DEFAULT_INITIAL_CAPACITY]);
+
+		// Test lazy allocation
+		l = new ShortArrayList();
+		l.ensureCapacity(1);
+		assertSame(ShortArrays.DEFAULT_EMPTY_ARRAY, l.elements());
+		l.ensureCapacity(4);
+		assertSame(ShortArrays.DEFAULT_EMPTY_ARRAY, l.elements());
+
+		l = new ShortArrayList();
+		l.ensureCapacity(1000000);
+		assertNotSame(ShortArrays.DEFAULT_EMPTY_ARRAY, l.elements());
+		assertEquals(1000000, l.elements().length);
+
+		l = new ShortArrayList(0);
+		l.ensureCapacity(1);
+		assertNotSame(ShortArrays.DEFAULT_EMPTY_ARRAY, l.elements());
+
+		l = new ShortArrayList(0);
+		l.ensureCapacity(1);
+		assertNotSame(ShortArrays.DEFAULT_EMPTY_ARRAY, l.elements());
+		l.ensureCapacity(1);
+	}
+
+	@Test
+	public void testSizeOnDefaultInstance() {
+		final ShortArrayList l = new ShortArrayList();
+		l.size(100);
+	}
+
+	@Test
+	public void testRemoveIf() {
+		final ShortArrayList l = new ShortArrayList(new short[] {1,2,3,4,5,6});
+		l.removeIf(i -> i % 2 == 0);
+		assertEquals(ShortArrayList.of(s(1),s(3),s(5)), l);
+	}
+
+	@Test
+	public void testOf() {
+		final ShortArrayList l = ShortArrayList.of(s(0), s(1), s(2));
+		assertEquals(ShortArrayList.wrap(new short[] { 0, 1, 2 }), l);
+	}
+
+	public void testOfEmpty() {
+		final ShortArrayList l = ShortArrayList.of();
+		assertTrue(l.isEmpty());
+	}
+
+	@Test
+	public void testOfSingleton() {
+		final ShortArrayList l = ShortArrayList.of(s(0));
+		assertEquals(ShortArrayList.wrap(new short[]{0}), l);
+	}
+
+	@Test
+	public void testLegacyMainMethodTests() throws Exception {
+		MainRunner.callMainIfExists(ShortArrayList.class, "test", /*num=*/"500", /*seed=*/"939384");
+	}
+}


### PR DESCRIPTION
The `removeIf` method had an ambiguity if you tried to use it with lambdas, requiring you to cast to a functor type yourself.

This change fixes it so it chooses a proper primitive Predicate.

It basically applies what was done to `forEach` and `forEachRemaining` to `removeIf`.