### PR TITLE
Replace KEY_CLASS_Reference with KEYS_USE_REFERENCE_EQUALITY

### DIFF
--- a/drv/AVLTreeMap.drv
+++ b/drv/AVLTreeMap.drv
@@ -1942,7 +1942,7 @@ public class AVL_TREE_MAP KEY_VALUE_GENERIC extends ABSTRACT_SORTED_MAP  KEY_VAL
 		return (VALUE_TYPE)(r.nextInt());
 #elif VALUES_PRIMITIVE
 		return r.NEXT_VALUE();
-#elif !VALUE_CLASS_Reference || KEY_CLASS_Reference
+#elif !VALUES_USE_REFERENCE_EQUALITY || KEYS_USE_REFERENCE_EQUALITY
 		return Integer.toBinaryString(r.nextInt());
 #else
 		return new java.io.Serializable() {};
@@ -2454,7 +2454,7 @@ public class AVL_TREE_MAP KEY_VALUE_GENERIC extends ABSTRACT_SORTED_MAP  KEY_VAL
 			ff.delete();
 		}
 
-#if !VALUE_CLASS_Reference
+#if !VALUES_USE_REFERENCE_EQUALITY
 		ensure(m2.hashCode() == h, "Error (" + level + ", " + seed + "): hashCode() changed after save/read");
 
 		/* Now we check that m2 actually holds that data. */

--- a/drv/AbstractBigList.drv
+++ b/drv/AbstractBigList.drv
@@ -388,7 +388,7 @@ public abstract class ABSTRACT_BIG_LIST KEY_GENERIC extends ABSTRACT_COLLECTION 
 
 		final BigListIterator<?> i1 = listIterator(), i2 = l.listIterator();
 
-#if KEY_CLASS_Reference
+#if KEYS_USE_REFERENCE_EQUALITY
 		while(s-- !=  0) if (i1.next() != i2.next()) return false;
 #else
 		while(s-- !=  0) if (! java.util.Objects.equals(i1.next(), i2.next())) return false;
@@ -396,7 +396,7 @@ public abstract class ABSTRACT_BIG_LIST KEY_GENERIC extends ABSTRACT_COLLECTION 
 		return true;
 	}
 
-#if ! KEY_CLASS_Reference
+#if ! KEYS_USE_REFERENCE_EQUALITY
 	/** Compares this big list to another object. If the
 	 * argument is a {@link BigList}, this method performs a lexicographical comparison; otherwise,
 	 * it throws a {@code ClassCastException}.

--- a/drv/AbstractList.drv
+++ b/drv/AbstractList.drv
@@ -396,7 +396,7 @@ public abstract class ABSTRACT_LIST KEY_GENERIC extends ABSTRACT_COLLECTION KEY_
 
 		final ListIterator<?> i1 = listIterator(), i2 = l.listIterator();
 
-#if KEY_CLASS_Reference
+#if KEYS_USE_REFERENCE_EQUALITY
 		while(s-- !=  0) if (i1.next() != i2.next()) return false;
 #else
 		while(s-- !=  0) if (! java.util.Objects.equals(i1.next(), i2.next())) return false;
@@ -404,7 +404,7 @@ public abstract class ABSTRACT_LIST KEY_GENERIC extends ABSTRACT_COLLECTION KEY_
 		return true;
 	}
 
-#if ! KEY_CLASS_Reference
+#if ! KEYS_USE_REFERENCE_EQUALITY
 	/** Compares this list to another object. If the
 	 * argument is a {@link java.util.List}, this method performs a lexicographical comparison; otherwise,
 	 * it throws a {@code ClassCastException}.

--- a/drv/ArrayList.drv
+++ b/drv/ArrayList.drv
@@ -1091,7 +1091,7 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 		return o instanceof ARRAY_LIST ? equals((ARRAY_LIST KEY_GENERIC)o) : super.equals(o);
 	}
 
-#if ! KEY_CLASS_Reference
+#if ! KEYS_USE_REFERENCE_EQUALITY
 
 	/** Compares this array list to another array list.
 	 *
@@ -1779,7 +1779,7 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 			ff.delete();
 		}
 
-#if ! KEY_CLASS_Reference
+#if ! KEYS_USE_REFERENCE_EQUALITY
 		ensure(m2.hashCode() == h, "Error (" + level + ", " + seed + "): hashCode() changed after save/read");
 
 		/* Now we check that m2 actually holds that data. */

