### PR TITLE
Simplify conditionals

### DIFF
--- a/drv/ArrayList.drv
+++ b/drv/ArrayList.drv
@@ -1256,7 +1256,7 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 #if KEYS_PRIMITIVE && ! KEY_CLASS_Boolean
 			/* We sum on t. */
 			ns = System.nanoTime();
-#if ! KEYS_INT_LONG_DOUBLE
+#if KEYS_BYTE_CHAR_SHORT_FLOAT
 			// Since the primitive stream has to upcast to a widened primitive, for fairness we will upcast here too
 #endif
 			java.util.stream.Stream<KEY_CLASS> tStream = ((java.util.List<KEY_CLASS>)t).stream();

--- a/drv/Collection.drv
+++ b/drv/Collection.drv
@@ -19,7 +19,7 @@ package PACKAGE;
 
 import java.util.Collection;
 import static it.unimi.dsi.fastutil.Size64.getSizeOf;
-#if KEYS_PRIMITIVE && !KEYS_INT_LONG_DOUBLE && !KEY_CLASS_Boolean
+#if KEYS_BYTE_CHAR_SHORT_FLOAT
 import WIDENED_PACKAGE.KEY_WIDENED_ITERATOR;
 import WIDENED_PACKAGE.KEY_WIDENED_SPLITERATOR;
 #endif
@@ -332,7 +332,7 @@ public interface COLLECTION KEY_GENERIC extends Collection<KEY_GENERIC_CLASS>, K
 	default boolean removeIf(final KEY_PREDICATE filter) {
 		return removeIf((JDK_PRIMITIVE_PREDICATE) filter);
 	}
-#elif !KEY_CLASS_Boolean
+#elif KEYS_BYTE_CHAR_SHORT_FLOAT
 	/** Remove from this collection all elements which satisfy the given predicate.
 	 *
 	 * @param filter a predicate which returns {@code true} for elements to be

--- a/drv/Iterable.drv
+++ b/drv/Iterable.drv
@@ -21,7 +21,7 @@ import java.lang.Iterable;
 #if KEYS_PRIMITIVE
 import java.util.Objects;
 import java.util.function.Consumer;
-#if !KEYS_INT_LONG_DOUBLE && !KEY_CLASS_Boolean
+#if KEYS_BYTE_CHAR_SHORT_FLOAT
 import WIDENED_PACKAGE.KEY_WIDENED_ITERATOR;
 import WIDENED_PACKAGE.WIDENED_ITERATORS;
 import WIDENED_PACKAGE.KEY_WIDENED_SPLITERATOR;
@@ -225,7 +225,7 @@ public interface KEY_ITERABLE KEY_GENERIC extends Iterable<KEY_GENERIC_CLASS> {
 	default void forEach(final KEY_CONSUMER action) {
 		forEach((JDK_PRIMITIVE_KEY_CONSUMER) action);
 	}
-#elif !KEY_CLASS_Boolean
+#elif KEYS_BYTE_CHAR_SHORT_FLOAT
 	/**
 	 * Performs the given action for each element of this type-specific {@link java.lang.Iterable},
 	 * performing widening primitive casts, until all elements have been processed or the action

--- a/drv/Iterator.drv
+++ b/drv/Iterator.drv
@@ -123,7 +123,7 @@ public interface KEY_ITERATOR KEY_GENERIC extends Iterator<KEY_GENERIC_CLASS> {
 		forEachRemaining(action instanceof KEY_CONSUMER ? (KEY_CONSUMER)action : (KEY_CONSUMER)action::accept);
 	}
 #endif
-	
+
 #endif
 
 	/** {@inheritDoc}

--- a/drv/Iterators.drv
+++ b/drv/Iterators.drv
@@ -29,7 +29,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 #if KEYS_PRIMITIVE && ! KEY_CLASS_Boolean
 import java.util.PrimitiveIterator;
-#if ! KEYS_INT_LONG_DOUBLE
+#if KEYS_BYTE_CHAR_SHORT_FLOAT
 import WIDENED_PACKAGE.KEY_WIDENED_ITERATOR;
 import WIDENED_PACKAGE.WIDENED_ITERATORS;
 #endif
@@ -588,8 +588,6 @@ public final class ITERATORS {
 		public KEY_GENERIC_TYPE NEXT_KEY() { return KEY_CLASS2TYPE(i.next()); }
 
 #if KEYS_INT_LONG_DOUBLE
-		// TODO: shouldn't we do the same in the other case (non int/long/double and JDK primitive argument)?
-
 		// This is pretty much the only time overriding this overload is correct; we want to
 		// delegate as an Object consumer, not wrap it as a primitive one.
 		@Override
@@ -646,7 +644,7 @@ public final class ITERATORS {
 	}
 #endif
 
-#if KEYS_PRIMITIVE && ! KEYS_INT_LONG_DOUBLE && ! KEY_CLASS_Boolean
+#if KEYS_BYTE_CHAR_SHORT_FLOAT
 	private static class CheckedPrimitiveIteratorWrapper KEY_GENERIC extends PrimitiveIteratorWrapper {
 		public CheckedPrimitiveIteratorWrapper(JDK_PRIMITIVE_ITERATOR i) {
 			super(i);
@@ -687,7 +685,7 @@ public final class ITERATORS {
 		return new IteratorWrapper KEY_GENERIC_DIAMOND(i);
 	}
 
-#if KEYS_PRIMITIVE && ! KEYS_INT_LONG_DOUBLE && ! KEY_CLASS_Boolean
+#if KEYS_BYTE_CHAR_SHORT_FLOAT
 	/** Wrap a JDK primitive iterator to a type-specific iterator, making checked
 	 * narrowed casts.
 	 *
@@ -707,7 +705,7 @@ public final class ITERATORS {
 	}
 #endif
 
-#if KEYS_PRIMITIVE && ! KEYS_INT_LONG_DOUBLE && ! KEY_CLASS_Boolean
+#if KEYS_BYTE_CHAR_SHORT_FLOAT
 	/** Wrap a JDK primitive iterator to a type-specific iterator, making <em>unchecked</em>
 	 * narrowing casts.
 	 *
@@ -725,7 +723,7 @@ public final class ITERATORS {
 	}
 #endif
 
-#if KEYS_PRIMITIVE && ! KEYS_INT_LONG_DOUBLE && ! KEY_CLASS_Boolean
+#if KEYS_BYTE_CHAR_SHORT_FLOAT
 #if KEY_CLASS_Character
 	/** Wrap a type-specific iterator to a JDK compatible primitive iterator.
 	 *
@@ -841,7 +839,7 @@ public final class ITERATORS {
 	public static KEY_GENERIC boolean any(final KEY_ITERATOR KEY_GENERIC iterator, final METHOD_ARG_PREDICATE predicate) {
 		return indexOf(iterator, predicate) != -1;
 	}
-#if KEYS_PRIMITIVE && ! KEYS_INT_LONG_DOUBLE && ! KEY_CLASS_Boolean
+#if KEYS_BYTE_CHAR_SHORT_FLOAT
 	/**
 	 * @deprecated Use the type specific version instead which doesn't perform a widening cast.
 	 */
