### PR TITLE
Minor touchups

### DIFF
--- a/drv/Iterators.drv
+++ b/drv/Iterators.drv
@@ -832,7 +832,7 @@ public final class ITERATORS {
 	 * Returned whether any element satisfies the given predicate.
 	 * Short circuit evaluation is performed; the first {@code true} from the predicate terminates the loop.
 	 */
-	public static KEY_GENERIC boolean any(final KEY_ITERATOR KEY_GENERIC iterator, final METHOD_ARG_PREDICATE predicate) {
+	public static KEY_GENERIC boolean any(final STD_KEY_ITERATOR KEY_GENERIC iterator, final METHOD_ARG_PREDICATE predicate) {
 		return indexOf(iterator, predicate) != -1;
 	}
 #if KEYS_BYTE_CHAR_SHORT_FLOAT
@@ -851,7 +851,7 @@ public final class ITERATORS {
 	  * Returns whether all elements in the given iterator satisfy the given predicate.
 	  * Short circuit evaluation is performed; the first {@code false} from the predicate terminates the loop.
 	  */
-	public static KEY_GENERIC boolean all(final KEY_ITERATOR KEY_GENERIC iterator, final METHOD_ARG_PREDICATE predicate) {
+	public static KEY_GENERIC boolean all(final STD_KEY_ITERATOR KEY_GENERIC iterator, final METHOD_ARG_PREDICATE predicate) {
 		Objects.requireNonNull(predicate);
 		do {
 			if (!iterator.hasNext()) return true;
@@ -877,7 +877,7 @@ public final class ITERATORS {
 	 * {@link java.util.ListIterator ListIterators}. In other words {@link java.util.ListIterator#nextIndex
 	 * ListIterator.nextIndex} is ignored.
 	 */ 
-	public static KEY_GENERIC int indexOf(final KEY_ITERATOR KEY_GENERIC iterator, final METHOD_ARG_PREDICATE predicate) {
+	public static KEY_GENERIC int indexOf(final STD_KEY_ITERATOR KEY_GENERIC iterator, final METHOD_ARG_PREDICATE predicate) {
 		Objects.requireNonNull(predicate);
 
 		for (int i = 0; iterator.hasNext(); ++i) {

--- a/drv/Iterators.drv
+++ b/drv/Iterators.drv
@@ -830,7 +830,7 @@ public final class ITERATORS {
 	
 	/**
 	 * Returned whether any element satisfies the given predicate.
-	 * Short circuit evaluation is performed; the first {@code true} from the prediate terminates the loop.
+	 * Short circuit evaluation is performed; the first {@code true} from the predicate terminates the loop.
 	 */
 	public static KEY_GENERIC boolean any(final KEY_ITERATOR KEY_GENERIC iterator, final METHOD_ARG_PREDICATE predicate) {
 		return indexOf(iterator, predicate) != -1;
@@ -838,7 +838,7 @@ public final class ITERATORS {
 #if KEYS_BYTE_CHAR_SHORT_FLOAT
 	/**
 	 * Returned whether any element satisfies the given predicate.
-	 * Short circuit evaluation is performed; the first {@code true} from the prediate terminates the loop.
+	 * Short circuit evaluation is performed; the first {@code true} from the predicate terminates the loop.
 	 * @deprecated Use the type specific version instead which doesn't perform a widening cast.
 	 */
 	@Deprecated

--- a/drv/Iterators.drv
+++ b/drv/Iterators.drv
@@ -839,9 +839,9 @@ public final class ITERATORS {
 	/**
 	 * Returned whether any element satisfies the given predicate.
 	 * Short circuit evaluation is performed; the first {@code true} from the predicate terminates the loop.
-	 * @deprecated Use the type specific version instead which doesn't perform a widening cast.
+	 * @implNote Unless the argument is type-specific, this method will introduce an intermediary
+	 *   lambda to perform widening casts. Please use the type-specific overload to avoid this overhead.
 	 */
-	@Deprecated
 	public static KEY_GENERIC boolean any(final KEY_ITERATOR KEY_GENERIC iterator, final JDK_PRIMITIVE_PREDICATE predicate) {
 		return any(iterator, predicate instanceof METHOD_ARG_PREDICATE ? (METHOD_ARG_PREDICATE) predicate : (METHOD_ARG_PREDICATE) predicate::test);
 	}
@@ -862,9 +862,9 @@ public final class ITERATORS {
 	/**
 	 * Returns whether all elements in the given iterator satisfy the given predicate.
 	 * Short circuit evaluation is performed; the first {@code false} terminates the loop.
-	 * @deprecated Use the type specific version instead which doesn't perform a widening cast.
+	 * @implNote Unless the argument is type-specific, this method will introduce an intermediary
+	 *   lambda to perform widening casts. Please use the type-specific overload to avoid this overhead.
 	 */
-	@Deprecated
 	public static KEY_GENERIC boolean all(final KEY_ITERATOR KEY_GENERIC iterator, final JDK_PRIMITIVE_PREDICATE predicate) {
 		return all(iterator, predicate instanceof METHOD_ARG_PREDICATE ? (METHOD_ARG_PREDICATE) predicate : (METHOD_ARG_PREDICATE) predicate::test);
 	}
@@ -893,9 +893,9 @@ public final class ITERATORS {
 	 * <p>The next element returned by the iterator always considered element {@code 0}, even for
 	 * {@link java.util.ListIterator ListIterators}. In other words {@link java.util.ListIterator#nextIndex
 	 * ListIterator.nextIndex} is ignored.
-	 * @deprecated Use the type specific version instead which doesn't perform a widening cast.
+	 * @implNote Unless the argument is type-specific, this method will introduce an intermediary
+	 *   lambda to perform widening casts. Please use the type-specific overload to avoid this overhead.
 	 */
-	@Deprecated
 	public static KEY_GENERIC int indexOf(final KEY_ITERATOR KEY_GENERIC iterator, final JDK_PRIMITIVE_PREDICATE predicate) {
 		return indexOf(iterator, predicate instanceof METHOD_ARG_PREDICATE ? (METHOD_ARG_PREDICATE) predicate : (METHOD_ARG_PREDICATE) predicate::test);
 	}

--- a/drv/Iterators.drv
+++ b/drv/Iterators.drv
@@ -828,11 +828,17 @@ public final class ITERATORS {
 		return new ListIteratorWrapper KEY_GENERIC_DIAMOND(i);
 	}
 	
+	/**
+	 * Returned whether any element satisfies the given predicate.
+	 * Short circuit evaluation is performed; the first {@code true} from the prediate terminates the loop.
+	 */
 	public static KEY_GENERIC boolean any(final KEY_ITERATOR KEY_GENERIC iterator, final METHOD_ARG_PREDICATE predicate) {
 		return indexOf(iterator, predicate) != -1;
 	}
 #if KEYS_BYTE_CHAR_SHORT_FLOAT
 	/**
+	 * Returned whether any element satisfies the given predicate.
+	 * Short circuit evaluation is performed; the first {@code true} from the prediate terminates the loop.
 	 * @deprecated Use the type specific version instead which doesn't perform a widening cast.
 	 */
 	@Deprecated
@@ -841,6 +847,10 @@ public final class ITERATORS {
 	}
 #endif
 
+	/**
+	  * Returns whether all elements in the given iterator satisfy the given predicate.
+	  * Short circuit evaluation is performed; the first {@code false} from the predicate terminates the loop.
+	  */
 	public static KEY_GENERIC boolean all(final KEY_ITERATOR KEY_GENERIC iterator, final METHOD_ARG_PREDICATE predicate) {
 		Objects.requireNonNull(predicate);
 		do {
@@ -850,6 +860,8 @@ public final class ITERATORS {
 	}
 #if KEYS_BYTE_CHAR_SHORT_FLOAT
 	/**
+	 * Returns whether all elements in the given iterator satisfy the given predicate.
+	 * Short circuit evaluation is performed; the first {@code false} terminates the loop.
 	 * @deprecated Use the type specific version instead which doesn't perform a widening cast.
 	 */
 	@Deprecated
@@ -858,6 +870,13 @@ public final class ITERATORS {
 	}
 #endif
 
+	/**
+	 * Returns the index of the first element that satisfies the given predicate, or {@code -1} if
+	 * no such element was found.
+	 * <p>The next element returned by the iterator always considered element {@code 0}, even for
+	 * {@link java.util.ListIterator ListIterators}. In other words {@link java.util.ListIterator#nextIndex
+	 * ListIterator.nextIndex} is ignored.
+	 */ 
 	public static KEY_GENERIC int indexOf(final KEY_ITERATOR KEY_GENERIC iterator, final METHOD_ARG_PREDICATE predicate) {
 		Objects.requireNonNull(predicate);
 
@@ -869,6 +888,11 @@ public final class ITERATORS {
 	}
 #if KEYS_BYTE_CHAR_SHORT_FLOAT
 	/**
+ 	 * Returns the index of the first element that satisfies the given predicate, or {@code -1} if
+	 * no such element was found.
+	 * <p>The next element returned by the iterator always considered element {@code 0}, even for
+	 * {@link java.util.ListIterator ListIterators}. In other words {@link java.util.ListIterator#nextIndex
+	 * ListIterator.nextIndex} is ignored.
 	 * @deprecated Use the type specific version instead which doesn't perform a widening cast.
 	 */
 	@Deprecated

--- a/drv/List.drv
+++ b/drv/List.drv
@@ -299,7 +299,7 @@ public interface LIST KEY_GENERIC extends List<KEY_GENERIC_CLASS>, COLLECTION KE
 	 *   lambda to perform widening and narrowing casts. Please use the type-specific overload to avoid this overhead.
 	 */
 	default void replaceAll(final JDK_PRIMITIVE_UNARY_OPERATOR operator) {
-		replaceAll(x -> KEY_NARROWING(operator.JDK_PRIMITIVE_KEY_APPLY(x)));
+		replaceAll(operator instanceof METHOD_ARG_KEY_UNARY_OPERATOR ? (METHOD_ARG_KEY_UNARY_OPERATOR) operator : x -> KEY_NARROWING(operator.JDK_PRIMITIVE_KEY_APPLY(x)));
 	}
 #endif
 

--- a/drv/Spliterators.drv
+++ b/drv/Spliterators.drv
@@ -716,7 +716,12 @@ public final class SPLITERATORS {
 #endif
 
 #ifdef KEYS_PRIMITIVE
-	/** Perform the given {@code action} on each element that matches the given {@code predicate}. */
+	/**
+	 * Perform the given {@code action} on each element that matches the given {@code predicate}.
+	 *
+	 * <p>This is equivalent to {@code java.util.stream.StreamSupport.stream(spliterator).filter(predicate).forEach(action)}
+	 * (substitute the proper primitive stream as needed), except it may perform better (but no potential for parallelism).
+	 */
 	public static void onEachMatching(final KEY_SPLITERATOR KEY_GENERIC spliterator, final METHOD_ARG_PREDICATE predicate, final METHOD_ARG_KEY_CONSUMER action) {
 		Objects.requireNonNull(predicate);
 		Objects.requireNonNull(action);
@@ -728,7 +733,12 @@ public final class SPLITERATORS {
 		});
 	}
 #if KEYS_BYTE_CHAR_SHORT_FLOAT
-	/** Perform the given {@code action} on each element that matches the given {@code predicate}. */
+	/**
+	 * Perform the given {@code action} on each element that matches the given {@code predicate}.
+	 *
+	 * <p>This is equivalent to {@code java.util.stream.StreamSupport.stream(spliterator).filter(predicate).forEach(action)}
+	 * (substitute the proper primitive stream as needed), except it may perform better (but no potential for parallelism).
+	 */
 	public static void onEachMatching(final KEY_SPLITERATOR KEY_GENERIC spliterator, final JDK_PRIMITIVE_PREDICATE predicate, final JDK_PRIMITIVE_KEY_CONSUMER action) {
 		Objects.requireNonNull(predicate);
 		Objects.requireNonNull(action);
@@ -742,7 +752,12 @@ public final class SPLITERATORS {
 	}
 #endif
 #else
-	/** Perform the given {@code action} on each element that matches the given {@code predicate}. */
+	/**
+	 * Perform the given {@code action} on each element that matches the given {@code predicate}.
+	 *
+	 *	<p>This is equivalent to {@code java.util.stream.StreamSupport.stream(spliterator).filter(predicate).forEach(action)}
+	 * (substitute the proper primitive stream as needed), except it may perform better (but no potential for parallelism).
+	 */
 	public static KEY_GENERIC void onEachMatching(final KEY_SPLITERATOR KEY_GENERIC spliterator, final java.util.function.Predicate<? super KEY_GENERIC_CLASS> predicate, final Consumer<? super KEY_GENERIC_CLASS> action) {
 		Objects.requireNonNull(predicate);
 		Objects.requireNonNull(action);

--- a/drv/Spliterators.drv
+++ b/drv/Spliterators.drv
@@ -755,7 +755,7 @@ public final class SPLITERATORS {
 	/**
 	 * Perform the given {@code action} on each element that matches the given {@code predicate}.
 	 *
-	 *	<p>This is equivalent to {@code java.util.stream.StreamSupport.stream(spliterator).filter(predicate).forEach(action)}
+	 * <p>This is equivalent to {@code java.util.stream.StreamSupport.stream(spliterator).filter(predicate).forEach(action)}
 	 * (substitute the proper primitive stream as needed), except it may perform better (but no potential for parallelism).
 	 */
 	public static KEY_GENERIC void onEachMatching(final KEY_SPLITERATOR KEY_GENERIC spliterator, final java.util.function.Predicate<? super KEY_GENERIC_CLASS> predicate, final Consumer<? super KEY_GENERIC_CLASS> action) {

--- a/drv/Spliterators.drv
+++ b/drv/Spliterators.drv
@@ -21,6 +21,9 @@ import java.util.Comparator;
 import java.util.Spliterator;
 import java.util.Objects;
 import java.util.function.Consumer;
+#if KEYS_REFERENCE
+import java.util.function.Predicate;
+#endif
 import it.unimi.dsi.fastutil.SafeMath;
 #if KEYS_BYTE_CHAR_SHORT_FLOAT
 import WIDENED_PACKAGE.KEY_WIDENED_SPLITERATOR;
@@ -715,14 +718,13 @@ public final class SPLITERATORS {
 	public static KEY_WIDENED_SPLITERATOR widen(KEY_SPLITERATOR i) { return WIDENED_SPLITERATORS.wrap(i); }
 #endif
 
-#ifdef KEYS_PRIMITIVE
 	/**
 	 * Perform the given {@code action} on each element that matches the given {@code predicate}.
 	 *
 	 * <p>This is equivalent to {@code java.util.stream.StreamSupport.stream(spliterator).filter(predicate).forEach(action)}
 	 * (substitute the proper primitive stream as needed), except it may perform better (but no potential for parallelism).
 	 */
-	public static void onEachMatching(final KEY_SPLITERATOR KEY_GENERIC spliterator, final METHOD_ARG_PREDICATE predicate, final METHOD_ARG_KEY_CONSUMER action) {
+	public static KEY_GENERIC void onEachMatching(final STD_KEY_SPLITERATOR KEY_GENERIC spliterator, final METHOD_ARG_PREDICATE predicate, final METHOD_ARG_KEY_CONSUMER action) {
 		Objects.requireNonNull(predicate);
 		Objects.requireNonNull(action);
 
@@ -739,7 +741,7 @@ public final class SPLITERATORS {
 	 * <p>This is equivalent to {@code java.util.stream.StreamSupport.stream(spliterator).filter(predicate).forEach(action)}
 	 * (substitute the proper primitive stream as needed), except it may perform better (but no potential for parallelism).
 	 */
-	public static void onEachMatching(final KEY_SPLITERATOR KEY_GENERIC spliterator, final JDK_PRIMITIVE_PREDICATE predicate, final JDK_PRIMITIVE_KEY_CONSUMER action) {
+	public static KEY_GENERIC void onEachMatching(final STD_KEY_SPLITERATOR KEY_GENERIC spliterator, final JDK_PRIMITIVE_PREDICATE predicate, final JDK_PRIMITIVE_KEY_CONSUMER action) {
 		Objects.requireNonNull(predicate);
 		Objects.requireNonNull(action);
 
@@ -747,24 +749,6 @@ public final class SPLITERATORS {
 		spliterator.forEachRemaining((KEY_GENERIC_TYPE value) -> {
 			if (predicate.test(value)) {
 				action.accept(value);
-			}
-		});
-	}
-#endif
-#else
-	/**
-	 * Perform the given {@code action} on each element that matches the given {@code predicate}.
-	 *
-	 * <p>This is equivalent to {@code java.util.stream.StreamSupport.stream(spliterator).filter(predicate).forEach(action)}
-	 * (substitute the proper primitive stream as needed), except it may perform better (but no potential for parallelism).
-	 */
-	public static KEY_GENERIC void onEachMatching(final KEY_SPLITERATOR KEY_GENERIC spliterator, final java.util.function.Predicate<? super KEY_GENERIC_CLASS> predicate, final Consumer<? super KEY_GENERIC_CLASS> action) {
-		Objects.requireNonNull(predicate);
-		Objects.requireNonNull(action);
-
-		spliterator.forEachRemaining((KEY_GENERIC_TYPE value) -> {
-			if (predicate.test(value)) {
-				action.accept(KEY2OBJ(value));
 			}
 		});
 	}

--- a/drv/Spliterators.drv
+++ b/drv/Spliterators.drv
@@ -763,7 +763,7 @@ public final class SPLITERATORS {
 		Objects.requireNonNull(action);
 
 		spliterator.forEachRemaining((KEY_GENERIC_TYPE value) -> {
-			if (predicate.test(value))) {
+			if (predicate.test(value)) {
 				action.accept(KEY2OBJ(value));
 			}
 		});

--- a/drv/Spliterators.drv
+++ b/drv/Spliterators.drv
@@ -715,29 +715,45 @@ public final class SPLITERATORS {
 	public static KEY_WIDENED_SPLITERATOR widen(KEY_SPLITERATOR i) { return WIDENED_SPLITERATORS.wrap(i); }
 #endif
 
-#ifdef JDK_PRIMITIVE_PREDICATE
-	public static void onEachMatching(final KEY_SPLITERATOR KEY_GENERIC spliterator, final JDK_PRIMITIVE_PREDICATE predicate, final METHOD_ARG_KEY_CONSUMER action) {
+#ifdef KEYS_PRIMITIVE
+	/** Perform the given {@code action} on each element that matches the given {@code predicate}. */
+	public static void onEachMatching(final KEY_SPLITERATOR KEY_GENERIC spliterator, final METHOD_ARG_PREDICATE predicate, final METHOD_ARG_KEY_CONSUMER action) {
 		Objects.requireNonNull(predicate);
 		Objects.requireNonNull(action);
 
-		spliterator.forEachRemaining((KEY_CONSUMER KEY_GENERIC)(KEY_GENERIC_TYPE value) -> {
+		spliterator.forEachRemaining((KEY_GENERIC_TYPE value) -> {
 			if (predicate.test(value)) {
 				action.accept(value);
 			}
 		});
+	}
+#if KEYS_BYTE_CHAR_SHORT_FLOAT
+	/** Perform the given {@code action} on each element that matches the given {@code predicate}. */
+	public static void onEachMatching(final KEY_SPLITERATOR KEY_GENERIC spliterator, final JDK_PRIMITIVE_PREDICATE predicate, final JDK_PRIMITIVE_KEY_CONSUMER action) {
+		Objects.requireNonNull(predicate);
+		Objects.requireNonNull(action);
+
+		// No lambda introduction here; this isn't overrideable (static method) and widening casts are implicit. 
+		spliterator.forEachRemaining((KEY_GENERIC_TYPE value) -> {
+			if (predicate.test(value)) {
+				action.accept(value);
+			}
+		});
+	}
+#endif
 #else
+	/** Perform the given {@code action} on each element that matches the given {@code predicate}. */
 	public static KEY_GENERIC void onEachMatching(final KEY_SPLITERATOR KEY_GENERIC spliterator, final java.util.function.Predicate<? super KEY_GENERIC_CLASS> predicate, final Consumer<? super KEY_GENERIC_CLASS> action) {
 		Objects.requireNonNull(predicate);
 		Objects.requireNonNull(action);
 
-		spliterator.forEachRemaining((KEY_CONSUMER KEY_GENERIC)(KEY_GENERIC_TYPE value) -> {
-			if (predicate.test(KEY2OBJ(value))) {
+		spliterator.forEachRemaining((KEY_GENERIC_TYPE value) -> {
+			if (predicate.test(value))) {
 				action.accept(KEY2OBJ(value));
 			}
 		});
-
-#endif
 	}
+#endif
 
 	/**
 	 * A skeletal implementation for a spliterator backed by an index based data store. High performance

--- a/gencsource.sh
+++ b/gencsource.sh
@@ -377,6 +377,7 @@ fi)\
 "#define KEY_LIST_ITERATOR ${TYPE_CAP2[$k]}ListIterator\n"\
 "#define KEY_BIG_LIST_ITERATOR ${TYPE_CAP2[$k]}BigListIterator\n"\
 "#define STD_KEY_ITERATOR ${TYPE_STD[$k]}Iterator\n"\
+"#define STD_KEY_SPLITERATOR ${TYPE_STD[$k]}Spliterator\n"\
 "#define STD_KEY_ITERABLE ${TYPE_STD[$k]}Iterable\n"\
 "#define KEY_COMPARATOR ${TYPE_STD[$k]}Comparator\n"\
 \


### PR DESCRIPTION
Minor touchups.

* Add Javadoc to Iterators.any/all/indexOf and Spliterators.forEachMatching
* Undeprecate the JDK primitive overloads of any/all/indexOf. Now the overhead is documented as an `@implNote` to conform to the other similar methods in fastutil.
* Make an overload of `Spliterators.forEachMatching` that accept the JDK primitive operators.
* Make `List.replaceAll(JDK_PRIMITIVE_UNARY_OPERATOR)` forward to `List.replaceAll(KEY_UNARY_OPERATOR)` if possible, because, for example, `ByteUnaryOperator` is a subinterface of `java.util.function.IntUnaryOperator`.
* Convert iterator accepting methods of `Iterators` that don't need the fastutil specific methods to use `STD_KEY_ITERATOR`, which allows the regular `java.util.Iterator` to be accepted for the `ObjectIterators` class.
* Convert spliterator accepting methods of `Spliterators` that don't need to fastutil specific methods to use the new `STD_KEY_SPLITERATOR`, which allows the regular `java.util.Spliterator` to be accepted for the `ObjectSpliterators` class.