### PR TITLE
Further document the spliterator methods in interfaces.

### DIFF
--- a/drv/AbstractBigList.drv
+++ b/drv/AbstractBigList.drv
@@ -160,7 +160,7 @@ public abstract class ABSTRACT_BIG_LIST KEY_GENERIC extends ABSTRACT_COLLECTION 
 		};
 	}
 
-	private static final class IndexBasedSpliterator KEY_GENERIC extends BIG_SPLITERATORS.LateBindingSizeIndexBasedSpliterator KEY_GENERIC {
+	static final class IndexBasedSpliterator KEY_GENERIC extends BIG_SPLITERATORS.LateBindingSizeIndexBasedSpliterator KEY_GENERIC {
 		final BIG_LIST KEY_GENERIC l;
 		
 		IndexBasedSpliterator(BIG_LIST KEY_GENERIC l, long pos) {
@@ -180,29 +180,6 @@ public abstract class ABSTRACT_BIG_LIST KEY_GENERIC extends ABSTRACT_COLLECTION 
 		@Override
 		protected final IndexBasedSpliterator KEY_GENERIC makeForSplit(long pos, long maxPos) {
 			return new IndexBasedSpliterator KEY_GENERIC_DIAMOND(l, pos, maxPos);
-		}
-	}
-
-	/**
-	 * {@inheritDoc}
-	 *
-	 * @implSpec For {@link java.util.RandomAccess RandomAccess} big-lists, this implementation
-	 * will return a simple {@code Spliterator} that just calls {@link #get(long)} (except the
-	 * appropriate type specific method) with the appropriate indexes, which should be able to
-	 * {@link java.util.Spliterator#trySplit trySplit} in constant time. For non {@code RandomAccess}
-	 * lists, then the linear time splitting {@link java.util.Spliterator Spliterator} provided by
-	 * the {@code BigList} interface is used.
-	 * <p>Like the {@code BigList} and {@code Collection} interfaces' default implementations, the
-	 * returned spliterator is late-binding with regards to size, that is, it will track size
-	 * changes until the first {@code java.util.Spliterator#trySplit trySplit} (after which case
-	 * whether it binds early or late is unspecified). 
-	 */
-	@Override
-	public KEY_SPLITERATOR KEY_GENERIC spliterator() {
-		if (this instanceof java.util.RandomAccess) {
-			return new IndexBasedSpliterator KEY_GENERIC_DIAMOND(this, 0);
-		} else {
-			return super.spliterator();
 		}
 	}
 

--- a/drv/AbstractList.drv
+++ b/drv/AbstractList.drv
@@ -165,7 +165,7 @@ public abstract class ABSTRACT_LIST KEY_GENERIC extends ABSTRACT_COLLECTION KEY_
 		};
 	}
 
