### PR TITLE
Don't have List.of(...) make a defensive copy.

### DIFF
--- a/drv/ImmutableList.drv
+++ b/drv/ImmutableList.drv
@@ -131,6 +131,8 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 
 	/** Creates an immutable list using a list of elements.
 	 *
+	 * <p>Note that this method does not perform a defensive copy.
+	 *
 	 * @param init a list of elements that will be used to initialize the list.
 	 * @return a new immutable list containing the given elements.
 	 */

--- a/drv/List.drv
+++ b/drv/List.drv
@@ -402,7 +402,9 @@ public interface LIST KEY_GENERIC extends List<KEY_GENERIC_CLASS>, COLLECTION KE
 		return IMMUTABLE_LIST.of(e0, e1, e2);
 	}
 
-	/** Returns an immutable list with the elements given. 
+	/** Returns an immutable list with the elements given.
+	 *
+	 * <p>Note that this method does not perform a defensive copy.
 	 *
 	 * @param a a list of elements that will be used to initialize the immutable list.
 	 * @return an immutable list containing the elements of {@code a}.
@@ -415,15 +417,11 @@ public interface LIST KEY_GENERIC extends List<KEY_GENERIC_CLASS>, COLLECTION KE
 				return of();
 			case 1:
 				return of(a[0]);
-			case 2:
-				return of(a[0], a[1]);
-			case 3:
-				return of(a[0], a[1], a[2]);
+			// Add cases of 2 and 3 if we ever have special logic for those.
 			default:
 				// fall through
 		}
-		// ArrayList.wrap() and ArrayList.of() will not make a defensive copy if you want that.
-		return IMMUTABLE_LIST.of(KEY_GENERIC_CAST a.clone());
+		return IMMUTABLE_LIST.of(a);
 	}
 
 #if defined(KEY_COMPARATOR) && KEYS_PRIMITIVE


### PR DESCRIPTION
If we don't even do it for ImmutableList.of(...), there is no point in the root List interface to doing it.