--- a/drv/BigArrayBigList.drv
+++ b/drv/BigArrayBigList.drv
@@ -1026,7 +1026,7 @@ public class BIG_ARRAY_BIG_LIST KEY_GENERIC extends ABSTRACT_BIG_LIST KEY_GENERI
 		return o instanceof BIG_ARRAY_BIG_LIST ? equals((BIG_ARRAY_BIG_LIST KEY_GENERIC)o) : super.equals(o);
 	}
 
-#if ! KEY_CLASS_Reference
+#if ! KEYS_USE_REFERENCE_EQUALITY
 
 	/** Compares this big list to another big list.
 	 *
@@ -1452,7 +1452,7 @@ public class BIG_ARRAY_BIG_LIST KEY_GENERIC extends ABSTRACT_BIG_LIST KEY_GENERI
 			ff.delete();
 		}
 
-#if ! KEY_CLASS_Reference
+#if ! KEYS_USE_REFERENCE_EQUALITY
 		ensure(m2.hashCode() == h, "Error (" + level + ", " + seed + "): hashCode() changed after save/read");
 
 		/* Now we check that m2 actually holds that data. */

--- a/drv/BigList.drv
+++ b/drv/BigList.drv
@@ -24,11 +24,10 @@ import it.unimi.dsi.fastutil.BigArrays;
 import it.unimi.dsi.fastutil.BigList;
 import it.unimi.dsi.fastutil.Size64;
 
-#if ! KEY_CLASS_Reference
-
+#if ! KEYS_USE_REFERENCE_EQUALITY
 /** A type-specific {@link BigList}; provides some additional methods that use polymorphism to avoid (un)boxing.
  *
- * Additionally, this interface strengthens {@link #iterator()}, {@link #listIterator()},
+ * <p>Additionally, this interface strengthens {@link #iterator()}, {@link #listIterator()},
  * {@link #listIterator(long)} and {@link #subList(long,long)}.
  *
  * <p>Besides polymorphic methods, this interfaces specifies methods to copy into an array or remove contiguous
@@ -37,14 +36,19 @@ import it.unimi.dsi.fastutil.Size64;
  *
  * @see List
  */