-	private static final class IndexBasedSpliterator KEY_GENERIC extends SPLITERATORS.LateBindingSizeIndexBasedSpliterator KEY_GENERIC {
+	static final class IndexBasedSpliterator KEY_GENERIC extends SPLITERATORS.LateBindingSizeIndexBasedSpliterator KEY_GENERIC {
 		final LIST KEY_GENERIC l;
 		IndexBasedSpliterator(LIST KEY_GENERIC l, int pos) {
 			super(pos);
@@ -184,29 +184,6 @@ public abstract class ABSTRACT_LIST KEY_GENERIC extends ABSTRACT_COLLECTION KEY_
 		@Override
 		protected final IndexBasedSpliterator KEY_GENERIC makeForSplit(int pos, int maxPos) {
 			return new IndexBasedSpliterator KEY_GENERIC_DIAMOND(l, pos, maxPos);
-		}
-	}
-
-	/**
-	 * {@inheritDoc}
-	 *
-	 * @implSpec For {@link java.util.RandomAccess RandomAccess} lists, this implementation
-	 * will return a simple {@code Spliterator} that just calls {@link #get(int)} (except the
-	 * appropriate type specific method) with the appropriate indexes, which should be able to
-	 * {@link java.util.Spliterator#trySplit trySplit} in constant time. For non {@code RandomAccess}
-	 * lists, then the linear time splitting {@link java.util.Spliterator Spliterator} provided by
-	 * the {@code List} interface is used.
-	 * <p>Like the {@code List} and {@code Collection} interfaces' default implementations, the
-	 * returned spliterator is late-binding with regards to size, that is, it will track size
-	 * changes until the first {@code java.util.Spliterator#trySplit trySplit} (after which case
-	 * whether it binds early or late is unspecified). 
-	 */
-	@Override
-	public KEY_SPLITERATOR KEY_GENERIC spliterator() {
-		if (this instanceof java.util.RandomAccess) {
-			return new IndexBasedSpliterator KEY_GENERIC_DIAMOND(this, 0);
-		} else {
-			return LIST.super.spliterator();
 		}
 	}
 

--- a/drv/BigList.drv
+++ b/drv/BigList.drv
@@ -80,6 +80,37 @@ public interface BIG_LIST KEY_GENERIC extends BigList<KEY_GENERIC_CLASS>, COLLEC
 	@Override
 	KEY_BIG_LIST_ITERATOR KEY_GENERIC listIterator(long index);
 
+	/** Returns a type-specific spliterator on the elements of this big-list.
+	 *
+	 * <p>BigList spliterators must report at least {@link Spliterator#SIZED} and {@link Spliterator#ORDERED}.
+	 *
+	 * <p>See {@link java.util.List#spliterator()} for more documentation on the requirements
+	 * of the returned spliterator (despite {@code BigList} not being a {@code List}, most of the
+	 * same requirements apply.
+	 *
+	 * @apiNote This is generally the only {@code spliterator} method subclasses should override.
+	 *
+	 * @implSpec The default implementation returns a late-binding spliterator (see
+	 * {@link Spliterator} for documentation on what binding policies mean).
+	 * <ul>
+	 * <li>For {@link java.util.RandomAccess RandomAccess} lists, this will return a spliterator
+	 * that calls the type-specific {@link #get(long)} method on the appropriate indexes.</li>
+	 * <li>Otherwise, the spliterator returned will wrap this instance's type specific {@link #iterator}.</li>
+	 * </ul>
+	 * <p>In either case, the spliterator reports {@link Spliterator#SIZED},
+	 * {@link Spliterator#SUBSIZED}, and {@link Spliterator#ORDERED}.
+	 *
+	 * @implNote As the non-{@linkplain java.util.RandomAccess RandomAccess} case is based on the
+	 * iterator, and {@link java.util.Iterator} is an inherently linear API, the returned
+	 * spliterator will yield limited performance gains when run in parallel contexts, as the
+	 * returned spliterator's {@link Spliterator#trySplit() trySplit()} will have linear runtime.
+	 * <p>For {@link java.util.RandomAccess RandomAccess} lists, the parallel performance should
+	 * be reasonable assuming {@link #get(long)} is truly constant time like {@link java.util.RandomAccess
+	 * RandomAccess} suggests. 
+	 *
+	 * @return {@inheritDoc}
+	 * @since 8.5.0
+	 */
 	@Override
 #if SPLITERATOR_ASSURE_OVERRIDE
 	abstract KEY_SPLITERATOR KEY_GENERIC spliterator();

--- a/drv/Collection.drv
+++ b/drv/Collection.drv
@@ -99,8 +99,22 @@ public interface COLLECTION KEY_GENERIC extends Collection<KEY_GENERIC_CLASS>, K
 
 	/** Returns a type-specific spliterator on the elements of this collection.
 	 *
+	 * <p>See {@link java.util.Collection#spliterator()} for more documentation on the requirements
+	 * of the returned spliterator.
+	 *
 	 * @apiNote This specification strengthens the one given in
 	 * {@link java.util.Collection#spliterator()}.
+	 * <p>Also, this is generally the only {@code spliterator} method subclasses should override.
+	 *
+	 * @implSpec The default implementation returns a late-binding spliterator (see
+	 * {@link java.util.Spliterator Spliterator} for documentation on what binding policies mean)
+	 * that wraps this instance's type specific {@link #iterator}.
+	 * <p>Additionally, it reports {@link java.util.Spliterator#SIZED Spliterator.SIZED}
+	 *
+	 * @implNote As this default implementation wraps the iterator, and {@link java.util.Iterator}
+	 * is an inherently linear API, the returned spliterator will yield limited performance gains
+	 * when run in parallel contexts, as the returned spliterator's
+	 * {@link java.util.Spliterator#trySplit() trySplit()} will have linear runtime.
 	 *
 	 * @return a type-specific spliterator on the elements of this collection.
 	 * @since 8.5.0
@@ -125,6 +139,7 @@ public interface COLLECTION KEY_GENERIC extends Collection<KEY_GENERIC_CLASS>, K
 	 * that have use for widened spliterators.
 	 *
 	 * @return a primitive spliterator on the elements of this collection.
+	 * @since 8.5.0
 	 */
 	@Override
 	default KEY_WIDENED_SPLITERATOR KEY_WIDENED_SPLITERATOR_METHOD() { return spliterator(); }

--- a/drv/List.drv
+++ b/drv/List.drv
@@ -17,6 +17,7 @@
 
 package PACKAGE;
 
+import java.util.Spliterator;
 import java.util.List;
 import static it.unimi.dsi.fastutil.Size64.getSizeOf;
 
@@ -62,28 +63,58 @@ public interface LIST KEY_GENERIC extends List<KEY_GENERIC_CLASS>, COLLECTION KE
 	 * @apiNote This specification strengthens the one given in {@link List#iterator()}.
 	 * It would not be normally necessary, but {@link java.lang.Iterable#iterator()} is bizarrily re-specified
 	 * in {@link List}.
+	 * <p>Also, this is generally the only {@code iterator} method subclasses should override.
 	 *
 	 * @return an iterator on the elements of this list.
 	 */
 	@Override
 	KEY_LIST_ITERATOR KEY_GENERIC iterator();
 
-	/**
-	 * {@inheritDoc}
+	/** Returns a type-specific spliterator on the elements of this collection.
+	 *
+	 * <p>List spliterators must report at least {@link Spliterator#SIZED} and {@link Spliterator#ORDERED}.
+	 *
+	 * <p>See {@link java.util.List#spliterator()} for more documentation on the requirements
+	 * of the returned spliterator.
 	 *
 	 * @apiNote This specification strengthens the one given in
 	 * {@link java.util.Collection#spliterator()}, which was already
 	 * strengthened in the corresponding type-specific class,
 	 * but was weakened by the fact that this interface extends {@link List}.
+	 * <p>Also, this is generally the only {@code spliterator} method subclasses should override.
 	 *
+	 * @implSpec The default implementation returns a late-binding spliterator (see
+	 * {@link Spliterator} for documentation on what binding policies mean).
+	 * <ul>
+	 * <li>For {@link java.util.RandomAccess RandomAccess} lists, this will return a spliterator
+	 * that calls the type-specific {@link #get(int)} method on the appropriate indexes.</li>
+	 * <li>Otherwise, the spliterator returned will wrap this instance's type specific {@link #iterator}.</li>
+	 * </ul>
+	 * <p>In either case, the spliterator reports {@link Spliterator#SIZED},
+	 * {@link Spliterator#SUBSIZED}, and {@link Spliterator#ORDERED}.
+	 *
+	 * @implNote As the non-{@linkplain java.util.RandomAccess RandomAccess} case is based on the
+	 * iterator, and {@link java.util.Iterator} is an inherently linear API, the returned
+	 * spliterator will yield limited performance gains when run in parallel contexts, as the
+	 * returned spliterator's {@link Spliterator#trySplit() trySplit()} will have linear runtime.
+	 * <p>For {@link java.util.RandomAccess RandomAccess} lists, the parallel performance should
+	 * be reasonable assuming {@link #get(int)} is truly constant time like {@link java.util.RandomAccess
+	 * RandomAccess} suggests. 
+	 *
+	 * @return {@inheritDoc}
+	 * @since 8.5.0
 	 */
 	@Override
 #if SPLITERATOR_ASSURE_OVERRIDE
 	abstract KEY_SPLITERATOR KEY_GENERIC spliterator();
 #else
 	default KEY_SPLITERATOR KEY_GENERIC spliterator() {
-		return SPLITERATORS.asSpliterator(
+		if (this instanceof java.util.RandomAccess) {
+			return new ABSTRACT_LIST.IndexBasedSpliterator KEY_GENERIC_DIAMOND(this, 0);
+		} else {
+			return SPLITERATORS.asSpliterator(
 				iterator(), getSizeOf(this), SPLITERATORS.LIST_SPLITERATOR_CHARACTERISTICS);
+		}
 	}
 #endif
 

--- a/drv/List.drv
+++ b/drv/List.drv
@@ -70,7 +70,7 @@ public interface LIST KEY_GENERIC extends List<KEY_GENERIC_CLASS>, COLLECTION KE
 	@Override
 	KEY_LIST_ITERATOR KEY_GENERIC iterator();
 
-	/** Returns a type-specific spliterator on the elements of this collection.
+	/** Returns a type-specific spliterator on the elements of this list.
 	 *
 	 * <p>List spliterators must report at least {@link Spliterator#SIZED} and {@link Spliterator#ORDERED}.
 	 *

--- a/drv/Set.drv
+++ b/drv/Set.drv
@@ -43,7 +43,7 @@ public interface SET KEY_GENERIC extends COLLECTION KEY_GENERIC, Set<KEY_GENERIC
 	KEY_ITERATOR KEY_GENERIC iterator();
 
 	/**
-	 * Returns a type-specific spliterator on the elements of this collection.
+	 * Returns a type-specific spliterator on the elements of this set.
 	 *
 	 * <p>Set spliterators must report at least {@link Spliterator.UNIQUE}.
 	 *

--- a/drv/Set.drv
+++ b/drv/Set.drv
@@ -17,6 +17,7 @@
 
 package PACKAGE;
 
+import java.util.Spliterator;
 import java.util.Set;
 import static it.unimi.dsi.fastutil.Size64.getSizeOf;
 
@@ -34,6 +35,7 @@ public interface SET KEY_GENERIC extends COLLECTION KEY_GENERIC, Set<KEY_GENERIC
 	 * @apiNote This specification strengthens the one given in {@link java.lang.Iterable#iterator()},
 	 * which was already strengthened in the corresponding type-specific class,
 	 * but was weakened by the fact that this interface extends {@link Set}.
+	 * <p>Also, this is generally the only {@code iterator} method subclasses should override.
 	 *
 	 * @return a type-specific iterator on the elements of this set.
 	 */
@@ -41,12 +43,31 @@ public interface SET KEY_GENERIC extends COLLECTION KEY_GENERIC, Set<KEY_GENERIC
 	KEY_ITERATOR KEY_GENERIC iterator();
 
 	/**
-	 * {@inheritDoc}
+	 * Returns a type-specific spliterator on the elements of this collection.
+	 *
+	 * <p>Set spliterators must report at least {@link Spliterator.UNIQUE}.
+	 *
+	 * <p>See {@link java.util.Set#spliterator()} for more documentation on the requirements
+	 * of the returned spliterator.
 	 *
 	 * @apiNote This specification strengthens the one given in
 	 * {@link java.util.Collection#spliterator()}, which was already
 	 * strengthened in the corresponding type-specific class,
 	 * but was weakened by the fact that this interface extends {@link Set}.
+	 * <p>Also, this is generally the only {@code spliterator} method subclasses should override.
+	 *
+	 * @implSpec The default implementation returns a late-binding spliterator (see
+	 * {@link Spliterator} for documentation on what binding policies mean)
+	 * that wraps this instance's type specific {@link #iterator}.
+	 * <p>Additionally, it reports {@link Spliterator#SIZED} and {@link Spliterator#UNIQUE}.
+	 *
+	 * @implNote As this default implementation wraps the iterator, and {@link java.util.Iterator}
+	 * is an inherently linear API, the returned spliterator will yield limited performance gains
+	 * when run in parallel contexts, as the returned spliterator's
+	 * {@link Spliterator#trySplit() trySplit()} will have linear runtime.
+	 *
+	 * @return {@inheritDoc}
+	 * @since 8.5.0
 	 */
 	@Override
 #if SPLITERATOR_ASSURE_OVERRIDE

--- a/drv/SortedSet.drv
+++ b/drv/SortedSet.drv
@@ -97,7 +97,7 @@ public interface SORTED_SET KEY_GENERIC extends SET KEY_GENERIC, SortedSet<KEY_G
 	 * that wraps this instance's type specific {@link #iterator}.
 	 * <p>Additionally, it reports {@link Spliterator.SIZED}, {@link Spliterator.UNIQUE},
 	 * {@link Spliterator#SORTED}, and {@link Spliterator#ORDERED}. The reported {@link java.util.Comparator}
-	 * from {@link Spliterator#getComparator()} will be the one reported by this instance's {@link #getComparator()}.
+	 * from {@link Spliterator#getComparator()} will be the one reported by this instance's {@link #comparator()}.
 	 *
 	 * @implNote As this default implementation wraps the iterator, and {@link java.util.Iterator}
 	 * is an inherently linear API, the returned spliterator will yield limited performance gains

--- a/drv/SortedSet.drv
+++ b/drv/SortedSet.drv
@@ -17,6 +17,7 @@
 
 package PACKAGE;
 
+import java.util.Spliterator;
 import java.util.SortedSet;
 import java.util.Collection;
 import static it.unimi.dsi.fastutil.Size64.getSizeOf;
@@ -77,12 +78,34 @@ public interface SORTED_SET KEY_GENERIC extends SET KEY_GENERIC, SortedSet<KEY_G
 	KEY_BIDI_ITERATOR KEY_GENERIC iterator();
 
 	/**
-	 * {@inheritDoc}
+	 * Returns a type-specific spliterator on the elements of this collection.
+	 *
+	 * <p>SortedSet spliterators must report at least {@link Spliterator#UNIQUE},
+	 * {@link Spliterator#ORDERED}, and {@link Spliterator#SORTED}.
+	 *
+	 * <p>See {@link java.util.SortedSet#spliterator()} for more documentation on the requirements
+	 * of the returned spliterator.
 	 *
 	 * @apiNote This specification strengthens the one given in
 	 * {@link java.util.Collection#spliterator()}, which was already
 	 * strengthened in the corresponding type-specific class,
 	 * but was weakened by the fact that this interface extends {@link SortedSet}.
+	 * <p>Also, this is generally the only {@code spliterator} method subclasses should override.
+	 *
+	 * @implSpec The default implementation returns a late-binding spliterator (see
+	 * {@link Spliterator} for documentation on what binding policies mean)
+	 * that wraps this instance's type specific {@link #iterator}.
+	 * <p>Additionally, it reports {@link Spliterator.SIZED}, {@link Spliterator.UNIQUE},
+	 * {@link Spliterator#SORTED}, and {@link Spliterator#ORDERED}. The reported {@link java.util.Comparator}
+	 * from {@link Spliterator#getComparator()} will be the one reported by this instance's {@link #getComparator()}.
+	 *
+	 * @implNote As this default implementation wraps the iterator, and {@link java.util.Iterator}
+	 * is an inherently linear API, the returned spliterator will yield limited performance gains
+	 * when run in parallel contexts, as the returned spliterator's
+	 * {@link Spliterator#trySplit() trySplit()} will have linear runtime.
+	 *
+	 * @return {@inheritDoc}
+	 * @since 8.5.0
 	 */
 	@Override
 #if SPLITERATOR_ASSURE_OVERRIDE

--- a/drv/SortedSet.drv
+++ b/drv/SortedSet.drv
@@ -81,7 +81,9 @@ public interface SORTED_SET KEY_GENERIC extends SET KEY_GENERIC, SortedSet<KEY_G
 	 * Returns a type-specific spliterator on the elements of this collection.
 	 *
 	 * <p>SortedSet spliterators must report at least {@link Spliterator#UNIQUE},
-	 * {@link Spliterator#ORDERED}, and {@link Spliterator#SORTED}.
+	 * {@link Spliterator#ORDERED}, and {@link Spliterator#SORTED}. The returned spliterator's
+	 * {@link Spliterator#getComparator() getComparator()} must be the same (or at the very least,
+	 * consistent with) this instance's {@link #comparator()}.
 	 *
 	 * <p>See {@link java.util.SortedSet#spliterator()} for more documentation on the requirements
 	 * of the returned spliterator.

--- a/drv/SortedSet.drv
+++ b/drv/SortedSet.drv
@@ -78,7 +78,7 @@ public interface SORTED_SET KEY_GENERIC extends SET KEY_GENERIC, SortedSet<KEY_G
 	KEY_BIDI_ITERATOR KEY_GENERIC iterator();
 
 	/**
-	 * Returns a type-specific spliterator on the elements of this collection.
+	 * Returns a type-specific spliterator on the elements of this sorted-set.
 	 *
 	 * <p>SortedSet spliterators must report at least {@link Spliterator#UNIQUE},
 	 * {@link Spliterator#ORDERED}, and {@link Spliterator#SORTED}. The returned spliterator's


### PR DESCRIPTION
Also pull the RandomAccess check for the default implementation of
spliterator() from AbstractList into List, to match up with what java.util.List does.

The detail is rather excruciating, but spliterator is kind of a nuanced API like that requiring that level of detail, at least in the interfaces it does.