@@ -858,7 +856,7 @@ public final class ITERATORS {
 		} while (predicate.test(iterator.NEXT_KEY()));
 		return false;
 	}
-#if KEYS_PRIMITIVE && ! KEYS_INT_LONG_DOUBLE && ! KEY_CLASS_Boolean
+#if KEYS_BYTE_CHAR_SHORT_FLOAT
 	/**
 	 * @deprecated Use the type specific version instead which doesn't perform a widening cast.
 	 */
@@ -877,7 +875,7 @@ public final class ITERATORS {
 
 		return -1;
 	}
-#if KEYS_PRIMITIVE && ! KEYS_INT_LONG_DOUBLE && ! KEY_CLASS_Boolean
+#if KEYS_BYTE_CHAR_SHORT_FLOAT
 	/**
 	 * @deprecated Use the type specific version instead which doesn't perform a widening cast.
 	 */

--- a/drv/Spliterators.drv
+++ b/drv/Spliterators.drv
@@ -453,8 +453,7 @@ public final class SPLITERATORS {
 			this.i = i;
 		}
 
-// TODO: check these overloads
-#if KEYS_BYTE_CHAR_SHORT_FLOAT && 0
+#if KEYS_INT_LONG_DOUBLE
 		// This is pretty much the only time overriding this overload is correct; we want to
 		// delegate as an Object consumer, not wrap it as a primitive one.
 		@Override
@@ -484,8 +483,7 @@ public final class SPLITERATORS {
 			return i.tryAdvance(action);
 		}
 
-// TODO: check these overloads
-#if KEYS_BYTE_CHAR_SHORT_FLOAT && 0
+#if KEYS_INT_LONG_DOUBLE
 		// This is pretty much the only time overriding this overload is correct; we want to
 		// delegate as an Object consumer, not wrap it as a primitive one.
 		@Override


### PR DESCRIPTION
Some more conditional fixups and simplifications, especially taking advantage of the new `KEY_BYTE_CHAR_SHORT_FLOAT` macro.