### PR TITLE
Add identity() to UnaryOperator

### DIFF
--- a/drv/Predicate.drv
+++ b/drv/Predicate.drv
@@ -36,7 +36,7 @@ import java.util.function.Predicate;
 #if ! KEY_CLASS_Boolean
 public interface KEY_PREDICATE KEY_GENERIC extends Predicate<KEY_GENERIC_CLASS>, JDK_PRIMITIVE_PREDICATE {
 #else
-public interface KEY_PREDICATE KEY_GENERIC extends Predicate<KEY_GENERIC_CLASS> {
+public interface KEY_PREDICATE KEY_GENERIC extends Predicate<KEY_GENERIC_CLASS>, KEY_UNARY_OPERATOR {
 #endif
 
 #if ! KEYS_INT_LONG_DOUBLE
@@ -59,6 +59,21 @@ public interface KEY_PREDICATE KEY_GENERIC extends Predicate<KEY_GENERIC_CLASS> 
 	}
 #endif
 
+#if KEY_CLASS_Boolean
+	/**
+	 * Returns a {@code BooleanPredicate} that returns the boolean to be tested unmodified.
+	 * @see java.util.function.UnaryOperator#identity()
+	 */
+	public static KEY_PREDICATE identity() {
+		 return b -> b;
+	}
+
+	/** Returns a {@code BooleanPredicate} that returns the negation of the boolean to be tested. */
+	public static KEY_PREDICATE negation() {
+		 return b -> !b;
+	}
+#endif
+
 #endif
 
 	/** {@inheritDoc}
@@ -68,6 +83,16 @@ public interface KEY_PREDICATE KEY_GENERIC extends Predicate<KEY_GENERIC_CLASS> 
 	default boolean test(final KEY_CLASS t) {
 		return test(t.KEY_VALUE());
 	}
+
+#if KEY_CLASS_Boolean
+	/** Evaluates this predicate on the given input.
+	 *  @see #test(boolean)
+	 */
+	@Override
+	default boolean apply(final KEY_TYPE b) {
+		return test(b);
+	}
+#endif
 
     /**
 	 * Returns a composed type-specific predicate that represents a short-circuiting logical
@@ -135,7 +160,6 @@ public interface KEY_PREDICATE KEY_GENERIC extends Predicate<KEY_GENERIC_CLASS> 
 	default KEY_PREDICATE negate() {
 		return t -> ! test(t);
 	}
-
 
     /**
 	 * Returns a composed type-specific predicate that represents a short-circuiting logical

--- a/drv/Predicate.drv
+++ b/drv/Predicate.drv
@@ -36,7 +36,7 @@ import java.util.function.Predicate;
 #if ! KEY_CLASS_Boolean
 public interface KEY_PREDICATE KEY_GENERIC extends Predicate<KEY_GENERIC_CLASS>, JDK_PRIMITIVE_PREDICATE {
 #else
-public interface KEY_PREDICATE KEY_GENERIC extends Predicate<KEY_GENERIC_CLASS>, KEY_UNARY_OPERATOR {
+public interface KEY_PREDICATE KEY_GENERIC extends Predicate<KEY_GENERIC_CLASS> {
 #endif
 
 #if ! KEYS_INT_LONG_DOUBLE
@@ -65,12 +65,13 @@ public interface KEY_PREDICATE KEY_GENERIC extends Predicate<KEY_GENERIC_CLASS>,
 	 * @see java.util.function.UnaryOperator#identity()
 	 */
 	public static KEY_PREDICATE identity() {
-		 return b -> b;
+		// Java is smart enough to see this lambda is stateless and will return the same instance every time.
+		return b -> b;
 	}
 
 	/** Returns a {@code BooleanPredicate} that returns the negation of the boolean to be tested. */
 	public static KEY_PREDICATE negation() {
-		 return b -> !b;
+		return b -> !b;
 	}
 #endif
 
@@ -83,16 +84,6 @@ public interface KEY_PREDICATE KEY_GENERIC extends Predicate<KEY_GENERIC_CLASS>,
 	default boolean test(final KEY_CLASS t) {
 		return test(t.KEY_VALUE());
 	}
-
-#if KEY_CLASS_Boolean
-	/** Evaluates this predicate on the given input.
-	 *  @see #test(boolean)
-	 */
-	@Override
-	default boolean apply(final KEY_TYPE b) {
-		return test(b);
-	}
-#endif
 
     /**
 	 * Returns a composed type-specific predicate that represents a short-circuiting logical

--- a/drv/UnaryOperator.drv
+++ b/drv/UnaryOperator.drv
@@ -56,6 +56,23 @@ public interface KEY_UNARY_OPERATOR KEY_GENERIC extends UnaryOperator<KEY_GENERI
 	public static KEY_UNARY_OPERATOR negation() {
 		return i -> !i;
 	}
+#elif KEYS_PRIMITIVE && !KEY_CLASS_Character
+	/**
+	 * Returns a {@code UnaryOperator} that always returns the arithmetic negation of the input.
+	 * <p>As with all negation, be wary of unexpected behavior near the minimum value of the data type.
+	 * For example, {@code -Integer.MIN_VALUE} will result in {@link Integer.MIN_VALUE} (still negative),
+	 * as the positive value of {@code Integer.MIN_VALUE} is too big for {@code int}
+	 * (it would be 1 greater then {@link Integer.MAX_VALUE}.
+	 */
+	public static KEY_UNARY_OPERATOR negation() {
+#if KEYS_BYTE_CHAR_SHORT_FLOAT && !KEY_CLASS_Float
+		// Annoyingly, negating a byte (or similar) results in an int.
+		return i -> (KEY_TYPE) -i;
+#else
+		return i -> -i;
+#endif
+	
+	}
 #endif
 
 #if KEYS_INT_LONG_DOUBLE

--- a/drv/UnaryOperator.drv
+++ b/drv/UnaryOperator.drv
@@ -42,6 +42,24 @@ public interface KEY_UNARY_OPERATOR KEY_GENERIC extends UnaryOperator<KEY_GENERI
 	 */
 	KEY_TYPE apply(KEY_TYPE x);
 
+#if !KEY_CLASS_Boolean
+	/** Returns a {@code UnaryOperator} that always returns the input unmodified. */
+	public static KEY_UNARY_OPERATOR identity() {
+		// Java is smart enough to see this lambda is stateless and will return the same instance every time.
+		return i -> i;
+	}
+#else
+	/** Returns a {@code UnaryOperator} that always returns the input unmodified. */
+	public static KEY_UNARY_OPERATOR identity() {
+		return KEY_PREDICATE.identity();
+	}
+
+	/** Returns a {@code UnaryOperator} that always returns the logical negation of the input. */
+	public static KEY_UNARY_OPERATOR negation() {
+		return KEY_PREDICATE.negation();
+	}
+#endif
+
 #if KEYS_INT_LONG_DOUBLE
 	/** {@inheritDoc}
 	 *

--- a/drv/UnaryOperator.drv
+++ b/drv/UnaryOperator.drv
@@ -42,21 +42,19 @@ public interface KEY_UNARY_OPERATOR KEY_GENERIC extends UnaryOperator<KEY_GENERI
 	 */
 	KEY_TYPE apply(KEY_TYPE x);
 
-#if !KEY_CLASS_Boolean
-	/** Returns a {@code UnaryOperator} that always returns the input unmodified. */
+	/**
+	 * Returns a {@code UnaryOperator} that always returns the input unmodified.
+	 * @see java.util.function.UnaryOperator#identity()
+	 */
 	public static KEY_UNARY_OPERATOR identity() {
 		// Java is smart enough to see this lambda is stateless and will return the same instance every time.
 		return i -> i;
 	}
-#else
-	/** Returns a {@code UnaryOperator} that always returns the input unmodified. */
-	public static KEY_UNARY_OPERATOR identity() {
-		return KEY_PREDICATE.identity();
-	}
 
+#if KEY_CLASS_Boolean
 	/** Returns a {@code UnaryOperator} that always returns the logical negation of the input. */
 	public static KEY_UNARY_OPERATOR negation() {
-		return KEY_PREDICATE.negation();
+		return i -> !i;
 	}
 #endif
 


### PR DESCRIPTION
Adds the static method `identity` to UnaryOperator
For numeric primitives, adds `negation`, performing arithmetic negation.
For `BooleanUnaryOperator`, adds `negation`, performing logical negation.

For `BooleanPredicate`, it also adds those methods, as it also takes a boolean and returns a boolean, thus they make sense there too.