### PR TITLE
Document effecient spliterator for a RandomAccess AbstractList

### DIFF
--- a/drv/AbstractBigList.drv
+++ b/drv/AbstractBigList.drv
@@ -175,6 +175,15 @@ public abstract class ABSTRACT_BIG_LIST KEY_GENERIC extends ABSTRACT_COLLECTION 
 		}
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @implSpec For {@link java.util.RandomAccess RandomAccess} big-lists, this implementation
+	 * will return a simple {@code Spliterator} that just calls {@link #get} on the
+	 * appropriate indexes, which should be able to {@code trySplit} in constant time. For non
+	 * {@code RandomAccess} lists, then the linear {@code Spliterator} provided by the
+	 * {@code BigList} interface is used.
+	 */ 
 	@Override
 	public KEY_SPLITERATOR KEY_GENERIC spliterator() {
 		if (this instanceof java.util.RandomAccess) {

--- a/drv/AbstractBigList.drv
+++ b/drv/AbstractBigList.drv
@@ -192,10 +192,10 @@ public abstract class ABSTRACT_BIG_LIST KEY_GENERIC extends ABSTRACT_COLLECTION 
 	 * {@link java.util.Spliterator#trySplit trySplit} in constant time. For non {@code RandomAccess}
 	 * lists, then the linear time splitting {@link java.util.Spliterator Spliterator} provided by
 	 * the {@code BigList} interface is used.
-	 * <p>Like the {@code BigList} and {@code Collection} interfaces, the returned spliterator is
-	 * late-binding with regards to size, that is, it will track size changes until the first
-	 * {@code java.util.Spliterator#trySplit trySplit} (after which case whether it binds early or
-	 * late is unspecified). 
+	 * <p>Like the {@code BigList} and {@code Collection} interfaces' default implementations, the
+	 * returned spliterator is late-binding with regards to size, that is, it will track size
+	 * changes until the first {@code java.util.Spliterator#trySplit trySplit} (after which case
+	 * whether it binds early or late is unspecified). 
 	 */
 	@Override
 	public KEY_SPLITERATOR KEY_GENERIC spliterator() {

--- a/drv/AbstractBigList.drv
+++ b/drv/AbstractBigList.drv
@@ -160,13 +160,21 @@ public abstract class ABSTRACT_BIG_LIST KEY_GENERIC extends ABSTRACT_COLLECTION 
 		};
 	}
 
-	private static final class IndexBasedSpliterator KEY_GENERIC extends BIG_SPLITERATORS.EarlyBindingSizeIndexBasedSpliterator KEY_GENERIC {
+	private static final class IndexBasedSpliterator KEY_GENERIC extends BIG_SPLITERATORS.LateBindingSizeIndexBasedSpliterator KEY_GENERIC {
 		final BIG_LIST KEY_GENERIC l;
+		
+		IndexBasedSpliterator(BIG_LIST KEY_GENERIC l, long pos) {
+			super(pos);
+			this.l = l;
+		}
+		
 		IndexBasedSpliterator(BIG_LIST KEY_GENERIC l, long pos, long maxPos) {
 			super(pos, maxPos);
 			this.l = l;
 		}
-
+		
+		@Override
+		protected final long getMaxPosFromBackingStore() { return l.size64(); }
 		@Override
 		protected final KEY_GENERIC_TYPE get(long i) { return l.GET_KEY(i); }
 		@Override
@@ -179,15 +187,20 @@ public abstract class ABSTRACT_BIG_LIST KEY_GENERIC extends ABSTRACT_COLLECTION 
 	 * {@inheritDoc}
 	 *
 	 * @implSpec For {@link java.util.RandomAccess RandomAccess} big-lists, this implementation
-	 * will return a simple {@code Spliterator} that just calls {@link #get} on the
-	 * appropriate indexes, which should be able to {@code trySplit} in constant time. For non
-	 * {@code RandomAccess} lists, then the linear {@code Spliterator} provided by the
-	 * {@code BigList} interface is used.
-	 */ 
+	 * will return a simple {@code Spliterator} that just calls {@link #get(long)} (except the
+	 * appropriate type specific method) with the appropriate indexes, which should be able to
+	 * {@link java.util.Spliterator#trySplit trySplit} in constant time. For non {@code RandomAccess}
+	 * lists, then the linear time splitting {@link java.util.Spliterator Spliterator} provided by
+	 * the {@code BigList} interface is used.
+	 * <p>Like the {@code BigList} and {@code Collection} interfaces, the returned spliterator is
+	 * late-binding with regards to size, that is, it will track size changes until the first
+	 * {@code java.util.Spliterator#trySplit trySplit} (after which case whether it binds early or
+	 * late is unspecified). 
+	 */
 	@Override
 	public KEY_SPLITERATOR KEY_GENERIC spliterator() {
 		if (this instanceof java.util.RandomAccess) {
-			return new IndexBasedSpliterator KEY_GENERIC_DIAMOND(this, 0, ABSTRACT_BIG_LIST.this.size());
+			return new IndexBasedSpliterator KEY_GENERIC_DIAMOND(this, 0);
 		} else {
 			return super.spliterator();
 		}

--- a/drv/AbstractList.drv
+++ b/drv/AbstractList.drv
@@ -180,6 +180,15 @@ public abstract class ABSTRACT_LIST KEY_GENERIC extends ABSTRACT_COLLECTION KEY_
 		}
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @implSpec For {@link java.util.RandomAccess RandomAccess} lists, this implementation
+	 * will return a simple {@code Spliterator} that just calls {@link #get} on the
+	 * appropriate indexes, which should be able to {@code trySplit} in constant time. For non
+	 * {@code RandomAccess} lists, then the linear {@code Spliterator} provided by the
+	 * {@code List} interface is used.
+	 */ 
 	@Override
 	public KEY_SPLITERATOR KEY_GENERIC spliterator() {
 		if (this instanceof java.util.RandomAccess) {

--- a/drv/AbstractList.drv
+++ b/drv/AbstractList.drv
@@ -165,13 +165,20 @@ public abstract class ABSTRACT_LIST KEY_GENERIC extends ABSTRACT_COLLECTION KEY_
 		};
 	}
 
-	private static final class IndexBasedSpliterator KEY_GENERIC extends SPLITERATORS.EarlyBindingSizeIndexBasedSpliterator KEY_GENERIC {
+	private static final class IndexBasedSpliterator KEY_GENERIC extends SPLITERATORS.LateBindingSizeIndexBasedSpliterator KEY_GENERIC {
 		final LIST KEY_GENERIC l;
+		IndexBasedSpliterator(LIST KEY_GENERIC l, int pos) {
+			super(pos);
+			this.l = l;
+		}
+		
 		IndexBasedSpliterator(LIST KEY_GENERIC l, int pos, int maxPos) {
 			super(pos, maxPos);
 			this.l = l;
 		}
-
+		
+		@Override
+		protected final int getMaxPosFromBackingStore() { return l.size(); }
 		@Override
 		protected final KEY_GENERIC_TYPE get(int i) { return l.GET_KEY(i); }
 		@Override
@@ -184,15 +191,20 @@ public abstract class ABSTRACT_LIST KEY_GENERIC extends ABSTRACT_COLLECTION KEY_
 	 * {@inheritDoc}
 	 *
 	 * @implSpec For {@link java.util.RandomAccess RandomAccess} lists, this implementation
-	 * will return a simple {@code Spliterator} that just calls {@link #get} on the
-	 * appropriate indexes, which should be able to {@code trySplit} in constant time. For non
-	 * {@code RandomAccess} lists, then the linear {@code Spliterator} provided by the
-	 * {@code List} interface is used.
-	 */ 
+	 * will return a simple {@code Spliterator} that just calls {@link #get(int)} (except the
+	 * appropriate type specific method) with the appropriate indexes, which should be able to
+	 * {@link java.util.Spliterator#trySplit trySplit} in constant time. For non {@code RandomAccess}
+	 * lists, then the linear time splitting {@link java.util.Spliterator Spliterator} provided by
+	 * the {@code List} interface is used.
+	 * <p>Like the {@code List} and {@code Collection} interfaces, the returned spliterator is
+	 * late-binding with regards to size, that is, it will track size changes until the first
+	 * {@code java.util.Spliterator#trySplit trySplit} (after which case whether it binds early or
+	 * late is unspecified). 
+	 */
 	@Override
 	public KEY_SPLITERATOR KEY_GENERIC spliterator() {
 		if (this instanceof java.util.RandomAccess) {
-			return new IndexBasedSpliterator KEY_GENERIC_DIAMOND(this, 0, ABSTRACT_LIST.this.size());
+			return new IndexBasedSpliterator KEY_GENERIC_DIAMOND(this, 0);
 		} else {
 			return LIST.super.spliterator();
 		}

--- a/drv/AbstractList.drv
+++ b/drv/AbstractList.drv
@@ -196,10 +196,10 @@ public abstract class ABSTRACT_LIST KEY_GENERIC extends ABSTRACT_COLLECTION KEY_
 	 * {@link java.util.Spliterator#trySplit trySplit} in constant time. For non {@code RandomAccess}
 	 * lists, then the linear time splitting {@link java.util.Spliterator Spliterator} provided by
 	 * the {@code List} interface is used.
-	 * <p>Like the {@code List} and {@code Collection} interfaces, the returned spliterator is
-	 * late-binding with regards to size, that is, it will track size changes until the first
-	 * {@code java.util.Spliterator#trySplit trySplit} (after which case whether it binds early or
-	 * late is unspecified). 
+	 * <p>Like the {@code List} and {@code Collection} interfaces' default implementations, the
+	 * returned spliterator is late-binding with regards to size, that is, it will track size
+	 * changes until the first {@code java.util.Spliterator#trySplit trySplit} (after which case
+	 * whether it binds early or late is unspecified). 
 	 */
 	@Override
 	public KEY_SPLITERATOR KEY_GENERIC spliterator() {


### PR DESCRIPTION
AbstractList gives a mostly effecient spliterator for RandomAccess subclasses.
While subclasses can certainly do better by abusing internals, this one
won't display the terrible splitting performance that the Iterator based one
from the root List interface does.

We should document this fact (and make it an assurance) so subclassers don't
feel obligated to write their own Spliterator to not get terrible parallel
performance.

Also make the spliterator late-binding, bringing them into line with the default implementations in the List and BigList classes.

Same for AbstractBigList.