### PR TITLE
Sub list for immutable list

### DIFF
--- a/drv/ArrayList.drv
+++ b/drv/ArrayList.drv
@@ -1063,7 +1063,7 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 
 	/** Compares this type-specific array list to another one.
 	 *
-	 * <p>This method exists only for sake of efficiency. The implementation
+	 * @apiNote This method exists only for sake of efficiency. The implementation
 	 * inherited from the abstract implementation would already work.
 	 *
 	 * @param l a type-specific array list.
@@ -1095,7 +1095,7 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 
 	/** Compares this array list to another array list.
 	 *
-	 * <p>This method exists only for sake of efficiency. The implementation
+	 * @apiNote This method exists only for sake of efficiency. The implementation
 	 * inherited from the abstract implementation would already work.
 	 *
 	 * @param l an array list.

--- a/drv/ArrayList.drv
+++ b/drv/ArrayList.drv
@@ -607,6 +607,11 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 
 		// Most of the inherited methods should be fine, but we can override a few of them for performance.
 
+		// Needed because we can't access the parent class' instance variables directly in a different instance of SubList.
+		private KEY_GENERIC_TYPE[] getParentArray() {
+			return a;
+		}
+
 		@Override
 		public KEY_GENERIC_TYPE GET_KEY(int i) {
 			ensureRestrictedIndex(i);
@@ -689,7 +694,74 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 		public KEY_SPLITERATOR KEY_GENERIC spliterator() {
 			return new SubListSpliterator();
 		}
+		
+		boolean contentsEquals(KEY_GENERIC_TYPE[] otherA, int otherAFrom, int otherATo) {
+			if (a == otherA && from == otherAFrom && to == otherATo) return true;
+			if (otherATo - otherAFrom != size()) {
+				return false;
+			}
+			int pos = from, otherPos = otherAFrom;
+			// We have already assured that the two ranges are the same size, so we only need to check one bound.
+			// TODO When minimum version of Java becomes Java 9, use the Arrays.equals which takes bounds, which is vectorized.
+			// Make sure to split out the reference equality case when you do this.
+#if KEY_CLASS_Object
+			while(pos < to) if (!java.util.Objects.equals(a[pos++], otherA[otherPos++])) return false;
+#else
+			while(pos < to) if (a[pos++] != otherA[otherPos++]) return false;
+#endif
+			return true;
+		}
 
+		@Override
+		public boolean equals(Object o) {
+			if (o == this) return true;
+			if (o == null) return false;
+			if (!(o instanceof java.util.List)) return false;
+			if (o instanceof ARRAY_LIST) {
+				SUPPRESS_WARNINGS_KEY_UNCHECKED
+				ARRAY_LIST KEY_GENERIC other = (ARRAY_LIST KEY_GENERIC) o;
+				return contentsEquals(other.a, 0, other.size());
+			}
+			if (o instanceof ARRAY_LIST.SubList) {
+				SUPPRESS_WARNINGS_KEY_UNCHECKED
+				ARRAY_LIST KEY_GENERIC.SubList other = (ARRAY_LIST KEY_GENERIC.SubList) o;
+				return contentsEquals(other.getParentArray(), other.from, other.to);
+			}
+			return super.equals(o);
+		}
+
+#if ! KEYS_USE_REFERENCE_EQUALITY
+		int contentsCompareTo(KEY_GENERIC_TYPE[] otherA, int otherAFrom, int otherATo) {
+#if KEYS_PRIMITIVE // Can't make this assumption for reference types in case we have a goofy Comparable that doesn't compare itself equal
+			if (a == otherA && from == otherAFrom && to == otherATo) return 0;
+#endif
+			// TODO When minimum version of Java becomes Java 9, use Arrays.compare, which vectorizes.
+			KEY_GENERIC_TYPE e1, e2;
+			int r, i, j;
+			for(i = from, j = otherAFrom; i < to && i < otherATo; i++, j++) {
+				e1 = a[i];
+				e2 = otherA[j];
+				if ((r = KEY_CMP(e1, e2)) != 0) return r;
+			}
+			return i < otherATo ? -1 : (i < to ? 1 : 0);
+		}
+
+		SUPPRESS_WARNINGS_KEY_UNCHECKED
+		@Override
+		public int compareTo(final java.util.List <? extends KEY_GENERIC_CLASS> l) {
+			if (l instanceof ARRAY_LIST) {
+				SUPPRESS_WARNINGS_KEY_UNCHECKED
+				ARRAY_LIST KEY_GENERIC other = (ARRAY_LIST KEY_GENERIC) l;
+				return contentsCompareTo(other.a, 0, other.size());
+			}
+			if (l instanceof ARRAY_LIST.SubList) {
+				SUPPRESS_WARNINGS_KEY_UNCHECKED
+				ARRAY_LIST KEY_GENERIC.SubList other = (ARRAY_LIST KEY_GENERIC.SubList) l;
+				return contentsCompareTo(other.getParentArray(), other.from, other.to);
+			}
+			return super.compareTo(l);
+		}
+#endif
 		// We don't override subList as we want AbstractList's "sub-sublist" nesting handling,
 		// which would be tricky to do here.
 		// TODO Do override it so array access isn't sent through N indirections.
@@ -698,6 +770,7 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 
 	@Override
 	public LIST KEY_GENERIC subList(int from, int to) {
+		if (from == 0 && to == size()) return this;
 		ensureIndex(from);
 		ensureIndex(to);
 		if (from > to) throw new IndexOutOfBoundsException("Start index (" + from + ") is greater than end index (" + to + ")");
@@ -1077,6 +1150,8 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 		final KEY_GENERIC_TYPE[] a1 = a;
 		final KEY_GENERIC_TYPE[] a2 = l.a;
 
+		if (a1 == a2 && s == l.size()) return true; 
+
 #if KEY_CLASS_Object
 		while(s-- !=  0) if (! java.util.Objects.equals(a1[s], a2[s])) return false;
 #else
@@ -1085,10 +1160,26 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 		return true;
 	}
 
-	SUPPRESS_WARNINGS_KEY_UNCHECKED
+#if KEYS_REFERENCE
+	@SuppressWarnings({"unchecked", "unlikely-arg-type"})
+#else
+	@SuppressWarnings("unlikely-arg-type")
+#endif
 	@Override
-	public boolean equals(Object o) {
-		return o instanceof ARRAY_LIST ? equals((ARRAY_LIST KEY_GENERIC)o) : super.equals(o);
+	public boolean equals(final Object o) {
+		if (o == this) return true;
+		if (o == null) return false;
+		if (!(o instanceof java.util.List)) return false;
+		if (o instanceof ARRAY_LIST) {
+			// Safe cast because we are only going to take elements from other list, never give them
+			return equals((ARRAY_LIST KEY_GENERIC) o);
+		}
+		if (o instanceof ARRAY_LIST.SubList) {
+			// Safe cast because we are only going to take elements from other list, never give them
+			// Sublist has an optimized sub-array based comparison, reuse that. 
+			return ((ARRAY_LIST KEY_GENERIC.SubList)o).equals(this);
+		}
+		return super.equals(o);
 	}
 
 #if ! KEYS_USE_REFERENCE_EQUALITY
@@ -1105,9 +1196,13 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 	 */
 	SUPPRESS_WARNINGS_KEY_UNCHECKED
 	public int compareTo(final ARRAY_LIST KEY_EXTENDS_GENERIC l) {
-		// TODO When minimum version of Java becomes Java 9, use Arrays.compare, which vectorizes.
 		final int s1 = size(), s2 = l.size();
 		final KEY_GENERIC_TYPE a1[] = a, a2[] = l.a;
+#if KEYS_PRIMITIVE // Can't make this assumption for reference types in case we have a goofy Comparable that doesn't compare itself equal
+		if (a1 == a2 && s1 == s2) return 0;
+#endif
+		
+		// TODO When minimum version of Java becomes Java 9, use Arrays.compare, which vectorizes.
 		KEY_GENERIC_TYPE e1, e2;
 		int r, i;
 
@@ -1120,12 +1215,19 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 		return i < s2 ? -1 : (i < s1 ? 1 : 0);
 	}
 
+	SUPPRESS_WARNINGS_KEY_UNCHECKED
 	@Override
 	public int compareTo(final java.util.List <? extends KEY_GENERIC_CLASS> l) {
-		return l instanceof ARRAY_LIST ? compareTo((ARRAY_LIST KEY_EXTENDS_GENERIC)l) : super.compareTo(l);
+		if (l instanceof ARRAY_LIST) {
+			return compareTo((ARRAY_LIST KEY_EXTENDS_GENERIC)l);
+		}
+		if (l instanceof ARRAY_LIST.SubList) {
+			// Must negate because we are inverting the order of the comparison.
+			return -((ARRAY_LIST KEY_EXTENDS_GENERIC.SubList) l).compareTo(this);
+		}
+		return super.compareTo(l);
 	}
 #endif
