### PR TITLE
Add a faster case if BigArrayBigList.of() (no arguments) is called.

### DIFF
--- a/drv/ArrayList.drv
+++ b/drv/ArrayList.drv
@@ -339,7 +339,7 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 	public static KEY_GENERIC ARRAY_LIST KEY_GENERIC wrap(final KEY_GENERIC_TYPE a[]) {
 		return wrap(a, a.length);
 	}
-	
+
 	/** Creates a new empty array list. 
 	 *
 	 * @return a new empty array list.
@@ -383,7 +383,7 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 	 * {@link java.util.stream.Collector Collector} is necessary because there is no
 	 * primitive {@code Collector} equivalent in the Java API.
 	 * @implNote The current implementation preallocates the full size for every worker thread when used on parallel streams.
-	 *   This can be quite wasteful, as worker threads other then the first don't usually handle the full stream.
+	 *   This can be quite wasteful, as worker threads other then the first don't usually handle the contents of the full stream.
 	 */
 	public static KEY_GENERIC ARRAY_LIST KEY_GENERIC toListWithExpectedSize(JDK_PRIMITIVE_STREAM stream, int expectedSize) {
 		return stream.collect(
@@ -413,7 +413,7 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
  	/**
  	 * Returns a {@link Collector} that collects a {@code Stream}'s elements into a new ArrayList.
 	 * @implNote The current implementation preallocates the full size for every worker thread when used on parallel streams.
-	 *   This can be quite wasteful, as worker threads other then the first don't usually handle the full stream.
+	 *   This can be quite wasteful, as worker threads other then the first don't usually handle the contents of the full stream.
  	 */
  	public static KEY_GENERIC Collector<KEY_GENERIC_TYPE, ?, ARRAY_LIST KEY_GENERIC> toListWithExpectedSize(int expectedSize) {
  		return Collector.of(

--- a/drv/BigArrayBigList.drv
+++ b/drv/BigArrayBigList.drv
@@ -278,11 +278,21 @@ public class BIG_ARRAY_BIG_LIST KEY_GENERIC extends ABSTRACT_BIG_LIST KEY_GENERI
 		return wrap(a, length(a));
 	}
 
+	/** Creates a new empty big array list. 
+	 *
+	 * @return a new empty big-array big list.
+	 */
+	public static KEY_GENERIC BIG_ARRAY_BIG_LIST KEY_GENERIC of() {
+		return new BIG_ARRAY_BIG_LIST KEY_GENERIC_DIAMOND();
+	}
 
 	/** Creates a big array list using a list of elements.
 	 *
 	 * @param init a list of elements that will be used to initialize the big list.
+	 *   It is possible (but not assured) that the returned big-array big list will be
+	 *   backed by the given array in one of its segments.
 	 * @return a new big-array big list containing the given elements.
+	 * @see BigArrays#wrap
 	 */
 	SAFE_VARARGS
 	public static KEY_GENERIC BIG_ARRAY_BIG_LIST KEY_GENERIC of(final KEY_GENERIC_TYPE... init) {
@@ -312,6 +322,8 @@ public class BIG_ARRAY_BIG_LIST KEY_GENERIC extends ABSTRACT_BIG_LIST KEY_GENERI
 	 * @apiNote Taking a primitive stream instead returning something like a
 	 * {@link java.util.stream.Collector Collector} is necessary because there is no
 	 * primitive {@code Collector} equivalent in the Java API.
+	 * @implNote The current implementation preallocates the full size for every worker thread when used on parallel streams.
+	 *   This can be quite wasteful, as worker threads other then the first don't usually handle the contents of the full stream.
 	 */
 	public static KEY_GENERIC BIG_ARRAY_BIG_LIST KEY_GENERIC toBigListWithExpectedSize(JDK_PRIMITIVE_STREAM stream, long expectedSize) {
 		return stream.collect(
@@ -338,7 +350,12 @@ public class BIG_ARRAY_BIG_LIST KEY_GENERIC extends ABSTRACT_BIG_LIST KEY_GENERI
 		return (Collector) TO_LIST_COLLECTOR;
 	}
 
- 	/** Returns a {@link Collector} that collects a {@code Stream}'s elements into a new ArrayList. */
+ 	/**
+ 	 * Returns a {@link Collector} that collects a {@code Stream}'s elements into a new ArrayList.
+ 	 *
+ 	 * @implNote The current implementation preallocates the full size for every worker thread when used on parallel streams.
+	 *   This can be quite wasteful, as worker threads other then the first don't usually handle the contents of the full stream.
+ 	 */
  	public static KEY_GENERIC Collector<KEY_GENERIC_TYPE, ?, BIG_ARRAY_BIG_LIST KEY_GENERIC> toBigListWithExpectedSize(long expectedSize) {
  		return Collector.of(
 		() -> new BIG_ARRAY_BIG_LIST KEY_GENERIC(expectedSize),


### PR DESCRIPTION
Instead of newly creating an empty big array, now it fallsback to the default constructor.
This will allow it to have much better resizing performance, as instead of 0->1 on first add, it will go 0->10 (because of `DEFAULT_EMPTY_BIG_ARRAY` being used now).

The array based `of` remains the same; we need to ensure the same runtime type is kept, even if empty.

Also minor doc updates to `ArrayList` as well.