### PR TITLE
Warn about preallocation collectors and parallel streams

### DIFF
--- a/drv/ArrayList.drv
+++ b/drv/ArrayList.drv
@@ -382,6 +382,8 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 	 * @apiNote Taking a primitive stream instead returning something like a
 	 * {@link java.util.stream.Collector Collector} is necessary because there is no
 	 * primitive {@code Collector} equivalent in the Java API.
+	 * @implNote The current implementation preallocates the full size for every worker thread when used on parallel streams.
+	 *   This can be quite wasteful, as worker threads other then the first don't usually handle the full stream.
 	 */
 	public static KEY_GENERIC ARRAY_LIST KEY_GENERIC toListWithExpectedSize(JDK_PRIMITIVE_STREAM stream, int expectedSize) {
 		return stream.collect(
@@ -408,7 +410,11 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 		return (Collector) TO_LIST_COLLECTOR;
 	}
 
- 	/** Returns a {@link Collector} that collects a {@code Stream}'s elements into a new ArrayList. */
+ 	/**
+ 	 * Returns a {@link Collector} that collects a {@code Stream}'s elements into a new ArrayList.
+	 * @implNote The current implementation preallocates the full size for every worker thread when used on parallel streams.
+	 *   This can be quite wasteful, as worker threads other then the first don't usually handle the full stream.
+ 	 */
  	public static KEY_GENERIC Collector<KEY_GENERIC_TYPE, ?, ARRAY_LIST KEY_GENERIC> toListWithExpectedSize(int expectedSize) {
  		return Collector.of(
 		() -> new ARRAY_LIST KEY_GENERIC_DIAMOND(expectedSize),

--- a/drv/ImmutableList.drv
+++ b/drv/ImmutableList.drv
@@ -174,6 +174,8 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 	 * @apiNote Taking a primitive stream instead returning something like a
 	 * {@link java.util.stream.Collector Collector} is necessary because there is no
 	 * primitive {@code Collector} equivalent in the Java API.
+	 * @implNote The current implementation preallocates the full size for every worker thread when used on parallel streams.
+	 *   This can be quite wasteful, as worker threads other then the first don't usually handle the full stream.
 	 */
 	public static KEY_GENERIC IMMUTABLE_LIST KEY_GENERIC toListWithExpectedSize(JDK_PRIMITIVE_STREAM stream, int expectedSize) {
 		return convertTrustedToImmutableList(ARRAY_LIST.toListWithExpectedSize(stream, expectedSize));
@@ -192,7 +194,11 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 		return (Collector) TO_LIST_COLLECTOR;
 	}
 
- 	/** Returns a {@link Collector} that collects a {@code Stream}'s elements into a new ImmutableList. */
+ 	/**
+ 	 * Returns a {@link Collector} that collects a {@code Stream}'s elements into a new ImmutableList.
+ 	 * @implNote The current implementation preallocates the full size for every worker thread when used on parallel streams.
+	 *   This can be quite wasteful, as worker threads other then the first don't usually handle the full stream.
+ 	 */
  	public static KEY_GENERIC Collector<KEY_GENERIC_TYPE, ?, IMMUTABLE_LIST KEY_GENERIC> toListWithExpectedSize(int expectedSize) {
  		return Collector.<KEY_GENERIC_TYPE, ARRAY_LIST KEY_GENERIC, IMMUTABLE_LIST KEY_GENERIC>of(
 			() -> new ARRAY_LIST KEY_GENERIC_DIAMOND(expectedSize),

--- a/drv/OpenHashSet.drv
+++ b/drv/OpenHashSet.drv
@@ -676,6 +676,8 @@ public class OPEN_HASH_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implemen
 	 * @apiNote Taking a primitive stream instead returning something like a
 	 * {@link java.util.stream.Collector Collector} is necessary because there is no
 	 * primitive {@code Collector} equivalent in the Java API.
+	 * @implNote The current implementation preallocates the full size for every worker thread when used on parallel streams.
+	 *   This can be quite wasteful, as worker threads other then the first don't usually handle the full stream.
 	 */
 	public static KEY_GENERIC OPEN_HASH_SET KEY_GENERIC toSetWithExpectedSize(JDK_PRIMITIVE_STREAM stream, int expectedSize) {
 		return stream.collect(
@@ -702,7 +704,11 @@ public class OPEN_HASH_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implemen
 		return (Collector) TO_SET_COLLECTOR;
 	}
 
- 	/** Returns a {@link Collector} that collects a {@code Stream}'s elements into a new hash set. */
+ 	/**
+ 	 * Returns a {@link Collector} that collects a {@code Stream}'s elements into a new hash set.
+ 	 * @implNote The current implementation preallocates the full size for every worker thread when used on parallel streams.
+	 *   This can be quite wasteful, as worker threads other then the first don't usually handle the full stream.
+ 	 */
  	public static KEY_GENERIC Collector<KEY_GENERIC_TYPE, ?, OPEN_HASH_SET KEY_GENERIC> toSetWithExpectedSize(int expectedSize) {
  		return Collector.of(
 		() -> new OPEN_HASH_SET KEY_GENERIC(expectedSize),


### PR DESCRIPTION
Per https://github.com/vigna/fastutil/issues/211, the `toXWithExpectedSize` collector methods will preallocate the full size for every worker thread when used on parallel streams.
This is rather wasteful, as most worker threads will not handle the full contents of the stream.

Actually solving this shortcoming may come in future work, but for now we just warn about it in an `@implNote`