### PR TITLE
Fix a rather critical bug where ImmutableList.equals would return true erroneosly

### DIFF
--- a/drv/ImmutableList.drv
+++ b/drv/ImmutableList.drv
@@ -451,10 +451,10 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 
 #if KEY_CLASS_Reference
 		while(s-- !=  0) if (a1[s] != a2[s]) return false;
-#else
-		java.util.Arrays.equals(a1, a2);
-#endif
 		return true;
+#else
+		return java.util.Arrays.equals(a1, a2);
+#endif
 	}
 
 	SUPPRESS_WARNINGS_KEY_UNCHECKED

--- a/test/it/unimi/dsi/fastutil/ints/IntImmutableListTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntImmutableListTest.java
@@ -17,6 +17,7 @@
 package it.unimi.dsi.fastutil.ints;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -66,6 +67,20 @@ public class IntImmutableListTest {
 		// Also conveniently serves as a test of the intStream and spliterator.
 		final IntImmutableList transformed = IntImmutableList.toList(baseList.intStream().map(i -> i + 40));
 		assertEquals(IntImmutableList.of(42, 420, 1337), transformed);
+	}
+	
+	@Test
+	public void testEquals_AnotherImmutableList() {
+		final IntImmutableList baseList = IntImmutableList.of(2, 380, 1297);
+		assertEquals(IntImmutableList.of(2, 380, 1297), baseList);
+		assertNotEquals(IntImmutableList.of(42, 420, 1337), baseList);
+	}
+
+	@Test
+	public void testEquals_OtherListImpl() {
+		final IntImmutableList baseList = IntImmutableList.of(2, 380, 1297);
+		assertEquals(IntArrayList.of(2, 380, 1297), baseList);
+		assertNotEquals(IntArrayList.of(42, 420, 1337), baseList);
 	}
 
 	@Test


### PR DESCRIPTION
Would happen to return `true` if any ImmutableList was given, equal contents or not.