-
 
 	private void writeObject(java.io.ObjectOutputStream s) throws java.io.IOException {
 		s.defaultWriteObject();

--- a/drv/ImmutableList.drv
+++ b/drv/ImmutableList.drv
@@ -441,6 +441,7 @@ public class IMMUTABLE_LIST KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENE
 		 */
 		final transient KEY_GENERIC_TYPE a[];
 
+		/** No validation; callers must validate arguments. */
 		ImmutableSubList(IMMUTABLE_LIST KEY_GENERIC innerList, int from, int to) {
 			this.innerList = innerList;
 			this.from = from;

--- a/drv/ImmutableList.drv
+++ b/drv/ImmutableList.drv
@@ -429,7 +429,8 @@ public class IMMUTABLE_LIST KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENE
 		return new Spliterator();
 	}
 	
-	private final static class ImmutableSubList KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENERIC implements java.util.RandomAccess {
+	private final static class ImmutableSubList KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENERIC implements java.util.RandomAccess, java.io.Serializable {
+		private static final long serialVersionUID = 7054639518438982401L;
 		final IMMUTABLE_LIST KEY_GENERIC innerList;
 		final int from;
 		final int to;
@@ -437,8 +438,8 @@ public class IMMUTABLE_LIST KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENE
 		 * An alias to {@code innerList}'s array to save some typing. Note that 0 in this array is actually
 		 * the first element of the {@code innerList}, not this sublist. {@code a[from]} is the
 		 * first element of this sublist.
-		 */  
-		final KEY_GENERIC_TYPE a[];
+		 */
+		final transient KEY_GENERIC_TYPE a[];
 
 		ImmutableSubList(IMMUTABLE_LIST KEY_GENERIC innerList, int from, int to) {
 			this.innerList = innerList;
@@ -642,10 +643,11 @@ public class IMMUTABLE_LIST KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENE
 			}
 			int pos = from, otherPos = otherAFrom;
 			// We have already assured that the two ranges are the same size, so we only need to check one bound.
+			// TODO When minimum version of Java becomes Java 9, use the Arrays.equals which takes bounds, which is vectorized.
+			// Make sure to split out the reference equality case when you do this.
 #if KEY_CLASS_Object
 			while(pos < to) if (!java.util.Objects.equals(a[pos++], otherA[otherPos++])) return false;
 #else
-			// TODO When minimum version of Java becomes Java 9, use the Arrays.equals which takes bounds, which is vectorized.
 			while(pos < to) if (a[pos++] != otherA[otherPos++]) return false;
 #endif
 			return true;
@@ -702,6 +704,18 @@ public class IMMUTABLE_LIST KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENE
 		}
 
 #endif
+
+		private Object readResolve() throws java.io.ObjectStreamException {
+			// We need to recheck the invariants of the subList and reestablish our "a" array alias.
+			// Easiest way to do this is to just make a subList anew.
+			// This will not cause a recopy of contents as subLists are a view, so this is all constant time.
+			try {
+				return innerList.subList(from, to);
+			} catch (IllegalArgumentException | IndexOutOfBoundsException ex) {
+				throw (java.io.InvalidObjectException) (new java.io.InvalidObjectException(ex.getMessage()).initCause(ex));
+			}
+		}
+
 		@Override
 		public LIST KEY_GENERIC subList(int from, int to) {
 			// We don't need to worry about keeping all nested sublists up to date with bounds as we are immutable.
@@ -816,7 +830,16 @@ public class IMMUTABLE_LIST KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENE
 	SUPPRESS_WARNINGS_KEY_UNCHECKED
 	@Override
 	public int compareTo(final java.util.List <? extends KEY_GENERIC_CLASS> l) {
-		return l instanceof IMMUTABLE_LIST ? compareTo((IMMUTABLE_LIST KEY_EXTENDS_GENERIC)l) : super.compareTo(l);
+		if (l instanceof IMMUTABLE_LIST) {
+			return compareTo((IMMUTABLE_LIST KEY_EXTENDS_GENERIC)l);
+		}
+		if (l instanceof ImmutableSubList) {
+			// Safe to strip the "extends" because we will only ever take elements, never modify them (especially because it is immutable).
+			ImmutableSubList KEY_GENERIC other = (ImmutableSubList KEY_GENERIC)l;
+			// Must negate because we are inverting the order of the comparison.
+			return -other.compareTo(this);
+		}
+		return super.compareTo(l);
 	}
 #endif
 }

--- a/drv/ImmutableList.drv
+++ b/drv/ImmutableList.drv
@@ -43,7 +43,7 @@ public class IMMUTABLE_LIST KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENE
 	private static final long serialVersionUID = 0L;
 	
 	SUPPRESS_WARNINGS_KEY_UNCHECKED_RAWTYPES
-	private static final IMMUTABLE_LIST EMPTY = new IMMUTABLE_LIST(ARRAYS.EMPTY_ARRAY);
+	static final IMMUTABLE_LIST EMPTY = new IMMUTABLE_LIST(ARRAYS.EMPTY_ARRAY);
 
 #if KEYS_PRIMITIVE
 #define _EMPTY_ARRAY ARRAYS.EMPTY_ARRAY
@@ -108,7 +108,7 @@ public class IMMUTABLE_LIST KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENE
 	 */
 	SUPPRESS_WARNINGS_KEY_UNCHECKED
 	public IMMUTABLE_LIST(final KEY_GENERIC_TYPE a[], final int offset, final int length) {
-		this(KEY_GENERIC_ARRAY_CAST new KEY_TYPE[length]);
+		this(length == 0 ? _EMPTY_ARRAY : KEY_GENERIC_ARRAY_CAST new KEY_TYPE[length]);
 		System.arraycopy(a, offset, this.a, 0, length);
 	}
 
@@ -430,7 +430,7 @@ public class IMMUTABLE_LIST KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENE
 	}
 	
 	private final static class ImmutableSubList KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENERIC implements java.util.RandomAccess {
-		final IMMUTABLE_LIST innerList;
+		final IMMUTABLE_LIST KEY_GENERIC innerList;
 		final int from;
 		final int to;
 		/**
@@ -438,9 +438,9 @@ public class IMMUTABLE_LIST KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENE
 		 * the first element of the {@code innerList}, not this sublist. {@code a[from]} is the
 		 * first element of this sublist.
 		 */  
-		private final KEY_GENERIC_TYPE a[];
-		
-		ImmutableSubList(IMMUTABLE_LIST innerList, int from, int to) {
+		final KEY_GENERIC_TYPE a[];
+
+		ImmutableSubList(IMMUTABLE_LIST KEY_GENERIC innerList, int from, int to) {
 			this.innerList = innerList;
 			this.from = from;
 			this.to = to;
@@ -669,6 +669,7 @@ public class IMMUTABLE_LIST KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENE
 			return super.equals(o);
 		}
 
+#if ! KEY_CLASS_Reference
 		int contentsCompareTo(KEY_GENERIC_TYPE[] otherA, int otherAFrom, int otherATo) {
 #if KEYS_PRIMITIVE // Can't make this assumption for reference types in case we have a goofy Comparable that doesn't compare itself equal
 			if (a == otherA && from == otherAFrom && to == otherATo) return 0;
@@ -700,12 +701,14 @@ public class IMMUTABLE_LIST KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENE
 			return super.compareTo(l);
 		}
 
+#endif
 		@Override
 		public LIST KEY_GENERIC subList(int from, int to) {
 			// We don't need to worry about keeping all nested sublists up to date with bounds as we are immutable.
 			// So don't even nest; just return a sublist with the immediate parent of the root list.
 			ensureIndex(from);
 			ensureIndex(to);
+			if (from == to) return EMPTY;
 			if (from > to) throw new IllegalArgumentException("Start index (" + from + ") is greater than end index (" + to + ")");
 			return new ImmutableSubList KEY_GENERIC_DIAMOND(innerList, from + this.from, to + this.from);
 		}
@@ -714,7 +717,7 @@ public class IMMUTABLE_LIST KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENE
 	/**
 	 * {@inheritDoc}
 	 *
-	 * <p>The returned list will be immutable, but is currently not declared to return an
+	 * @apiNote The returned list will be immutable, but is currently not declared to return an
 	 * instance of {@code ImmutableList} due to complications of implementation details.
 	 * This may change in a future version (in other words, do not consider the return type of
 	 * this method to be stable if making a subclass of {@code ImmutableList}).
@@ -724,6 +727,7 @@ public class IMMUTABLE_LIST KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENE
 		if (from == 0 && to == size()) return this;
 		ensureIndex(from);
 		ensureIndex(to);
+		if (from == to) return EMPTY;
 		if (from > to) throw new IllegalArgumentException("Start index (" + from + ") is greater than end index (" + to + ")");
 		return new ImmutableSubList KEY_GENERIC_DIAMOND(this, from, to);
 	}
@@ -736,7 +740,7 @@ public class IMMUTABLE_LIST KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENE
 
 	/** Compares this type-specific immutable list to another one.
 	 *
-	 * <p>This method exists only for sake of efficiency. The implementation
+	 * @apiNote This method exists only for sake of efficiency. The implementation
 	 * inherited from the abstract implementation would already work.
 	 *
 	 * @param l a type-specific immutable list.
@@ -758,7 +762,11 @@ public class IMMUTABLE_LIST KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENE
 #endif
 	}
 
-	SUPPRESS_WARNINGS_KEY_UNCHECKED
+#if KEYS_REFERENCE
+	@SuppressWarnings({"unchecked", "unlikely-arg-type"})
+#else
+	@SuppressWarnings("unlikely-arg-type")
+#endif
 	@Override
 	public boolean equals(final Object o) {
 		if (o == this) return true;
@@ -771,15 +779,14 @@ public class IMMUTABLE_LIST KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENE
 			// Sublist has an optimized sub-array based comparison, reuse that. 
 			return ((ImmutableSubList KEY_GENERIC)o).equals(this);
 		}
-		return super.equals(0);
+		return super.equals(o);
 	}
-
 
 #if ! KEY_CLASS_Reference
 
 	/** Compares this immutable list to another immutable list.
 	 *
-	 * <p>This method exists only for sake of efficiency. The implementation
+	 * @apiNote This method exists only for sake of efficiency. The implementation
 	 * inherited from the abstract implementation would already work.
 	 *
 	 * @param l an immutable list.

--- a/drv/ImmutableList.drv
+++ b/drv/ImmutableList.drv
@@ -39,7 +39,7 @@ import java.util.stream.Collector;
  * expensive loops.
  */
 
-public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements RandomAccess, Cloneable, java.io.Serializable {
+public class IMMUTABLE_LIST KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENERIC implements LIST KEY_GENERIC, RandomAccess, Cloneable, java.io.Serializable {
 	private static final long serialVersionUID = 0L;
 	
 	SUPPRESS_WARNINGS_KEY_UNCHECKED_RAWTYPES
@@ -428,7 +428,307 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 	public KEY_SPLITERATOR KEY_GENERIC spliterator() {
 		return new Spliterator();
 	}
+	
+	private final static class ImmutableSubList KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENERIC implements java.util.RandomAccess {
+		final IMMUTABLE_LIST innerList;
+		final int from;
+		final int to;
+		/**
+		 * An alias to {@code innerList}'s array to save some typing. Note that 0 in this array is actually
+		 * the first element of the {@code innerList}, not this sublist. {@code a[from]} is the
+		 * first element of this sublist.
+		 */  
+		private final KEY_GENERIC_TYPE a[];
+		
+		ImmutableSubList(IMMUTABLE_LIST innerList, int from, int to) {
+			this.innerList = innerList;
+			this.from = from;
+			this.to = to;
+			this.a = innerList.a;
+		}
 
+		@Override
+		public KEY_GENERIC_TYPE GET_KEY(final int index) {
+			ensureRestrictedIndex(index);
+			return a[index + from];
+		}
+
+		@Override
+		public int indexOf(final KEY_TYPE k) {
+			for(int i = from; i < to; i++) if (KEY_EQUALS(k, a[i])) return i - from;
+			return -1;
+		}
+
+		@Override
+		public int lastIndexOf(final KEY_TYPE k) {
+			for(int i = to; i-- != from;) if (KEY_EQUALS(k, a[i])) return i - from;
+			return -1;
+		}
+	
+		@Override
+		public int size() {
+			return to - from;
+		}
+	
+		@Override
+		public boolean isEmpty() {
+			return to <= from;
+		}
+
+		@Override
+		public void getElements(final int fromSublistIndex, final KEY_TYPE[] a, final int offset, final int length) {
+			ARRAYS.ensureOffsetLength(a, offset, length);
+			ensureRestrictedIndex(fromSublistIndex);
+			if (from + length > to) {
+				throw new IndexOutOfBoundsException(
+					String.format("Final index: %i (startingIndex: %i + length: %i) is greater then the list's length %i",
+						from + length, from, length, size()));
+			}
+			System.arraycopy(this.a, fromSublistIndex + from, a, offset, length);
+		}
+	
+		@Override
+		public void forEach(final METHOD_ARG_KEY_CONSUMER action) {
+			for (int i = from; i < to; ++i) {
+				action.accept(a[i]);
+			}
+		}
+
+#if KEYS_PRIMITIVE
+		@Override
+		public KEY_TYPE[] TO_KEY_ARRAY() {
+			return java.util.Arrays.copyOfRange(a, from, to); 
+		}
+	
+		@Override
+		public KEY_TYPE[] toArray(KEY_TYPE a[]) {
+			if (a == null || a.length < size()) a = new KEY_TYPE[size()];
+			System.arraycopy(this.a, from, a, 0, size());
+			return a;
+		}
+#else // KEYS_REFERENCE
+		@Override
+		public Object[] toArray() {
+			// A subtle part of the spec says the returned array must be Object[] exactly.
+			return java.util.Arrays.copyOfRange(a, from, to, Object[].class);
+		}
+	
+		SUPPRESS_WARNINGS_KEY_UNCHECKED
+		@Override
+		public KEY_GENERIC KEY_GENERIC_TYPE[] toArray(KEY_GENERIC_TYPE a[]) {
+			final int size = size();
+			if (a == null) {
+				a = KEY_GENERIC_ARRAY_CAST new Object[size];
+			} else if (a.length < size) {
+				a = KEY_GENERIC_ARRAY_CAST Array.newInstance(a.getClass().getComponentType(), size);
+			}
+			System.arraycopy(this.a, from, a, 0, size);
+			if (a.length > size) {
+				a[size] = null;
+			}
+			return a;
+		}
+#endif
+
+		@Override
+		public KEY_LIST_ITERATOR KEY_GENERIC listIterator(final int index) {
+			ensureIndex(index);
+	
+			return new KEY_LIST_ITERATOR KEY_GENERIC() {
+					int pos = index;
+	
+					@Override
+					public boolean hasNext() { return pos < to; }
+					@Override
+					public boolean hasPrevious() { return pos > from; }
+					@Override
+					public KEY_GENERIC_TYPE NEXT_KEY() { if (! hasNext()) throw new NoSuchElementException(); return a[pos++ + from]; }
+					@Override
+					public KEY_GENERIC_TYPE PREV_KEY() { if (! hasPrevious()) throw new NoSuchElementException(); return a[--pos + from]; }
+					@Override
+					public int nextIndex() { return pos; }
+					@Override
+					public int previousIndex() { return pos - 1; }
+					@Override
+					public void forEachRemaining(final METHOD_ARG_KEY_CONSUMER action) {
+						while (pos < to) {
+							action.accept(a[pos++ + from]);
+						}
+					}
+					@Override
+					public void add(KEY_GENERIC_TYPE k) {
+						throw new UnsupportedOperationException();
+					}
+					@Override
+					public void set(KEY_GENERIC_TYPE k) {
+						throw new UnsupportedOperationException();
+					}
+					@Override
+					public void remove() {
+						throw new UnsupportedOperationException();
+					}
+					@Override
+					public int back(int n) {
+						if (n < 0) throw new IllegalArgumentException("Argument must be nonnegative: " + n);
+						final int remaining = to - pos;
+						if (n < remaining) {
+							pos -= n;
+						} else {
+							n = remaining;
+							pos = 0;
+						}
+						return n;
+					}
+					@Override
+					public int skip(int n) {
+						if (n < 0) throw new IllegalArgumentException("Argument must be nonnegative: " + n);
+						final int remaining = to - pos;
+						if (n < remaining) {
+							pos += n;
+						} else {
+							n = remaining;
+							pos = to;
+						}
+						return n;
+					}
+				};
+		}
+
+		private final class SubListSpliterator extends SPLITERATORS.EarlyBindingSizeIndexBasedSpliterator KEY_GENERIC {
+
+			// We are using pos == 0 to be 0 relative to real array 0
+			SubListSpliterator() {
+				super(from, to);
+			}
+
+			/** No validation; callers must validate arguments. */
+			private SubListSpliterator(int pos, int maxPos) {
+				super(pos, maxPos);
+			}
+
+			// Remember, the indexes we are getting is the real array's index, not our sublist relative index.
+	 		@Override
+			protected final KEY_GENERIC_TYPE get(int i) { return a[i]; }
+			@Override
+			protected final SubListSpliterator makeForSplit(int pos, int maxPos) {
+				return new SubListSpliterator(pos, maxPos);
+			}
+			@Override
+			public boolean tryAdvance(final METHOD_ARG_KEY_CONSUMER action) {
+				if (pos >= maxPos) return false;
+				action.accept(a[pos++]);
+				return true;
+			}
+			@Override
+			public void forEachRemaining(final METHOD_ARG_KEY_CONSUMER action) {
+				final int max = maxPos;
+				while(pos < max) {
+					action.accept(a[pos++]);
+				}
+			}
+		}
+
+		@Override
+		public KEY_SPLITERATOR KEY_GENERIC spliterator() {
+			return new SubListSpliterator();
+		}
+
+		boolean contentsEquals(KEY_GENERIC_TYPE[] otherA, int otherAFrom, int otherATo) {
+			if (a == otherA && from == otherAFrom && to == otherATo) {
+				return true;
+			}
+			if (otherATo - otherAFrom != size()) {
+				return false;
+			}
+			int pos = from, otherPos = otherAFrom;
+			// We have already assured that the two ranges are the same size, so we only need to check one bound.
+#if KEY_CLASS_Object
+			while(pos < to) if (!java.util.Objects.equals(a[pos++], otherA[otherPos++])) return false;
+#else
+			// TODO When minimum version of Java becomes Java 9, use the Arrays.equals which takes bounds, which is vectorized.
+			while(pos < to) if (a[pos++] != otherA[otherPos++]) return false;
+#endif
+			return true;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (o == this) return true;
+			if (o == null) return false;
+			if (!(o instanceof java.util.List)) return false;
+			if (o instanceof IMMUTABLE_LIST) {
+				SUPPRESS_WARNINGS_KEY_UNCHECKED
+				IMMUTABLE_LIST KEY_GENERIC other = (IMMUTABLE_LIST KEY_GENERIC) o;
+				return contentsEquals(other.a, 0, other.size());
+			}
+			if (o instanceof ImmutableSubList) {
+				SUPPRESS_WARNINGS_KEY_UNCHECKED
+				ImmutableSubList KEY_GENERIC other = (ImmutableSubList KEY_GENERIC) o;
+				return contentsEquals(other.a, other.from, other.to);
+			}
+			return super.equals(o);
+		}
+
+		int contentsCompareTo(KEY_GENERIC_TYPE[] otherA, int otherAFrom, int otherATo) {
+#if KEYS_PRIMITIVE // Can't make this assumption for reference types in case we have a goofy Comparable that doesn't compare itself equal
+			if (a == otherA && from == otherAFrom && to == otherATo) return 0;
+#endif
+			// TODO When minimum version of Java becomes Java 9, use Arrays.compare, which vectorizes.
+			KEY_GENERIC_TYPE e1, e2;
+			int r, i, j;
+			for(i = from, j = otherAFrom; i < to && i < otherATo; i++, j++) {
+				e1 = a[i];
+				e2 = otherA[j];
+				if ((r = KEY_CMP(e1, e2)) != 0) return r;
+			}
+			return i < otherATo ? -1 : (i < to ? 1 : 0);
+		}
+
+		SUPPRESS_WARNINGS_KEY_UNCHECKED
+		@Override
+		public int compareTo(final java.util.List <? extends KEY_GENERIC_CLASS> l) {
+			if (l instanceof IMMUTABLE_LIST) {
+				SUPPRESS_WARNINGS_KEY_UNCHECKED
+				IMMUTABLE_LIST KEY_GENERIC other = (IMMUTABLE_LIST KEY_GENERIC) l;
+				return contentsCompareTo(other.a, 0, other.size());
+			}
+			if (l instanceof ImmutableSubList) {
+				SUPPRESS_WARNINGS_KEY_UNCHECKED
+				ImmutableSubList KEY_GENERIC other = (ImmutableSubList KEY_GENERIC) l;
+				return contentsCompareTo(other.a, other.from, other.to);
+			}
+			return super.compareTo(l);
+		}
+
+		@Override
+		public LIST KEY_GENERIC subList(int from, int to) {
+			// We don't need to worry about keeping all nested sublists up to date with bounds as we are immutable.
+			// So don't even nest; just return a sublist with the immediate parent of the root list.
+			ensureIndex(from);
+			ensureIndex(to);
+			if (from > to) throw new IllegalArgumentException("Start index (" + from + ") is greater than end index (" + to + ")");
+			return new ImmutableSubList KEY_GENERIC_DIAMOND(innerList, from + this.from, to + this.from);
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * <p>The returned list will be immutable, but is currently not declared to return an
+	 * instance of {@code ImmutableList} due to complications of implementation details.
+	 * This may change in a future version (in other words, do not consider the return type of
+	 * this method to be stable if making a subclass of {@code ImmutableList}).
+	 */
+	@Override
+	public LIST KEY_GENERIC subList(int from, int to) {
+		if (from == 0 && to == size()) return this;
+		ensureIndex(from);
+		ensureIndex(to);
+		if (from > to) throw new IllegalArgumentException("Start index (" + from + ") is greater than end index (" + to + ")");
+		return new ImmutableSubList KEY_GENERIC_DIAMOND(this, from, to);
+	}
+		
+	
 	@Override
 	public IMMUTABLE_LIST KEY_GENERIC clone() {
 		return this;
@@ -444,6 +744,7 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 	 */
 	public boolean equals(final IMMUTABLE_LIST KEY_GENERIC l) {
 		if (l == this) return true;
+		if (a == l.a) return true;
 		int s = size();
 		if (s != l.size()) return false;
 		final KEY_GENERIC_TYPE[] a1 = a;
@@ -451,16 +752,26 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 
 #if KEY_CLASS_Reference
 		while(s-- !=  0) if (a1[s] != a2[s]) return false;
-#else
-		java.util.Arrays.equals(a1, a2);
-#endif
 		return true;
+#else
+		return java.util.Arrays.equals(a1, a2);
+#endif
 	}
 
 	SUPPRESS_WARNINGS_KEY_UNCHECKED
 	@Override
 	public boolean equals(final Object o) {
-		return o instanceof IMMUTABLE_LIST ? equals((IMMUTABLE_LIST KEY_GENERIC) o) : super.equals(o);
+		if (o == this) return true;
+		if (o == null) return false;
+		if (!(o instanceof java.util.List)) return false;
+		if (o instanceof IMMUTABLE_LIST) {
+			return equals((IMMUTABLE_LIST KEY_GENERIC) o);
+		}
+		if (o instanceof ImmutableSubList) {
+			// Sublist has an optimized sub-array based comparison, reuse that. 
+			return ((ImmutableSubList KEY_GENERIC)o).equals(this);
+		}
+		return super.equals(0);
 	}
 
 
@@ -478,6 +789,9 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 	 */
 	SUPPRESS_WARNINGS_KEY_UNCHECKED
 	public int compareTo(final IMMUTABLE_LIST KEY_EXTENDS_GENERIC l) {
+#if KEYS_PRIMITIVE // Can't make this assumption for reference types in case we have a goofy Comparable that doesn't compare itself equal
+		if (a == l.a) return 0;
+#endif
 		// TODO When minimum version of Java becomes Java 9, use Arrays.compare, which vectorizes.
 		final int s1 = size(), s2 = l.size();
 		final KEY_GENERIC_TYPE a1[] = a, a2[] = l.a;
@@ -499,379 +813,6 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 		return l instanceof IMMUTABLE_LIST ? compareTo((IMMUTABLE_LIST KEY_EXTENDS_GENERIC)l) : super.compareTo(l);
 	}
 #endif
-
-	// Overridden mutation methods to make unsupported.
-
-	/**
-	 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public final void add(final int index, final KEY_GENERIC_TYPE k) {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public final boolean add(final KEY_GENERIC_TYPE k) {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public final boolean addAll(final java.util.Collection<? extends KEY_GENERIC_CLASS> c) {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public final boolean addAll(int index, final java.util.Collection<? extends KEY_GENERIC_CLASS> c) {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public final KEY_GENERIC_TYPE REMOVE_KEY(final int index) {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public final boolean REMOVE(final KEY_TYPE k) {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public final boolean removeAll(final java.util.Collection<?> c) {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public final boolean retainAll(final java.util.Collection<?> c) {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public final boolean removeIf(final java.util.function.Predicate<? super KEY_GENERIC_CLASS> c) {
-		throw new UnsupportedOperationException();
-	}
-
-#if KEYS_PRIMITIVE
-	/**
-	 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public final boolean removeIf(final METHOD_ARG_PREDICATE c) {
-		throw new UnsupportedOperationException();
-	}
-#endif
-
-	/**
-	 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public final void replaceAll(final java.util.function.UnaryOperator<KEY_GENERIC_CLASS> operator) {
-		throw new UnsupportedOperationException();
-	}	
-
-#if KEYS_PRIMITIVE && ! KEY_CLASS_Boolean
-	/**
-	 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public final void replaceAll(final JDK_PRIMITIVE_UNARY_OPERATOR operator) {
-		throw new UnsupportedOperationException();
-	}
-#endif
-
-#if KEYS_PRIMITIVE
-	/**
-	 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public final void add(final int index, final KEY_GENERIC_CLASS k) {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public final boolean add(final KEY_GENERIC_CLASS k) {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public final KEY_GENERIC_CLASS remove(final int index) {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public final boolean remove(final Object k) {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public final KEY_GENERIC_CLASS set(final int index, final KEY_GENERIC_CLASS k) {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public final boolean addAll(final COLLECTION c) {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public final boolean addAll(final LIST c) {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public final boolean addAll(final int index, final COLLECTION c) {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public final boolean addAll(final int index, final LIST c) {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public final boolean removeAll(final COLLECTION c) {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public final boolean retainAll(final COLLECTION c) {
-		throw new UnsupportedOperationException();
-	}
-#endif
-
-	/**
-	 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public final KEY_GENERIC_TYPE set(final int index, final KEY_GENERIC_TYPE k) {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public final void clear() {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public final void size(final int size) {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public final void removeElements(final int from, final int to) {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public final void addElements(final int index, final KEY_GENERIC_TYPE a[], final int offset, final int length) {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public final void setElements(final int index, final KEY_GENERIC_TYPE a[], final int offset, final int length) {
-		throw new UnsupportedOperationException();
-	}
-
-#if KEYS_PRIMITIVE
-	/**
-	 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public final void sort(final KEY_COMPARATOR KEY_SUPER_GENERIC comp) {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public final void unstableSort(final KEY_COMPARATOR KEY_SUPER_GENERIC comp) {
-		throw new UnsupportedOperationException();
-	}
-#endif
-
-	/**
-	 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public final void sort(final java.util.Comparator<? super KEY_GENERIC_CLASS> comparator) {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
-	 *
-	 * @deprecated
-	 */
-	@Override
-	@Deprecated
-	public final void unstableSort(final java.util.Comparator<? super KEY_GENERIC_CLASS> comparator) {
-		throw new UnsupportedOperationException();
-	}
 }
 
 #undef _EMPTY_ARRAY

--- a/drv/Lists.drv
+++ b/drv/Lists.drv
@@ -857,8 +857,379 @@ public final class LISTS {
 		return l instanceof RandomAccess ? new UnmodifiableRandomAccessList KEY_GENERIC_DIAMOND(l) : new UnmodifiableList KEY_GENERIC_DIAMOND(l);
 	}
 
-
-
+	/** A stub class making all known mutation methods throw {@link UnsupportedOperationException}. */
+	static abstract class ImmutableListBase KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements LIST KEY_GENERIC {
+		/**
+		 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
+		 *
+		 * @deprecated
+		 */
+		@Override
+		@Deprecated
+		public final void add(final int index, final KEY_GENERIC_TYPE k) {
+			throw new UnsupportedOperationException();
+		}
+	
+		/**
+		 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
+		 *
+		 * @deprecated
+		 */
+		@Override
+		@Deprecated
+		public final boolean add(final KEY_GENERIC_TYPE k) {
+			throw new UnsupportedOperationException();
+		}
+	
+		/**
+		 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
+		 *
+		 * @deprecated
+		 */
+		@Override
+		@Deprecated
+		public final boolean addAll(final java.util.Collection<? extends KEY_GENERIC_CLASS> c) {
+			throw new UnsupportedOperationException();
+		}
+	
+		/**
+		 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
+		 *
+		 * @deprecated
+		 */
+		@Override
+		@Deprecated
+		public final boolean addAll(int index, final java.util.Collection<? extends KEY_GENERIC_CLASS> c) {
+			throw new UnsupportedOperationException();
+		}
+	
+		/**
+		 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
+		 *
+		 * @deprecated
+		 */
+		@Override
+		@Deprecated
+		public final KEY_GENERIC_TYPE REMOVE_KEY(final int index) {
+			throw new UnsupportedOperationException();
+		}
+	
+		/**
+		 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
+		 *
+		 * @deprecated
+		 */
+		@Override
+		@Deprecated
+		public final boolean REMOVE(final KEY_TYPE k) {
+			throw new UnsupportedOperationException();
+		}
+	
+		/**
+		 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
+		 *
+		 * @deprecated
+		 */
+		@Override
+		@Deprecated
+		public final boolean removeAll(final java.util.Collection<?> c) {
+			throw new UnsupportedOperationException();
+		}
+	
+		/**
+		 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
+		 *
+		 * @deprecated
+		 */
+		@Override
+		@Deprecated
+		public final boolean retainAll(final java.util.Collection<?> c) {
+			throw new UnsupportedOperationException();
+		}
+	
+		/**
+		 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
+		 *
+		 * @deprecated
+		 */
+		@Override
+		@Deprecated
+		public final boolean removeIf(final java.util.function.Predicate<? super KEY_GENERIC_CLASS> c) {
+			throw new UnsupportedOperationException();
+		}
+	
+#if KEYS_PRIMITIVE
+		/**
+		 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
+		 *
+		 * @deprecated
+		 */
+		@Override
+		@Deprecated
+		public final boolean removeIf(final METHOD_ARG_PREDICATE c) {
+			throw new UnsupportedOperationException();
+		}
+#endif
+	
+		/**
+		 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
+		 *
+		 * @deprecated
+		 */
+		@Override
+		@Deprecated
+		public final void replaceAll(final java.util.function.UnaryOperator<KEY_GENERIC_CLASS> operator) {
+			throw new UnsupportedOperationException();
+		}	
+	
+#if KEYS_PRIMITIVE && ! KEY_CLASS_Boolean
+		/**
+		 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
+		 *
+		 * @deprecated
+		 */
+		@Override
+		@Deprecated
+		public final void replaceAll(final JDK_PRIMITIVE_UNARY_OPERATOR operator) {
+			throw new UnsupportedOperationException();
+		}
+#endif
+	
+#if KEYS_PRIMITIVE
+		/**
+		 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
+		 *
+		 * @deprecated
+		 */
+		@Override
+		@Deprecated
+		public final void add(final int index, final KEY_GENERIC_CLASS k) {
+			throw new UnsupportedOperationException();
+		}
+	
+		/**
+		 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
+		 *
+		 * @deprecated
+		 */
+		@Override
+		@Deprecated
+		public final boolean add(final KEY_GENERIC_CLASS k) {
+			throw new UnsupportedOperationException();
+		}
+	
+		/**
+		 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
+		 *
+		 * @deprecated
+		 */
+		@Override
+		@Deprecated
+		public final KEY_GENERIC_CLASS remove(final int index) {
+			throw new UnsupportedOperationException();
+		}
+	
+		/**
+		 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
+		 *
+		 * @deprecated
+		 */
+		@Override
+		@Deprecated
+		public final boolean remove(final Object k) {
+			throw new UnsupportedOperationException();
+		}
+	
+		/**
+		 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
+		 *
+		 * @deprecated
+		 */
+		@Override
+		@Deprecated
+		public final KEY_GENERIC_CLASS set(final int index, final KEY_GENERIC_CLASS k) {
+			throw new UnsupportedOperationException();
+		}
+	
+		/**
+		 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
+		 *
+		 * @deprecated
+		 */
+		@Override
+		@Deprecated
+		public final boolean addAll(final COLLECTION c) {
+			throw new UnsupportedOperationException();
+		}
+	
+		/**
+		 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
+		 *
+		 * @deprecated
+		 */
+		@Override
+		@Deprecated
+		public final boolean addAll(final LIST c) {
+			throw new UnsupportedOperationException();
+		}
+	
+		/**
+		 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
+		 *
+		 * @deprecated
+		 */
+		@Override
+		@Deprecated
+		public final boolean addAll(final int index, final COLLECTION c) {
+			throw new UnsupportedOperationException();
+		}
+	
+		/**
+		 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
+		 *
+		 * @deprecated
+		 */
+		@Override
+		@Deprecated
+		public final boolean addAll(final int index, final LIST c) {
+			throw new UnsupportedOperationException();
+		}
+	
+		/**
+		 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
+		 *
+		 * @deprecated
+		 */
+		@Override
+		@Deprecated
+		public final boolean removeAll(final COLLECTION c) {
+			throw new UnsupportedOperationException();
+		}
+	
+		/**
+		 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
+		 *
+		 * @deprecated
+		 */
+		@Override
+		@Deprecated
+		public final boolean retainAll(final COLLECTION c) {
+			throw new UnsupportedOperationException();
+		}
+#endif
+	
+		/**
+		 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
+		 *
+		 * @deprecated
+		 */
+		@Override
+		@Deprecated
+		public final KEY_GENERIC_TYPE set(final int index, final KEY_GENERIC_TYPE k) {
+			throw new UnsupportedOperationException();
+		}
+	
+		/**
+		 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
+		 *
+		 * @deprecated
+		 */
+		@Override
+		@Deprecated
+		public final void clear() {
+			throw new UnsupportedOperationException();
+		}
+	
+		/**
+		 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
+		 *
+		 * @deprecated
+		 */
+		@Override
+		@Deprecated
+		public final void size(final int size) {
+			throw new UnsupportedOperationException();
+		}
+	
+		/**
+		 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
+		 *
+		 * @deprecated
+		 */
+		@Override
+		@Deprecated
+		public final void removeElements(final int from, final int to) {
+			throw new UnsupportedOperationException();
+		}
+	
+		/**
+		 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
+		 *
+		 * @deprecated
+		 */
+		@Override
+		@Deprecated
+		public final void addElements(final int index, final KEY_GENERIC_TYPE a[], final int offset, final int length) {
+			throw new UnsupportedOperationException();
+		}
+	
+		/**
+		 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
+		 *
+		 * @deprecated
+		 */
+		@Override
+		@Deprecated
+		public final void setElements(final int index, final KEY_GENERIC_TYPE a[], final int offset, final int length) {
+			throw new UnsupportedOperationException();
+		}
+	
+#if KEYS_PRIMITIVE
+		/**
+		 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
+		 *
+		 * @deprecated
+		 */
+		@Override
+		@Deprecated
+		public final void sort(final KEY_COMPARATOR KEY_SUPER_GENERIC comp) {
+			throw new UnsupportedOperationException();
+		}
+	
+		/**
+		 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
+		 *
+		 * @deprecated
+		 */
+		@Override
+		@Deprecated
+		public final void unstableSort(final KEY_COMPARATOR KEY_SUPER_GENERIC comp) {
+			throw new UnsupportedOperationException();
+		}
+#endif
+	
+		/**
+		 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
+		 *
+		 * @deprecated
+		 */
+		@Override
+		@Deprecated
+		public final void sort(final java.util.Comparator<? super KEY_GENERIC_CLASS> comparator) {
+			throw new UnsupportedOperationException();
+		}
+	
+		/**
+		 * @implSpec Always throws {@link UnsupportedOperationException} as this is an immutable type.
+		 *
+		 * @deprecated
+		 */
+		@Override
+		@Deprecated
+		public final void unstableSort(final java.util.Comparator<? super KEY_GENERIC_CLASS> comparator) {
+			throw new UnsupportedOperationException();
+		}
+	}
 
 #ifdef TEST
 

--- a/test/it/unimi/dsi/fastutil/ints/IntArrayListTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntArrayListTest.java
@@ -18,6 +18,7 @@ package it.unimi.dsi.fastutil.ints;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -28,6 +29,7 @@ import org.junit.Test;
 
 import it.unimi.dsi.fastutil.MainRunner;
 
+@SuppressWarnings("static-method")
 public class IntArrayListTest {
 
 	@SuppressWarnings("unlikely-arg-type")
@@ -250,6 +252,75 @@ public class IntArrayListTest {
 	}
 
 	@Test
+	public void testEquals_AnotherArrayList() {
+		final IntArrayList baseList = IntArrayList.of(2, 380, 1297);
+		assertEquals(IntArrayList.of(2, 380, 1297), baseList);
+		assertNotEquals(IntArrayList.of(42, 420, 1337), baseList);
+	}
+
+	@Test
+	public void testEquals_Sublist() {
+		final IntArrayList l1 = IntArrayList.of(0, 1, 2, 3);
+		final IntArrayList l2 = IntArrayList.of(5, 0, 1, 2, 3, 4);
+		final IntList sl2 = l2.subList(1, 5); // 0, 1, 2, 3
+		assertEquals(l1, sl2);
+		final IntList sl2b = l2.subList(0, 4); // 5, 0, 1, 2
+		assertNotEquals(l1, sl2b);
+	}
+
+	@Test
+	public void testEquals_OtherListImpl() {
+		final IntArrayList baseList = IntArrayList.of(2, 380, 1297);
+		assertEquals(IntImmutableList.of(2, 380, 1297), baseList);
+		assertNotEquals(IntImmutableList.of(42, 420, 1337), baseList);
+	}
+
+	@Test
+	public void testCompareTo_AnotherArrayList() {
+		final IntArrayList baseList = IntArrayList.of(2, 380, 1297);
+		final IntArrayList lessThenList = IntArrayList.of(2, 365, 1297);
+		final IntArrayList greaterThenList = IntArrayList.of(2, 380, 1300);
+		final IntArrayList lessBecauseItIsSmaller = IntArrayList.of(2, 380);
+		final IntArrayList greaterBecauseItIsLarger = IntArrayList.of(2, 380, 1297, 1);
+		final IntArrayList equalList = IntArrayList.of(2, 380, 1297);
+		assertTrue(baseList.compareTo(lessThenList) > 0);
+		assertTrue(baseList.compareTo(greaterThenList) < 0);
+		assertTrue(baseList.compareTo(lessBecauseItIsSmaller) > 0);
+		assertTrue(baseList.compareTo(greaterBecauseItIsLarger) < 0);
+		assertTrue(baseList.compareTo(equalList) == 0);
+	}
+
+	@Test
+	public void testCompareTo_Sublist() {
+		final IntArrayList baseList = IntArrayList.of(2, 380, 1297);
+		final IntList lessThenList = IntArrayList.of(2, 365, 1297, 1).subList(0, 3);
+		final IntList greaterThenList = IntArrayList.of(2, 380, 1300, 1).subList(0, 3);
+		final IntList lessBecauseItIsSmaller = IntArrayList.of(2, 380, 1).subList(0, 2);
+		final IntList greaterBecauseItIsLarger = IntArrayList.of(2, 380, 1297, 1, 1).subList(0, 4);
+		final IntList equalList = IntArrayList.of(2, 380, 1297, 1).subList(0, 3);
+		assertTrue(baseList.compareTo(lessThenList) > 0);
+		assertTrue(baseList.compareTo(greaterThenList) < 0);
+		assertTrue(baseList.compareTo(lessBecauseItIsSmaller) > 0);
+		assertTrue(baseList.compareTo(greaterBecauseItIsLarger) < 0);
+		assertTrue(baseList.compareTo(equalList) == 0);
+	}
+
+	@Test
+	public void testCompareTo_OtherListImpl() {
+		final IntArrayList baseList = IntArrayList.of(2, 380, 1297);
+		final IntImmutableList lessThenList = IntImmutableList.of(2, 365, 1297);
+		final IntImmutableList greaterThenList = IntImmutableList.of(2, 380, 1300);
+		final IntImmutableList lessBecauseItIsSmaller = IntImmutableList.of(2, 380);
+		final IntImmutableList greaterBecauseItIsLarger = IntImmutableList.of(2, 380, 1297, 1);
+		final IntImmutableList equalList = IntImmutableList.of(2, 380, 1297);
+		assertTrue(baseList.compareTo(lessThenList) > 0);
+		assertTrue(baseList.compareTo(greaterThenList) < 0);
+		assertTrue(baseList.compareTo(lessBecauseItIsSmaller) > 0);
+		assertTrue(baseList.compareTo(greaterBecauseItIsLarger) < 0);
+		assertTrue(baseList.compareTo(equalList) == 0);
+	}
+
+	@Test
 	public void testForEach() {
 		final IntArrayList l = IntArrayList.of(1,2,3,4,5,6);
 		// A hack-ish loop testing forEach, in real code you would use intStream to compute the sum.
@@ -388,6 +459,101 @@ public class IntArrayListTest {
 		assertEquals(1, spliterator.skip(1));
 		final java.util.stream.IntStream stream = java.util.stream.StreamSupport.intStream(spliterator, false);
 		assertEquals(baseList.subList(1, baseList.size()), IntArrayList.toList(stream));
+	}
+
+	@Test
+	public void testSubList_testEquals_ArrayList() {
+		final IntArrayList l = IntArrayList.of(0, 1, 2, 3);
+		final IntList sl = l.subList(0, 3);
+		assertEquals(IntArrayList.of(0, 1, 2), sl);
+		assertNotEquals(IntArrayList.of(0, 1, 3), sl);
+	}
+
+	@Test
+	public void testSubList_testEquals_Sublist() {
+		final IntArrayList l1 = IntArrayList.of(0, 1, 2, 3);
+		final IntArrayList l2 = IntArrayList.of(5, 0, 1, 2, 3, 4);
+		final IntList sl1 = l1.subList(0, 3); // 0, 1, 2
+		final IntList sl2 = l2.subList(1, 4); // 0, 1, 2
+		assertEquals(sl1, sl2);
+		final IntList sl3 = l2.subList(0, 3); // 5, 0, 1
+		assertNotEquals(sl1, sl3);
+	}
+
+	@Test
+	public void testSubList_testEquals_OtherListImpl() {
+		final IntArrayList l = IntArrayList.of(0, 1, 2, 3);
+		final IntList sl = l.subList(0, 3);
+		assertEquals(IntImmutableList.of(0, 1, 2), sl);
+		assertNotEquals(IntImmutableList.of(0, 1, 3), sl);
+	}
+
+	@Test
+	public void testSubList_testCompareTo_ArrayList() {
+		final IntList baseList = IntArrayList.of(2, 380, 1297, 1).subList(0, 3);
+		final IntArrayList lessThenList = IntArrayList.of(2, 365, 1297);
+		final IntArrayList greaterThenList = IntArrayList.of(2, 380, 1300);
+		final IntArrayList lessBecauseItIsSmaller = IntArrayList.of(2, 380);
+		final IntArrayList greaterBecauseItIsLarger = IntArrayList.of(2, 380, 1297, 1);
+		final IntArrayList equalList = IntArrayList.of(2, 380, 1297);
+		assertTrue(baseList.compareTo(lessThenList) > 0);
+		assertTrue(baseList.compareTo(greaterThenList) < 0);
+		assertTrue(baseList.compareTo(lessBecauseItIsSmaller) > 0);
+		assertTrue(baseList.compareTo(greaterBecauseItIsLarger) < 0);
+		assertTrue(baseList.compareTo(equalList) == 0);
+	}
+
+	@Test
+	public void testSubList_testCompareTo_Sublist() {
+		final IntList baseList = IntArrayList.of(2, 380, 1297, 1).subList(0, 3);
+		final IntList lessThenList = IntArrayList.of(2, 365, 1297, 1).subList(0, 3);
+		final IntList greaterThenList = IntArrayList.of(2, 380, 1300, 1).subList(0, 3);
+		final IntList lessBecauseItIsSmaller = IntArrayList.of(2, 380, 1).subList(0, 2);
+		final IntList greaterBecauseItIsLarger = IntArrayList.of(2, 380, 1297, 1, 1).subList(0, 4);
+		final IntList equalList = IntArrayList.of(2, 380, 1297, 1).subList(0, 3);
+		assertTrue(baseList.compareTo(lessThenList) > 0);
+		assertTrue(baseList.compareTo(greaterThenList) < 0);
+		assertTrue(baseList.compareTo(lessBecauseItIsSmaller) > 0);
+		assertTrue(baseList.compareTo(greaterBecauseItIsLarger) < 0);
+		assertTrue(baseList.compareTo(equalList) == 0);
+	}
+
+	@Test
+	public void testSubList_testCompareTo_OtherListImpl() {
+		final IntList baseList = IntArrayList.of(2, 380, 1297, 1).subList(0, 3);
+		final IntImmutableList lessThenList = IntImmutableList.of(2, 365, 1297);
+		final IntImmutableList greaterThenList = IntImmutableList.of(2, 380, 1300);
+		final IntImmutableList lessBecauseItIsSmaller = IntImmutableList.of(2, 380);
+		final IntImmutableList greaterBecauseItIsLarger = IntImmutableList.of(2, 380, 1297, 1);
+		final IntImmutableList equalList = IntImmutableList.of(2, 380, 1297);
+		assertTrue(baseList.compareTo(lessThenList) > 0);
+		assertTrue(baseList.compareTo(greaterThenList) < 0);
+		assertTrue(baseList.compareTo(lessBecauseItIsSmaller) > 0);
+		assertTrue(baseList.compareTo(greaterBecauseItIsLarger) < 0);
+		assertTrue(baseList.compareTo(equalList) == 0);
+	}
+
+	@Test
+	public void testSubList_testSpliteratorTrySplit() {
+		final IntList baseList = IntArrayList.of(0, 1, 2, 3, 72, 5, 6).subList(1, 5); // 1, 2, 3, 72
+		final IntSpliterator willBeSuffix = baseList.spliterator();
+		assertEquals(baseList.size(), willBeSuffix.getExactSizeIfKnown());
+		// Rather non-intuitively for finite sequences (but makes perfect sense for infinite ones),
+		// the spec demands the original spliterator becomes the suffix and the new Spliterator becomes the prefix.
+		final IntSpliterator prefix = willBeSuffix.trySplit();
+		// No assurance of where we split, but where ever it is it should be a perfect split into a prefix and suffix.
+		final java.util.stream.IntStream suffixStream = java.util.stream.StreamSupport.intStream(willBeSuffix, false);
+		final java.util.stream.IntStream prefixStream = java.util.stream.StreamSupport.intStream(prefix, false);
+
+		final IntArrayList prefixList = IntArrayList.toList(prefixStream);
+		final IntArrayList suffixList = IntArrayList.toList(suffixStream);
+		assertEquals(baseList.size(), prefixList.size() + suffixList.size());
+		assertEquals(baseList.subList(0, prefixList.size()), prefixList);
+		assertEquals(baseList.subList(prefixList.size(), baseList.size()), suffixList);
+		final IntArrayList recombinedList = new IntArrayList(baseList.size());
+		recombinedList.addAll(prefixList);
+		recombinedList.addAll(suffixList);
+		assertEquals(baseList, recombinedList);
 	}
 
 	@Test

--- a/test/it/unimi/dsi/fastutil/ints/IntImmutableListTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntImmutableListTest.java
@@ -18,11 +18,13 @@ package it.unimi.dsi.fastutil.ints;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+@SuppressWarnings("static-method")
 public class IntImmutableListTest {
 
 	@SuppressWarnings("unlikely-arg-type")
@@ -77,6 +79,14 @@ public class IntImmutableListTest {
 	}
 
 	@Test
+	public void testEquals_Sublist() {
+		final IntImmutableList l1 = IntImmutableList.of(0, 1, 2, 3);
+		final IntImmutableList l2 = IntImmutableList.of(5, 0, 1, 2, 3, 4);
+		final IntList sl2 = l2.subList(1, 5);
+		assertEquals(l1, sl2);
+	}
+
+	@Test
 	public void testEquals_OtherListImpl() {
 		final IntImmutableList baseList = IntImmutableList.of(2, 380, 1297);
 		assertEquals(IntArrayList.of(2, 380, 1297), baseList);
@@ -86,6 +96,72 @@ public class IntImmutableListTest {
 	@Test
 	public void testSpliteratorTrySplit() {
 		final IntImmutableList baseList = IntImmutableList.of(0, 1, 2, 3, 72, 5, 6);
+		final IntSpliterator willBeSuffix = baseList.spliterator();
+		assertEquals(baseList.size(), willBeSuffix.getExactSizeIfKnown());
+		// Rather non-intuitively for finite sequences (but makes perfect sense for infinite ones),
+		// the spec demands the original spliterator becomes the suffix and the new Spliterator becomes the prefix.
+		final IntSpliterator prefix = willBeSuffix.trySplit();
+		// No assurance of where we split, but where ever it is it should be a perfect split into a prefix and suffix.
+		final java.util.stream.IntStream suffixStream = java.util.stream.StreamSupport.intStream(willBeSuffix, false);
+		final java.util.stream.IntStream prefixStream = java.util.stream.StreamSupport.intStream(prefix, false);
+
+		final IntImmutableList prefixList = IntImmutableList.toList(prefixStream);
+		final IntImmutableList suffixList = IntImmutableList.toList(suffixStream);
+		assertEquals(baseList.size(), prefixList.size() + suffixList.size());
+		assertEquals(baseList.subList(0, prefixList.size()), prefixList);
+		assertEquals(baseList.subList(prefixList.size(), baseList.size()), suffixList);
+		final IntArrayList recombinedList = new IntArrayList(baseList.size());
+		recombinedList.addAll(prefixList);
+		recombinedList.addAll(suffixList);
+		assertEquals(baseList, recombinedList);
+	}
+
+	@Test
+	public void testSubList_testEquals_ImmutableList() {
+		final IntImmutableList l = IntImmutableList.of(0, 1, 2, 3);
+		final IntList sl = l.subList(0, 3);
+		assertEquals(IntImmutableList.of(0, 1, 2), sl);
+		assertNotEquals(IntImmutableList.of(0, 1, 3), sl);
+	}
+
+	@Test
+	public void testSubList_testEquals_Sublist() {
+		final IntImmutableList l1 = IntImmutableList.of(0, 1, 2, 3);
+		final IntImmutableList l2 = IntImmutableList.of(5, 0, 1, 2, 3, 4);
+		final IntList sl1 = l1.subList(0, 3);
+		final IntList sl2 = l2.subList(1, 4);
+		assertEquals(sl1, sl2);
+		final IntList sl3 = l2.subList(0, 3);
+		assertNotEquals(sl1, sl3);
+	}
+
+	@Test
+	public void testSubList_testEquals_OtherListImpl() {
+		final IntImmutableList l = IntImmutableList.of(0, 1, 2, 3);
+		final IntList sl = l.subList(0, 3);
+		assertEquals(IntArrayList.of(0, 1, 2), sl);
+		assertNotEquals(IntArrayList.of(0, 1, 3), sl);
+	}
+
+	@Test
+	public void testSubList_testToArray() {
+		final IntImmutableList l = IntImmutableList.of(0, 1, 2, 3);
+		final IntList sl = l.subList(0, 3);
+		assertArrayEquals(new int[] { 0, 1, 2 }, sl.toIntArray());
+	}
+	
+	@Test
+	public void testSubList_testSubSubList() {
+		final IntImmutableList l = IntImmutableList.of(0, 1, 2, 3, 4);
+		final IntList sl = l.subList(1, 4);
+		final IntList ssl = sl.subList(1, 2);
+		assertEquals(IntImmutableList.of(1, 2, 3), sl);
+		assertEquals(IntImmutableList.of(2), ssl);
+	}
+
+	@Test
+	public void testSubList_testSpliteratorTrySplit() {
+		final IntList baseList = IntImmutableList.of(0, 1, 2, 3, 72, 5, 6).subList(1, 5); // 1, 2, 3, 72
 		final IntSpliterator willBeSuffix = baseList.spliterator();
 		assertEquals(baseList.size(), willBeSuffix.getExactSizeIfKnown());
 		// Rather non-intuitively for finite sequences (but makes perfect sense for infinite ones),

--- a/test/it/unimi/dsi/fastutil/ints/IntImmutableListTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntImmutableListTest.java
@@ -82,8 +82,10 @@ public class IntImmutableListTest {
 	public void testEquals_Sublist() {
 		final IntImmutableList l1 = IntImmutableList.of(0, 1, 2, 3);
 		final IntImmutableList l2 = IntImmutableList.of(5, 0, 1, 2, 3, 4);
-		final IntList sl2 = l2.subList(1, 5);
+		final IntList sl2 = l2.subList(1, 5); // 0, 1, 2, 3
 		assertEquals(l1, sl2);
+		final IntList sl2b = l2.subList(0, 4); // 5, 0, 1, 2
+		assertNotEquals(l1, sl2b);
 	}
 
 	@Test
@@ -91,6 +93,51 @@ public class IntImmutableListTest {
 		final IntImmutableList baseList = IntImmutableList.of(2, 380, 1297);
 		assertEquals(IntArrayList.of(2, 380, 1297), baseList);
 		assertNotEquals(IntArrayList.of(42, 420, 1337), baseList);
+	}
+
+	@Test
+	public void testCompareTo_AnotherImmutableList() {
+		final IntImmutableList baseList = IntImmutableList.of(2, 380, 1297);
+		final IntImmutableList lessThenList = IntImmutableList.of(2, 365, 1297);
+		final IntImmutableList greaterThenList = IntImmutableList.of(2, 380, 1300);
+		final IntImmutableList lessBecauseItIsSmaller = IntImmutableList.of(2, 380);
+		final IntImmutableList greaterBecauseItIsLarger = IntImmutableList.of(2, 380, 1297, 1);
+		final IntImmutableList equalList = IntImmutableList.of(2, 380, 1297);
+		assertTrue(baseList.compareTo(lessThenList) > 0);
+		assertTrue(baseList.compareTo(greaterThenList) < 0);
+		assertTrue(baseList.compareTo(lessBecauseItIsSmaller) > 0);
+		assertTrue(baseList.compareTo(greaterBecauseItIsLarger) < 0);
+		assertTrue(baseList.compareTo(equalList) == 0);
+	}
+
+	@Test
+	public void testCompareTo_Sublist() {
+		final IntImmutableList baseList = IntImmutableList.of(2, 380, 1297);
+		final IntList lessThenList = IntImmutableList.of(2, 365, 1297, 1).subList(0, 3);
+		final IntList greaterThenList = IntImmutableList.of(2, 380, 1300, 1).subList(0, 3);
+		final IntList lessBecauseItIsSmaller = IntImmutableList.of(2, 380, 1).subList(0, 2);
+		final IntList greaterBecauseItIsLarger = IntImmutableList.of(2, 380, 1297, 1, 1).subList(0, 4);
+		final IntList equalList = IntImmutableList.of(2, 380, 1297, 1).subList(0, 3);
+		assertTrue(baseList.compareTo(lessThenList) > 0);
+		assertTrue(baseList.compareTo(greaterThenList) < 0);
+		assertTrue(baseList.compareTo(lessBecauseItIsSmaller) > 0);
+		assertTrue(baseList.compareTo(greaterBecauseItIsLarger) < 0);
+		assertTrue(baseList.compareTo(equalList) == 0);
+	}
+
+	@Test
+	public void testCompareTo_OtherListImpl() {
+		final IntImmutableList baseList = IntImmutableList.of(2, 380, 1297);
+		final IntArrayList lessThenList = IntArrayList.of(2, 365, 1297);
+		final IntArrayList greaterThenList = IntArrayList.of(2, 380, 1300);
+		final IntArrayList lessBecauseItIsSmaller = IntArrayList.of(2, 380);
+		final IntArrayList greaterBecauseItIsLarger = IntArrayList.of(2, 380, 1297, 1);
+		final IntArrayList equalList = IntArrayList.of(2, 380, 1297);
+		assertTrue(baseList.compareTo(lessThenList) > 0);
+		assertTrue(baseList.compareTo(greaterThenList) < 0);
+		assertTrue(baseList.compareTo(lessBecauseItIsSmaller) > 0);
+		assertTrue(baseList.compareTo(greaterBecauseItIsLarger) < 0);
+		assertTrue(baseList.compareTo(equalList) == 0);
 	}
 
 	@Test
@@ -128,10 +175,10 @@ public class IntImmutableListTest {
 	public void testSubList_testEquals_Sublist() {
 		final IntImmutableList l1 = IntImmutableList.of(0, 1, 2, 3);
 		final IntImmutableList l2 = IntImmutableList.of(5, 0, 1, 2, 3, 4);
-		final IntList sl1 = l1.subList(0, 3);
-		final IntList sl2 = l2.subList(1, 4);
+		final IntList sl1 = l1.subList(0, 3); // 0, 1, 2
+		final IntList sl2 = l2.subList(1, 4); // 0, 1, 2
 		assertEquals(sl1, sl2);
-		final IntList sl3 = l2.subList(0, 3);
+		final IntList sl3 = l2.subList(0, 3); // 5, 0, 1
 		assertNotEquals(sl1, sl3);
 	}
 
@@ -180,5 +227,50 @@ public class IntImmutableListTest {
 		recombinedList.addAll(prefixList);
 		recombinedList.addAll(suffixList);
 		assertEquals(baseList, recombinedList);
+	}
+
+	@Test
+	public void testSubList_testCompareTo_ImmutableList() {
+		final IntList baseList = IntImmutableList.of(2, 380, 1297, 1).subList(0, 3);
+		final IntImmutableList lessThenList = IntImmutableList.of(2, 365, 1297);
+		final IntImmutableList greaterThenList = IntImmutableList.of(2, 380, 1300);
+		final IntImmutableList lessBecauseItIsSmaller = IntImmutableList.of(2, 380);
+		final IntImmutableList greaterBecauseItIsLarger = IntImmutableList.of(2, 380, 1297, 1);
+		final IntImmutableList equalList = IntImmutableList.of(2, 380, 1297);
+		assertTrue(baseList.compareTo(lessThenList) > 0);
+		assertTrue(baseList.compareTo(greaterThenList) < 0);
+		assertTrue(baseList.compareTo(lessBecauseItIsSmaller) > 0);
+		assertTrue(baseList.compareTo(greaterBecauseItIsLarger) < 0);
+		assertTrue(baseList.compareTo(equalList) == 0);
+	}
+
+	@Test
+	public void testSubList_testCompareTo_Sublist() {
+		final IntList baseList = IntImmutableList.of(2, 380, 1297, 1).subList(0, 3);
+		final IntList lessThenList = IntImmutableList.of(2, 365, 1297, 1).subList(0, 3);
+		final IntList greaterThenList = IntImmutableList.of(2, 380, 1300, 1).subList(0, 3);
+		final IntList lessBecauseItIsSmaller = IntImmutableList.of(2, 380, 1).subList(0, 2);
+		final IntList greaterBecauseItIsLarger = IntImmutableList.of(2, 380, 1297, 1, 1).subList(0, 4);
+		final IntList equalList = IntImmutableList.of(2, 380, 1297, 1).subList(0, 3);
+		assertTrue(baseList.compareTo(lessThenList) > 0);
+		assertTrue(baseList.compareTo(greaterThenList) < 0);
+		assertTrue(baseList.compareTo(lessBecauseItIsSmaller) > 0);
+		assertTrue(baseList.compareTo(greaterBecauseItIsLarger) < 0);
+		assertTrue(baseList.compareTo(equalList) == 0);
+	}
+
+	@Test
+	public void testSubList_testCompareTo_OtherListImpl() {
+		final IntList baseList = IntImmutableList.of(2, 380, 1297, 1).subList(0, 3);
+		final IntArrayList lessThenList = IntArrayList.of(2, 365, 1297);
+		final IntArrayList greaterThenList = IntArrayList.of(2, 380, 1300);
+		final IntArrayList lessBecauseItIsSmaller = IntArrayList.of(2, 380);
+		final IntArrayList greaterBecauseItIsLarger = IntArrayList.of(2, 380, 1297, 1);
+		final IntArrayList equalList = IntArrayList.of(2, 380, 1297);
+		assertTrue(baseList.compareTo(lessThenList) > 0);
+		assertTrue(baseList.compareTo(greaterThenList) < 0);
+		assertTrue(baseList.compareTo(lessBecauseItIsSmaller) > 0);
+		assertTrue(baseList.compareTo(greaterBecauseItIsLarger) < 0);
+		assertTrue(baseList.compareTo(equalList) == 0);
 	}
 }


### PR DESCRIPTION
Add a fast `subList` for `ImmutableList`.

Currently `ImmutableList.subList` doesn't return an `ImmutableList` itself due to the current implementation of `ImmutableList` being closely tied to the idea the full array is the whole list. This may change in a future release.
Fixes https://github.com/vigna/fastutil/issues/223

Also applies some of the optimizations conceived for `ImmutableList.subList` to `ArrayList.subList`