-
 public interface BIG_LIST KEY_GENERIC extends BigList<KEY_GENERIC_CLASS>, COLLECTION KEY_GENERIC, Size64, Comparable<BigList<? extends KEY_GENERIC_CLASS>> {
 #else
-
 /** A type-specific {@link BigList}; provides some additional methods that use polymorphism to avoid (un)boxing.
  *
- * <p>Additionally, this interface strengthens {@link #listIterator()},
+ * <p>Additionally, this interface strengthens {@link #iterator()}, {@link #listIterator()},
  * {@link #listIterator(long)} and {@link #subList(long,long)}.
+ *
+ * <p>This interface specifies reference equality semantics (members will be compared equal with
+ * {@code ==} instead of {@link Object#equals(Object) equals}), which may result in breaks in contract
+ * if attempted to be used with non reference-equality semantics based {@link BigList}s. For example, a
+ * {@code aReferenceBigList.equals(aObjectBigList)} may return different a different result then
+ * {@code aObjectBigList.equals(aReferenceBigList)}, in violation of {@link Object#equals equals}'s contract
+ * requiring it being symmetric.
  *
  * <p>Besides polymorphic methods, this interfaces specifies methods to copy into an array or remove contiguous
  * sublists. Although the abstract implementation of this interface provides simple, one-by-one implementations
@@ -52,7 +56,6 @@ public interface BIG_LIST KEY_GENERIC extends BigList<KEY_GENERIC_CLASS>, COLLEC
  *
  * @see List
  */
-
 public interface BIG_LIST KEY_GENERIC extends BigList<KEY_GENERIC_CLASS>, COLLECTION KEY_GENERIC, Size64 {
 #endif
 

--- a/drv/BigLists.drv
+++ b/drv/BigLists.drv
@@ -179,7 +179,7 @@ public final class BIG_LISTS {
 		@Override
 		public long size64() { return 0; }
 
-#if ! KEY_CLASS_Reference
+#if ! KEYS_USE_REFERENCE_EQUALITY
 		@Override
 		public int compareTo(final BigList<? extends KEY_GENERIC_CLASS> o) {
 			if (o == this) return 0;
@@ -426,7 +426,7 @@ public final class BIG_LISTS {
 		@Override
 		public int hashCode() { synchronized(sync) { return list.hashCode(); } }
 
-#if ! KEY_CLASS_Reference
+#if ! KEYS_USE_REFERENCE_EQUALITY
 		@Override
 		public int compareTo(final BigList<? extends KEY_GENERIC_CLASS> o) { synchronized(sync) { return list.compareTo(o); } }
 #endif
@@ -574,7 +574,7 @@ public final class BIG_LISTS {
 		@Override
 		public int hashCode() { return list.hashCode(); }
 
-#if ! KEY_CLASS_Reference
+#if ! KEYS_USE_REFERENCE_EQUALITY
 		@Override
 		public int compareTo(final BigList<? extends KEY_GENERIC_CLASS> o) { return list.compareTo(o); }
 #endif
@@ -1128,7 +1128,7 @@ public final class BIG_LISTS {
 			ff.delete();
 		}
 
-#if ! KEY_CLASS_Reference
+#if ! KEYS_USE_REFERENCE_EQUALITY
 
 		ensure(m2.hashCode() == h, "Error (" + level + ", " + seed + "): hashCode() changed after save/read");
 

--- a/drv/Collection.drv
+++ b/drv/Collection.drv
@@ -24,6 +24,7 @@ import WIDENED_PACKAGE.KEY_WIDENED_ITERATOR;
 import WIDENED_PACKAGE.KEY_WIDENED_SPLITERATOR;
 #endif
 
+#if KEYS_USE_REFERENCE_EQUALITY
 /** A type-specific {@link Collection}; provides some additional methods
  * that use polymorphism to avoid (un)boxing.
  *
@@ -31,7 +32,22 @@ import WIDENED_PACKAGE.KEY_WIDENED_SPLITERATOR;
  *
  * @see Collection
  */
-
+#else
+ /** A type-specific {@link Collection}; provides some additional methods
+ * that use polymorphism to avoid (un)boxing.
+ *
+ * <p>Additionally, this class defines strengthens (again) {@link #iterator()}.
+ *
+ * <p>This interface specifies reference equality semantics (members will be compared equal with
+ * {@code ==} instead of {@link Object#equals(Object) equals}), which may result in breaks in contract
+ * if attempted to be used with non reference-equality semantics based {@link Collection}s. For example, a
+ * {@code aReferenceCollection.equals(aObjectCollection)} may return different a different result then
+ * {@code aObjectCollection.equals(aReferenceCollection)}, in violation of {@link Object#equals equals}'s
+ * contract requiring it being symmetric.
+ *
+ * @see Collection
+ */
+#endif
 public interface COLLECTION KEY_GENERIC extends Collection<KEY_GENERIC_CLASS>, KEY_ITERABLE KEY_GENERIC {
 
 	/** Returns a type-specific iterator on the elements of this collection.

--- a/drv/ImmutableList.drv
+++ b/drv/ImmutableList.drv
@@ -449,7 +449,7 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 		final KEY_GENERIC_TYPE[] a1 = a;
 		final KEY_GENERIC_TYPE[] a2 = l.a;
 
-#if KEY_CLASS_Reference
+#if KEYS_USE_REFERENCE_EQUALITY
 		while(s-- !=  0) if (a1[s] != a2[s]) return false;
 #else
 		java.util.Arrays.equals(a1, a2);
@@ -464,7 +464,7 @@ public class IMMUTABLE_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implem
 	}
 
 
-#if ! KEY_CLASS_Reference
+#if ! KEYS_USE_REFERENCE_EQUALITY
 
 	/** Compares this immutable list to another immutable list.
 	 *

--- a/drv/ImmutablePair.drv
+++ b/drv/ImmutablePair.drv
@@ -78,12 +78,12 @@ public class IMMUTABLE_PAIR KEY_VALUE_GENERIC implements PAIR KEY_VALUE_GENERIC,
 
 		if (other instanceof it.unimi.dsi.fastutil.Pair) {
 			return
-#if KEY_CLASS_Reference
+#if KEYS_USE_REFERENCE_EQUALITY
 	left == ((it.unimi.dsi.fastutil.Pair)other).left()
 #else
 	java.util.Objects.equals(KEY2OBJ(left), ((it.unimi.dsi.fastutil.Pair)other).left())
 #endif
-#if VALUE_CLASS_Reference
+#if VALUES_USE_REFERENCE_EQUALITY
 	&& right == ((it.unimi.dsi.fastutil.Pair)other).right();
 #else
 	&& java.util.Objects.equals(VALUE2OBJ(right), ((it.unimi.dsi.fastutil.Pair)other).right());

--- a/drv/ImmutableSortedPair.drv
+++ b/drv/ImmutableSortedPair.drv
@@ -74,12 +74,12 @@ public class IMMUTABLE_SORTED_PAIR <K extends Comparable<K>> extends IMMUTABLE_P
 
 		if (other instanceof it.unimi.dsi.fastutil.SortedPair) {
 			return
-#if KEY_CLASS_Reference
+#if KEYS_USE_REFERENCE_EQUALITY
 	left == ((it.unimi.dsi.fastutil.SortedPair)other).left()
 #else
 	java.util.Objects.equals(KEY2OBJ(left), ((it.unimi.dsi.fastutil.SortedPair)other).left())
 #endif
-#if VALUE_CLASS_Reference
+#if VALUES_USE_REFERENCE_EQUALITY
 	&& right == ((it.unimi.dsi.fastutil.SortedPair)other).right();
 #else
 	&& java.util.Objects.equals(VALUE2OBJ(right), ((it.unimi.dsi.fastutil.SortedPair)other).right());

--- a/drv/List.drv
+++ b/drv/List.drv
@@ -21,28 +21,12 @@ import java.util.Spliterator;
 import java.util.List;
 import static it.unimi.dsi.fastutil.Size64.sizeOf;
 
-#if ! KEY_CLASS_Reference
-
+#if ! KEYS_USE_REFERENCE_EQUALITY
 /** A type-specific {@link List}; provides some additional methods that use polymorphism to avoid (un)boxing.
  *
  * <p>Note that this type-specific interface extends {@link Comparable}: it is expected that implementing
  * classes perform a lexicographical comparison using the standard operator "less then" for primitive types,
  * and the usual {@link Comparable#compareTo(Object) compareTo()} method for objects.
- *
- * <p>Additionally, this interface strengthens {@link #listIterator()},
- * {@link #listIterator(int)} and {@link #subList(int,int)}.
- *
- * <p>Besides polymorphic methods, this interfaces specifies methods to copy into an array or remove contiguous
- * sublists. Although the abstract implementation of this interface provides simple, one-by-one implementations
- * of these methods, it is expected that concrete implementation override them with optimized versions.
- *
- * @see List
- */
-
-public interface LIST KEY_GENERIC extends List<KEY_GENERIC_CLASS>, Comparable<List<? extends KEY_GENERIC_CLASS>>, COLLECTION KEY_GENERIC {
-#else
-
-/** A type-specific {@link List}; provides some additional methods that use polymorphism to avoid (un)boxing.
  *
  * <p>Additionally, this interface strengthens {@link #iterator()}, {@link #listIterator()},
  * {@link #listIterator(int)} and {@link #subList(int,int)}. The former had been already
@@ -55,6 +39,27 @@ public interface LIST KEY_GENERIC extends List<KEY_GENERIC_CLASS>, Comparable<Li
  * @see List
  */
 
+public interface LIST KEY_GENERIC extends List<KEY_GENERIC_CLASS>, Comparable<List<? extends KEY_GENERIC_CLASS>>, COLLECTION KEY_GENERIC {
+#else
+/** A type-specific {@link List}; provides some additional methods that use polymorphism to avoid (un)boxing.
+ *
+ * <p>Additionally, this interface strengthens {@link #iterator()}, {@link #listIterator()},
+ * {@link #listIterator(int)} and {@link #subList(int,int)}. The former had been already
+ * strengthened upstream, but unfortunately {@link List} re-specifies it.
+ *
+ * <p>This interface specifies reference equality semantics (members will be compared equal with
+ * {@code ==} instead of {@link Object#equals(Object) equals}), which may result in breaks in contract
+ * if attempted to be used with non reference-equality semantics based {@link List}s. For example, a
+ * {@code aReferenceList.equals(aObjectList)} may return different a different result then
+ * {@code aObjectList.equals(aReferenceList)}, in violation of {@link Object#equals equals}'s contract
+ * requiring it being symmetric.
+ *
+ * <p>Besides polymorphic methods, this interfaces specifies methods to copy into an array or remove contiguous
+ * sublists. Although the abstract implementation of this interface provides simple, one-by-one implementations
+ * of these methods, it is expected that concrete implementation override them with optimized versions.
+ *
+ * @see List
+ */
 public interface LIST KEY_GENERIC extends List<KEY_GENERIC_CLASS>, COLLECTION KEY_GENERIC {
 #endif
 

--- a/drv/Lists.drv
+++ b/drv/Lists.drv
@@ -228,7 +228,7 @@ public final class LISTS {
 		@Override
 		public void size(int s)  { throw new UnsupportedOperationException(); }
 
-#if ! KEY_CLASS_Reference
+#if ! KEYS_USE_REFERENCE_EQUALITY
 		@Override
 		public int compareTo(final List<? extends KEY_GENERIC_CLASS> o) {
 			if (o == this) return 0;
@@ -564,7 +564,7 @@ public final class LISTS {
 		@Override
 		public int hashCode() { synchronized(sync) { return collection.hashCode(); } }
 
-#if ! KEY_CLASS_Reference
+#if ! KEYS_USE_REFERENCE_EQUALITY
 		@Override
 		public int compareTo(final List<? extends KEY_GENERIC_CLASS> o) { synchronized(sync) { return list.compareTo(o); } }
 #endif
@@ -760,7 +760,7 @@ public final class LISTS {
 		@Override
 		public int hashCode() { return collection.hashCode(); }
 
-#if ! KEY_CLASS_Reference
+#if ! KEYS_USE_REFERENCE_EQUALITY
 		@Override
 		public int compareTo(final List<? extends KEY_GENERIC_CLASS> o) { return list.compareTo(o); }
 #endif
@@ -1220,7 +1220,7 @@ public final class LISTS {
 			ff.delete();
 		}
 
-#if ! KEY_CLASS_Reference
+#if ! KEYS_USE_REFERENCE_EQUALITY
 
 		ensure(m2.hashCode() == h, "Error (" + level + ", " + seed + "): hashCode() changed after save/read");
 

--- a/drv/Map.drv
+++ b/drv/Map.drv
@@ -29,6 +29,7 @@ import it.unimi.dsi.fastutil.objects.ObjectIterator;
 import java.util.function.Consumer;
 import java.util.Map;
 
+#if !KEYS_USE_REFERENCE_EQUALITY && !VALUES_USE_REFERENCE_EQUALITY
 /** A type-specific {@link Map}; provides some additional methods that use polymorphism to avoid (un)boxing, and handling of a default return value.
  *
  * <p>Besides extending the corresponding type-specific {@linkplain it.unimi.dsi.fastutil.Function function}, this interface strengthens {@link Map#entrySet()},
@@ -42,7 +43,28 @@ import java.util.Map;
  *
  * @see Map
  */
-
+#else
+/** A type-specific {@link Map}; provides some additional methods that use polymorphism to avoid (un)boxing, and handling of a default return value.
+ *
+ * <p>Besides extending the corresponding type-specific {@linkplain it.unimi.dsi.fastutil.Function function}, this interface strengthens {@link Map#entrySet()},
+ * {@link #keySet()} and {@link #values()}. Moreover, a number of methods, such as {@link #size()}, {@link #defaultReturnValue()}, etc., are un-defaulted
+ * as their function default do not make sense for a map.
+ * Maps returning entry sets of type {@link FastEntrySet} support also fast iteration.
+ *
+ * <p>This interface specifies reference equality semantics (members will be compared equal with
+ * {@code ==} instead of {@link Object#equals(Object) equals}) for its keys or values (or both), which may result in breaks in contract
+ * if attempted to be used with non reference-equality semantics based {@link Maps}s. For example, a
+ * {@code aReferenceToIntMap.equals(aObjectToIntMap)} may return different a different result then
+ * {@code aObjectToIntMap.equals(aReferenceToIntMap)}, in violation of {@link Object#equals equals}'s
+ * contract requiring it being symmetric.
+ *
+ * <p>A submap or subset may or may not have an
+ * independent default return value (which however must be initialized to the
+ * default return value of the originator).
+ *
+ * @see Map
+ */
+#endif
 public interface MAP KEY_VALUE_GENERIC extends FUNCTION KEY_VALUE_GENERIC, Map<KEY_GENERIC_CLASS,VALUE_GENERIC_CLASS> {
 
 	/** An entry set providing fast iteration.

--- a/drv/MutablePair.drv
+++ b/drv/MutablePair.drv
@@ -91,12 +91,12 @@ public class MUTABLE_PAIR KEY_VALUE_GENERIC implements PAIR KEY_VALUE_GENERIC, j
 
 		if (other instanceof it.unimi.dsi.fastutil.Pair) {
 			return
-#if KEY_CLASS_Reference
+#if KEYS_USE_REFERENCE_EQUALITY
 	left == ((it.unimi.dsi.fastutil.Pair)other).left()
 #else
 	java.util.Objects.equals(KEY2OBJ(left), ((it.unimi.dsi.fastutil.Pair)other).left())
 #endif
-#if VALUE_CLASS_Reference
+#if VALUES_USE_REFERENCE_EQUALITY
 	&& right == ((it.unimi.dsi.fastutil.Pair)other).right();
 #else
 	&& java.util.Objects.equals(VALUE2OBJ(right), ((it.unimi.dsi.fastutil.Pair)other).right());

--- a/drv/OpenHashBigSet.drv
+++ b/drv/OpenHashBigSet.drv
@@ -1404,7 +1404,7 @@ public class OPEN_HASH_BIG_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC impl
 			ff.delete();
 		}
 
-#if !KEY_CLASS_Reference
+#if !KEYS_USE_REFERENCE_EQUALITY
 		ensure(m.hashCode() == h, "Error (" + seed + "): hashCode() changed after save/read");;
 
 		printProbes(m);

--- a/drv/OpenHashMap.drv
+++ b/drv/OpenHashMap.drv
@@ -2892,7 +2892,7 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 		return (KEY_TYPE)(r.nextInt());
 #elif KEYS_PRIMITIVE
 		return r.NEXT_KEY();
-#elif !KEY_CLASS_Reference
+#elif !KEYS_USE_REFERENCE_EQUALITY
 #ifdef Custom
 		int i = r.nextInt(3);
 		byte a[] = new byte[i];
@@ -2911,7 +2911,7 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 		return (VALUE_TYPE)(r.nextInt());
 #elif VALUES_PRIMITIVE
 		return r.NEXT_VALUE();
-#elif !VALUE_CLASS_Reference
+#elif !VALUES_USE_REFERENCE_EQUALITY
 		return Integer.toBinaryString(r.nextInt());
 #else
 		return new java.io.Serializable() {};
@@ -2999,14 +2999,14 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 								Object curr;
 								public Object next() {
 									curr = iterator.next();
-#if VALUE_CLASS_Reference
-#if KEY_CLASS_Reference
+#if VALUES_USE_REFERENCE_EQUALITY
+#if KEYS_USE_REFERENCE_EQUALITY
 									return new ABSTRACT_MAP.BasicEntry((Object)curr, (Object)get(curr)) {
 #else
 									return new ABSTRACT_MAP.BasicEntry((KEY_CLASS)curr, (Object)get(curr)) {
 #endif
 #else
-#if KEY_CLASS_Reference
+#if KEYS_USE_REFERENCE_EQUALITY
 									return new ABSTRACT_MAP.BasicEntry((Object)curr, (VALUE_CLASS)get(curr)) {
 #else
 									return new ABSTRACT_MAP.BasicEntry((KEY_CLASS)curr, (VALUE_CLASS)get(curr)) {
@@ -3381,7 +3381,7 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 		}
 
 
-#if !KEY_CLASS_Reference && !VALUE_CLASS_Reference
+#if !KEYS_USE_REFERENCE_EQUALITY && !VALUES_USE_REFERENCE_EQUALITY
 		ensure(m.hashCode() == h, "Error (" + seed + "): hashCode() changed after save/read");;
 
 		/* Now we check that m actually holds that data. */

--- a/drv/OpenHashSet.drv
+++ b/drv/OpenHashSet.drv
@@ -2581,7 +2581,7 @@ public class OPEN_HASH_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implemen
 			ff.delete();
 		}
 
-#if !KEY_CLASS_Reference
+#if !KEYS_USE_REFERENCE_EQUALITY
 		ensure(m.hashCode() == h, "Error (" + seed + "): hashCode() changed after save/read");;
 
 		printProbes(m);

--- a/drv/RBTreeMap.drv
+++ b/drv/RBTreeMap.drv
@@ -1896,7 +1896,7 @@ public class RB_TREE_MAP KEY_VALUE_GENERIC extends ABSTRACT_SORTED_MAP KEY_VALUE
 		return (VALUE_TYPE)(r.nextInt());
 #elif VALUES_PRIMITIVE
 		return r.NEXT_VALUE();
-#elif !VALUE_CLASS_Reference || KEY_CLASS_Reference
+#elif !VALUES_USE_REFERENCE_EQUALITY || KEYS_USE_REFERENCE_EQUALITY
 		return Integer.toBinaryString(r.nextInt());
 #else
 		return new java.io.Serializable() {};
@@ -2423,7 +2423,7 @@ public class RB_TREE_MAP KEY_VALUE_GENERIC extends ABSTRACT_SORTED_MAP KEY_VALUE
 			ff.delete();
 		}
 
-#if !VALUE_CLASS_Reference
+#if !VALUES_USE_REFERENCE_EQUALITY
 		ensure(m2.hashCode() == h, "Error (" + level + ", " + seed + "): hashCode() changed after save/read");
 
 		/* Now we check that m2 actually holds that data. */

--- a/drv/Set.drv
+++ b/drv/Set.drv
@@ -21,13 +21,28 @@ import java.util.Spliterator;
 import java.util.Set;
 import static it.unimi.dsi.fastutil.Size64.sizeOf;
 
+#if !KEYS_USE_REFERENCE_EQUALITY
 /** A type-specific {@link Set}; provides some additional methods that use polymorphism to avoid (un)boxing.
  *
  * <p>Additionally, this interface strengthens (again) {@link #iterator()}.
  *
  * @see Set
  */
-
+#else
+/** A type-specific {@link Set}; provides some additional methods that use polymorphism to avoid (un)boxing.
+ *
+ * <p>Additionally, this interface strengthens (again) {@link #iterator()}.
+ *
+ * <p>This interface specifies reference equality semantics (members will be compared equal with
+ * {@code ==} instead of {@link Object#equals(Object) equals}), which may result in breaks in contract
+ * if attempted to be used with non reference-equality semantics based {@link Set}s. For example, a
+ * {@code aReferenceSet.equals(aObjectSet)} may return different a different result then
+ * {@code aObjectSet.equals(aReferenceSet)}, in violation of {@link Object#equals equals}'s contract
+ * requiring it being symmetric.
+ *
+ * @see Set
+ */
+#endif
 public interface SET KEY_GENERIC extends COLLECTION KEY_GENERIC, Set<KEY_GENERIC_CLASS> {
 
 	/** Returns a type-specific iterator on the elements of this set.

--- a/drv/Sets.drv
+++ b/drv/Sets.drv
@@ -638,7 +638,7 @@ public final class SETS {
 			ff.delete();
 		}
 
-#if ! KEY_CLASS_Reference
+#if ! KEYS_USE_REFERENCE_EQUALITY
 
 		ensure(m2.hashCode() == h, "Error (" + seed + "): hashCode() changed after save/read");
 

--- a/drv/SortedMaps.drv
+++ b/drv/SortedMaps.drv
@@ -531,7 +531,7 @@ public final class SORTED_MAPS {
 
 
 
-#if defined(TEST) && ! KEY_CLASS_Reference
+#if defined(TEST) && ! KEYS_USE_REFERENCE_EQUALITY
 
 	private static long seed = System.currentTimeMillis();
 	private static java.util.Random r = new java.util.Random(seed);
@@ -551,7 +551,7 @@ public final class SORTED_MAPS {
 		return (VALUE_TYPE)(r.nextInt());
 #elif VALUES_PRIMITIVE
 		return r.NEXT_VALUE();
-#elif !VALUE_CLASS_Reference || KEY_CLASS_Reference
+#elif !VALUES_USE_REFERENCE_EQUALITY || KEYS_USE_REFERENCE_EQUALITY
 		return Integer.toBinaryString(r.nextInt());
 #else
 		return new java.io.Serializable() {};
@@ -905,7 +905,7 @@ public final class SORTED_MAPS {
 			ff.delete();
 		}
 
-#if !VALUE_CLASS_Reference
+#if !VALUES_USE_REFERENCE_EQUALITY
 		ensure(m2.hashCode() == h, "Error (" + level + ", " + seed + "): hashCode() changed after save/read");
 
 		/* Now we check that m2 actually holds that data. */

--- a/drv/SortedSets.drv
+++ b/drv/SortedSets.drv
@@ -456,7 +456,7 @@ public final class SORTED_SETS {
 
 
 
-#if defined(TEST) && ! KEY_CLASS_Reference
+#if defined(TEST) && ! KEYS_USE_REFERENCE_EQUALITY
 
 	private static KEY_TYPE genKey() {
 #if KEY_CLASS_Byte || KEY_CLASS_Short || KEY_CLASS_Character
@@ -715,7 +715,7 @@ public final class SORTED_SETS {
 			ff.delete();
 		}
 
-#if ! KEY_CLASS_Reference
+#if ! KEYS_USE_REFERENCE_EQUALITY
 
 		ensure(m2.hashCode() == h, "Error (" + level + ", " + seed + "): hashCode() changed after save/read");
 

--- a/gencsource.sh
+++ b/gencsource.sh
@@ -205,6 +205,8 @@ fi)\
 "#define KEY_CLASS_WIDENED ${CLASS[$wk]}\n"\
 "#define VALUE_CLASS_WIDENED ${CLASS[$wv]}\n"\
 \
+"#define KEYS_USE_REFERENCE_EQUALITY KEY_CLASS_Reference\n"\
+"#define VALUES_USE_REFERENCE_EQUALITY VALUE_CLASS_Reference\n"\
 \
 "#if KEYS_REFERENCE\n"\
 "#define KEY_GENERIC_CLASS K\n"\


### PR DESCRIPTION
This is much clearer that we mean the types that use `==` for equality testing instead of `.equals`, and not confuse it with the `KEYS_REFERENCE` macro which means any types using Object backed members.

Also documents the gotcha of trying to use a Reference based and a non-Reference based collection together (e.g. you may get non symmetric `equals`)

Also does the same for VALUE.