### PR TITLE
Fix issues with Map view iterators and spliterators

### DIFF
--- a/drv/AbstractMap.drv
+++ b/drv/AbstractMap.drv
@@ -24,12 +24,17 @@ import VALUE_PACKAGE.VALUE_ABSTRACT_COLLECTION;
 import VALUE_PACKAGE.VALUE_ITERATOR;
 import VALUE_PACKAGE.VALUE_SPLITERATOR;
 import VALUE_PACKAGE.VALUE_SPLITERATORS;
+#if VALUES_BYTE_CHAR_SHORT_FLOAT || VALUE_CLASS_Boolean
+import VALUE_PACKAGE.VALUE_CONSUMER;
+#endif
 #endif
 
 #if KEYS_PRIMITIVE && VALUES_PRIMITIVE
 import it.unimi.dsi.fastutil.objects.ObjectIterator;
 import it.unimi.dsi.fastutil.objects.ObjectSpliterator;
 import it.unimi.dsi.fastutil.objects.ObjectSpliterators;
+#else
+import java.util.function.Consumer;
 #endif
 
 #if KEYS_PRIMITIVE
@@ -253,34 +258,11 @@ public abstract class ABSTRACT_MAP KEY_VALUE_GENERIC extends ABSTRACT_FUNCTION K
 	 * this method and caching the result, but implementors are encouraged to
 	 * write more efficient ad-hoc implementations.
 	 *
-	 * @implNote  <strong>Warning</strong>: The returned {@code Set}'s {@link java.util.Set#iterator() iterator} is likely to be <em>thread hostile</em>
-	 *   (meaning not even external locking will make it safe for parallel use). This is because it attempts to use the {@code fastIterator()} of
-	 *   the parent class' {@link java.util.Map#entrySet() entrySet()} if it is present.
-	 *   <p><em>Do not</em> wrap it in a {@link java.util.Spliterator Spliterator} (such as by
-	 *   {@link java.util.Spliterators#spliterator(java.util.Iterator, long, int) Spliterators.spliterator(Iterator, long, int)}),
-	 *   or at the very least don't attempt to make {@linkplain java.util.stream.Stream steams} based on them.
-	 *   <p>The returned instance's {@link java.util.Set#spliterator() spliterator} already takes this into consideration, so it
-	 *   is safe to use in parallel streams.
-	 *
 	 * @return a set view of the keys of this map; it may be safely cast to a type-specific interface.
 	 */
 	@Override
 	public SET KEY_GENERIC keySet() {
 		return new ABSTRACT_SET KEY_GENERIC() {
-				final class KeySetIterator implements KEY_ITERATOR KEY_GENERIC {
-					// While using the fast iterator is fine for iterators, it is absolutely not for spliterators, due to parallel potential.
-					// Thus we need to be able to turn it on or off.
-					private final ObjectIterator<MAP.Entry KEY_VALUE_GENERIC> i;
-					KeySetIterator(boolean useFastIterator) {
-						i = useFastIterator ? MAPS.fastIterator(ABSTRACT_MAP.this) : ABSTRACT_MAP.this.ENTRYSET().iterator();
-					}
-					@Override
-					public KEY_GENERIC_TYPE NEXT_KEY() { return i.next().ENTRY_GET_KEY(); }
-					@Override
-					public boolean hasNext() { return i.hasNext(); }
-					@Override
-					public void remove() { i.remove(); }
-				}
 				@Override
 				public boolean contains(final KEY_TYPE k) { return containsKey(k); }
 				@Override
@@ -289,12 +271,24 @@ public abstract class ABSTRACT_MAP KEY_VALUE_GENERIC extends ABSTRACT_FUNCTION K
 				public void clear() { ABSTRACT_MAP.this.clear(); }
 				@Override
 				public KEY_ITERATOR KEY_GENERIC iterator() {
-					return new KeySetIterator(true);
+					return new KEY_ITERATOR KEY_GENERIC() {
+							private final ObjectIterator<MAP.Entry KEY_VALUE_GENERIC> i = MAPS.fastIterator(ABSTRACT_MAP.this);
+							@Override
+							public KEY_GENERIC_TYPE NEXT_KEY() { return i.next().ENTRY_GET_KEY(); }
+							@Override
+							public boolean hasNext() { return i.hasNext(); }
+							@Override
+							public void remove() { i.remove(); }
+							@Override
+							public void forEachRemaining(final METHOD_ARG_KEY_CONSUMER action) {
+								i.forEachRemaining(entry -> action.accept(entry.ENTRY_GET_KEY()));
+							}
+						};
 				}
 				@Override
 				public KEY_SPLITERATOR KEY_GENERIC spliterator() {
 					return SPLITERATORS.asSpliterator(
-	 					new KeySetIterator(false), sizeOf(ABSTRACT_MAP.this), SPLITERATORS.SET_SPLITERATOR_CHARACTERISTICS);
+	 					iterator(), sizeOf(ABSTRACT_MAP.this), SPLITERATORS.SET_SPLITERATOR_CHARACTERISTICS);
 				}
 			};
 	}
@@ -309,44 +303,35 @@ public abstract class ABSTRACT_MAP KEY_VALUE_GENERIC extends ABSTRACT_FUNCTION K
 	 * write more efficient ad-hoc implementations.
 	 *
 	 * @return a set view of the values of this map; it may be safely cast to a type-specific interface.
-	 * @implNote  <strong>Warning</strong>: The returned {@code Collection}'s {@link java.util.Collection#iterator() iterator} is likely to be <em>thread hostile</em>
-	 *   (meaning not even external locking will make it safe for parallel use). This is because it attempts to use the {@code fastIterator()} of
-	 *   the parent class' {@link java.util.Map#entrySet() entrySet()} if it is present.
-	 *   <p><em>Do not</em> wrap it in a {@link java.util.Spliterator Spliterator} (such as by
-	 *   {@link java.util.Spliterators#spliterator(java.util.Iterator, long, int) Spliterators.spliterator(Iterator, long, int)}),
-	 *   or at the very least don't attempt to make {@linkplain java.util.stream.Stream steams} based on them.
-	 *   <p>The returned instance's {@link java.util.Collection#spliterator() spliterator} already takes this into consideration, so it
-	 *   is safe to use in parallel streams.
 	 */
 	@Override
 	public VALUE_COLLECTION VALUE_GENERIC values() {
 		return new VALUE_ABSTRACT_COLLECTION VALUE_GENERIC() {
-				final class ValuesIterator implements VALUE_ITERATOR VALUE_GENERIC {
-					// While using the fast iterator is fine for iterators, it is absolutely not for spliterators, due to parallel potential.
-					// Thus we need to be able to turn it on or off.
-					private final ObjectIterator<MAP.Entry KEY_VALUE_GENERIC> i;
-					ValuesIterator(boolean useFastIterator) {
-						i = useFastIterator ? MAPS.fastIterator(ABSTRACT_MAP.this) : ABSTRACT_MAP.this.ENTRYSET().iterator();
-					}
-					@Override
-					public VALUE_GENERIC_TYPE NEXT_VALUE() { return i.next().ENTRY_GET_VALUE(); }
-					@Override
-					public boolean hasNext() { return i.hasNext(); }
-				}
 				@Override
 				public boolean contains(final VALUE_TYPE k) { return containsValue(k); }
 				@Override
 				public int size() { return ABSTRACT_MAP.this.size(); }
 				@Override
 				public void clear() { ABSTRACT_MAP.this.clear(); }
+
 				@Override
 				public VALUE_ITERATOR VALUE_GENERIC iterator() {
-					return new ValuesIterator(true);
+					return new VALUE_ITERATOR VALUE_GENERIC() {
+							private final ObjectIterator<MAP.Entry KEY_VALUE_GENERIC> i = MAPS.fastIterator(ABSTRACT_MAP.this);
+							@Override
+							public VALUE_GENERIC_TYPE NEXT_VALUE() { return i.next().ENTRY_GET_VALUE(); }
+							@Override
+							public boolean hasNext() { return i.hasNext(); }
+							@Override
+							public void forEachRemaining(final METHOD_ARG_VALUE_CONSUMER action) {
+								i.forEachRemaining(entry -> action.accept(entry.ENTRY_GET_VALUE()));
+							}
+						};
 				}
 				@Override
 				public VALUE_SPLITERATOR VALUE_GENERIC spliterator() {
 					return VALUE_SPLITERATORS.asSpliterator(
-	 					new ValuesIterator(false), sizeOf(ABSTRACT_MAP.this), VALUE_SPLITERATORS.COLLECTION_SPLITERATOR_CHARACTERISTICS);
+	 					iterator(), sizeOf(ABSTRACT_MAP.this), VALUE_SPLITERATORS.COLLECTION_SPLITERATOR_CHARACTERISTICS);
 				}
 			};
 	}

--- a/drv/AbstractMap.drv
+++ b/drv/AbstractMap.drv
@@ -17,14 +17,19 @@
 
 package PACKAGE;
 
+import static it.unimi.dsi.fastutil.Size64.sizeOf;
 #if KEY_INDEX != VALUE_INDEX && !(KEYS_REFERENCE && VALUES_REFERENCE)
 import VALUE_PACKAGE.VALUE_COLLECTION;
 import VALUE_PACKAGE.VALUE_ABSTRACT_COLLECTION;
 import VALUE_PACKAGE.VALUE_ITERATOR;
+import VALUE_PACKAGE.VALUE_SPLITERATOR;
+import VALUE_PACKAGE.VALUE_SPLITERATORS;
 #endif
 
 #if KEYS_PRIMITIVE && VALUES_PRIMITIVE
 import it.unimi.dsi.fastutil.objects.ObjectIterator;
+import it.unimi.dsi.fastutil.objects.ObjectSpliterator;
+import it.unimi.dsi.fastutil.objects.ObjectSpliterators;
 #endif
 
 #if KEYS_PRIMITIVE
@@ -230,6 +235,12 @@ public abstract class ABSTRACT_MAP KEY_VALUE_GENERIC extends ABSTRACT_FUNCTION K
 		public int size() {
 			return map.size();
 		}
+
+		@Override
+		public ObjectSpliterator<Entry KEY_VALUE_GENERIC> spliterator() {
+			return ObjectSpliterators.asSpliterator(
+				iterator(), sizeOf(map), ObjectSpliterators.SET_SPLITERATOR_CHARACTERISTICS);
+		}
 	}
 
 
@@ -242,11 +253,34 @@ public abstract class ABSTRACT_MAP KEY_VALUE_GENERIC extends ABSTRACT_FUNCTION K
 	 * this method and caching the result, but implementors are encouraged to
 	 * write more efficient ad-hoc implementations.
 	 *
+	 * @implNote  <strong>Warning</strong>: The returned {@code Set}'s {@link java.util.Set#iterator() iterator} is likely to be <em>thread hostile</em>
+	 *   (meaning not even external locking will make it safe for parallel use). This is because it attempts to use the {@code fastIterator()} of
+	 *   the parent class' {@link java.util.Map#entrySet() entrySet()} if it is present.
+	 *   <p><em>Do not</em> wrap it in a {@link java.util.Spliterator Spliterator} (such as by
+	 *   {@link java.util.Spliterators#spliterator(java.util.Iterator, long, int) Spliterators.spliterator(Iterator, long, int)}),
+	 *   or at the very least don't attempt to make {@linkplain java.util.stream.Stream steams} based on them.
+	 *   <p>The returned instance's {@link java.util.Set#spliterator() spliterator} already takes this into consideration, so it
+	 *   is safe to use in parallel streams.
+	 *
 	 * @return a set view of the keys of this map; it may be safely cast to a type-specific interface.
 	 */
 	@Override
 	public SET KEY_GENERIC keySet() {
 		return new ABSTRACT_SET KEY_GENERIC() {
+				final class KeySetIterator implements KEY_ITERATOR KEY_GENERIC {
+					// While using the fast iterator is fine for iterators, it is absolutely not for spliterators, due to parallel potential.
+					// Thus we need to be able to turn it on or off.
+					private final ObjectIterator<MAP.Entry KEY_VALUE_GENERIC> i;
+					KeySetIterator(boolean useFastIterator) {
+						i = useFastIterator ? MAPS.fastIterator(ABSTRACT_MAP.this) : ABSTRACT_MAP.this.ENTRYSET().iterator();
+					}
+					@Override
+					public KEY_GENERIC_TYPE NEXT_KEY() { return i.next().ENTRY_GET_KEY(); }
+					@Override
+					public boolean hasNext() { return i.hasNext(); }
+					@Override
+					public void remove() { i.remove(); }
+				}
 				@Override
 				public boolean contains(final KEY_TYPE k) { return containsKey(k); }
 				@Override
@@ -255,15 +289,12 @@ public abstract class ABSTRACT_MAP KEY_VALUE_GENERIC extends ABSTRACT_FUNCTION K
 				public void clear() { ABSTRACT_MAP.this.clear(); }
 				@Override
 				public KEY_ITERATOR KEY_GENERIC iterator() {
-					return new KEY_ITERATOR KEY_GENERIC() {
-							private final ObjectIterator<MAP.Entry KEY_VALUE_GENERIC> i = MAPS.fastIterator(ABSTRACT_MAP.this);
-							@Override
-							public KEY_GENERIC_TYPE NEXT_KEY() { return i.next().ENTRY_GET_KEY(); }
-							@Override
-							public boolean hasNext() { return i.hasNext(); }
-							@Override
-							public void remove() { i.remove(); }
-						};
+					return new KeySetIterator(true);
+				}
+				@Override
+				public KEY_SPLITERATOR KEY_GENERIC spliterator() {
+					return SPLITERATORS.asSpliterator(
+	 					new KeySetIterator(false), sizeOf(ABSTRACT_MAP.this), SPLITERATORS.SET_SPLITERATOR_CHARACTERISTICS);
 				}
 			};
 	}
@@ -278,26 +309,44 @@ public abstract class ABSTRACT_MAP KEY_VALUE_GENERIC extends ABSTRACT_FUNCTION K
 	 * write more efficient ad-hoc implementations.
 	 *
 	 * @return a set view of the values of this map; it may be safely cast to a type-specific interface.
+	 * @implNote  <strong>Warning</strong>: The returned {@code Collection}'s {@link java.util.Collection#iterator() iterator} is likely to be <em>thread hostile</em>
+	 *   (meaning not even external locking will make it safe for parallel use). This is because it attempts to use the {@code fastIterator()} of
+	 *   the parent class' {@link java.util.Map#entrySet() entrySet()} if it is present.
+	 *   <p><em>Do not</em> wrap it in a {@link java.util.Spliterator Spliterator} (such as by
+	 *   {@link java.util.Spliterators#spliterator(java.util.Iterator, long, int) Spliterators.spliterator(Iterator, long, int)}),
+	 *   or at the very least don't attempt to make {@linkplain java.util.stream.Stream steams} based on them.
+	 *   <p>The returned instance's {@link java.util.Collection#spliterator() spliterator} already takes this into consideration, so it
+	 *   is safe to use in parallel streams.
 	 */
 	@Override
 	public VALUE_COLLECTION VALUE_GENERIC values() {
 		return new VALUE_ABSTRACT_COLLECTION VALUE_GENERIC() {
+				final class ValuesIterator implements VALUE_ITERATOR VALUE_GENERIC {
+					// While using the fast iterator is fine for iterators, it is absolutely not for spliterators, due to parallel potential.
+					// Thus we need to be able to turn it on or off.
+					private final ObjectIterator<MAP.Entry KEY_VALUE_GENERIC> i;
+					ValuesIterator(boolean useFastIterator) {
+						i = useFastIterator ? MAPS.fastIterator(ABSTRACT_MAP.this) : ABSTRACT_MAP.this.ENTRYSET().iterator();
+					}
+					@Override
+					public VALUE_GENERIC_TYPE NEXT_VALUE() { return i.next().ENTRY_GET_VALUE(); }
+					@Override
+					public boolean hasNext() { return i.hasNext(); }
+				}
 				@Override
 				public boolean contains(final VALUE_TYPE k) { return containsValue(k); }
 				@Override
 				public int size() { return ABSTRACT_MAP.this.size(); }
 				@Override
 				public void clear() { ABSTRACT_MAP.this.clear(); }
-
 				@Override
 				public VALUE_ITERATOR VALUE_GENERIC iterator() {
-					return new VALUE_ITERATOR VALUE_GENERIC() {
-							private final ObjectIterator<MAP.Entry KEY_VALUE_GENERIC> i = MAPS.fastIterator(ABSTRACT_MAP.this);
-							@Override
-							public VALUE_GENERIC_TYPE NEXT_VALUE() { return i.next().ENTRY_GET_VALUE(); }
-							@Override
-							public boolean hasNext() { return i.hasNext(); }
-						};
+					return new ValuesIterator(true);
+				}
+				@Override
+				public VALUE_SPLITERATOR VALUE_GENERIC spliterator() {
+					return VALUE_SPLITERATORS.asSpliterator(
+	 					new ValuesIterator(false), sizeOf(ABSTRACT_MAP.this), VALUE_SPLITERATORS.COLLECTION_SPLITERATOR_CHARACTERISTICS);
 				}
 			};
 	}

--- a/drv/Map.drv
+++ b/drv/Map.drv
@@ -81,6 +81,12 @@ public interface MAP KEY_VALUE_GENERIC extends FUNCTION KEY_VALUE_GENERIC, Map<K
 	interface FastEntrySet KEY_VALUE_GENERIC extends ObjectSet<MAP.Entry KEY_VALUE_GENERIC> {
 		/** Returns a fast iterator over this entry set; the iterator might return always the same entry instance, suitably mutated.
 		 *
+		 * <p><strong>Warning</strong>: The returned {@link java.util.Iterator} is likely to be <em>thread hostile</em> (meaning not
+		 * even external locking will make it safe for parallel use).
+		 * <p><em>Do not</em> wrap it in a {@link java.util.Spliterator Spliterator} (such as by
+		 * {@link java.util.Spliterators#spliterator(java.util.Iterator, long, int) Spliterators.spliterator(Iterator, long, int)}),
+	     * or at the very least don't attempt to make {@linkplain java.util.stream.Stream steams} based on them.
+		 *
 		 * @return a fast iterator over this entry set; the iterator might return always the same {@link java.util.Map.Entry} instance, suitably mutated.
 		 */
 		ObjectIterator<MAP.Entry KEY_VALUE_GENERIC> fastIterator();

--- a/drv/Map.drv
+++ b/drv/Map.drv
@@ -81,12 +81,6 @@ public interface MAP KEY_VALUE_GENERIC extends FUNCTION KEY_VALUE_GENERIC, Map<K
 	interface FastEntrySet KEY_VALUE_GENERIC extends ObjectSet<MAP.Entry KEY_VALUE_GENERIC> {
 		/** Returns a fast iterator over this entry set; the iterator might return always the same entry instance, suitably mutated.
 		 *
-		 * <p><strong>Warning</strong>: The returned {@link java.util.Iterator} is likely to be <em>thread hostile</em> (meaning not
-		 * even external locking will make it safe for parallel use).
-		 * <p><em>Do not</em> wrap it in a {@link java.util.Spliterator Spliterator} (such as by
-		 * {@link java.util.Spliterators#spliterator(java.util.Iterator, long, int) Spliterators.spliterator(Iterator, long, int)}),
-	     * or at the very least don't attempt to make {@linkplain java.util.stream.Stream steams} based on them.
-		 *
 		 * @return a fast iterator over this entry set; the iterator might return always the same {@link java.util.Map.Entry} instance, suitably mutated.
 		 */
 		ObjectIterator<MAP.Entry KEY_VALUE_GENERIC> fastIterator();

--- a/drv/Maps.drv
+++ b/drv/Maps.drv
@@ -49,11 +49,6 @@ public final class MAPS {
 	/** Returns an iterator that will be {@linkplain FastEntrySet fast}, if possible, on the {@linkplain Map#entrySet() entry set} of the provided {@code map}.
 	 * @param map a map from which we will try to extract a (fast) iterator on the entry set.
 	 * @return an iterator on the entry set of the given map that will be fast, if possible.
- 	 * @implNote <strong>Warning</strong>: The returned {@link java.util.Iterator} is likely to be <em>thread hostile</em> (meaning not
-	 *   even external locking will make it safe for parallel use).
-	 *   <p><em>Do not</em> wrap it in a {@link java.util.Spliterator Spliterator} (such as by
-	 *   {@link java.util.Spliterators#spliterator(java.util.Iterator, long, int) Spliterators.spliterator(Iterator, long, int)}),
-     *   or at the very least don't attempt to make {@linkplain java.util.stream.Stream steams} based on them.
 	 * @since 8.0.0
 	 */
 	SUPPRESS_WARNINGS_KEY_VALUE_UNCHECKED
@@ -78,13 +73,6 @@ public final class MAPS {
 	 * @param map a map from which we will try to extract an iterable yielding a (fast) iterator on the entry set.
 	 * @return an iterable  yielding an iterator on the entry set of the given map that will be
 	 * fast, if possible.
-	 * @implNote <strong>Warning</strong>: The returned {@code Iterable}'s {@link java.lang.Iterable#iterator() iterator}
-	 *	 is likely to be <em>thread hostile</em> (meaning not even external locking will make it safe for parallel use).
-	 *   <p><em>Do not</em> wrap it in a {@link java.util.Spliterator Spliterator} (such as by
-	 *   {@link java.util.Spliterators#spliterator(java.util.Iterator, long, int) Spliterators.spliterator(Iterator, long, int)}),
-     *   or at the very least don't attempt to make {@linkplain java.util.stream.Stream steams} based on them.
-	 *   <p>The returned instance's {@link java.lang.Iterable#spliterator() spliterator} already takes this into consideration, so it
-	 *   is safe to use in parallel streams.
 	 * @since 8.0.0
 	 */
 	SUPPRESS_WARNINGS_KEY_VALUE_UNCHECKED
@@ -93,7 +81,6 @@ public final class MAPS {
 		return entries instanceof MAP.FastEntrySet ? new ObjectIterable<MAP.Entry KEY_VALUE_GENERIC>() {
 			@Override
 			public ObjectIterator<MAP.Entry KEY_VALUE_GENERIC> iterator() { return ((MAP.FastEntrySet KEY_VALUE_GENERIC)entries).fastIterator(); }
-			// Per above, we can't use the fastIterator backed version.
 			@Override
 			public ObjectSpliterator<MAP.Entry KEY_VALUE_GENERIC> spliterator() { return entries.spliterator(); } 
 			@Override

--- a/drv/Maps.drv
+++ b/drv/Maps.drv
@@ -20,6 +20,7 @@ package PACKAGE;
 #if ! KEYS_REFERENCE
 import it.unimi.dsi.fastutil.objects.ObjectIterator;
 import it.unimi.dsi.fastutil.objects.ObjectIterable;
+import it.unimi.dsi.fastutil.objects.ObjectSpliterator;
 import it.unimi.dsi.fastutil.objects.ObjectSet;
 import it.unimi.dsi.fastutil.objects.ObjectSets;
 #endif
@@ -48,6 +49,11 @@ public final class MAPS {
 	/** Returns an iterator that will be {@linkplain FastEntrySet fast}, if possible, on the {@linkplain Map#entrySet() entry set} of the provided {@code map}.
 	 * @param map a map from which we will try to extract a (fast) iterator on the entry set.
 	 * @return an iterator on the entry set of the given map that will be fast, if possible.
+ 	 * @implNote <strong>Warning</strong>: The returned {@link java.util.Iterator} is likely to be <em>thread hostile</em> (meaning not
+	 *   even external locking will make it safe for parallel use).
+	 *   <p><em>Do not</em> wrap it in a {@link java.util.Spliterator Spliterator} (such as by
+	 *   {@link java.util.Spliterators#spliterator(java.util.Iterator, long, int) Spliterators.spliterator(Iterator, long, int)}),
+     *   or at the very least don't attempt to make {@linkplain java.util.stream.Stream steams} based on them.
 	 * @since 8.0.0
 	 */
 	SUPPRESS_WARNINGS_KEY_VALUE_UNCHECKED
@@ -72,6 +78,13 @@ public final class MAPS {
 	 * @param map a map from which we will try to extract an iterable yielding a (fast) iterator on the entry set.
 	 * @return an iterable  yielding an iterator on the entry set of the given map that will be
 	 * fast, if possible.
+	 * @implNote <strong>Warning</strong>: The returned {@code Iterable}'s {@link java.lang.Iterable#iterator() iterator}
+	 *	 is likely to be <em>thread hostile</em> (meaning not even external locking will make it safe for parallel use).
+	 *   <p><em>Do not</em> wrap it in a {@link java.util.Spliterator Spliterator} (such as by
+	 *   {@link java.util.Spliterators#spliterator(java.util.Iterator, long, int) Spliterators.spliterator(Iterator, long, int)}),
+     *   or at the very least don't attempt to make {@linkplain java.util.stream.Stream steams} based on them.
+	 *   <p>The returned instance's {@link java.lang.Iterable#spliterator() spliterator} already takes this into consideration, so it
+	 *   is safe to use in parallel streams.
 	 * @since 8.0.0
 	 */
 	SUPPRESS_WARNINGS_KEY_VALUE_UNCHECKED
@@ -80,6 +93,9 @@ public final class MAPS {
 		return entries instanceof MAP.FastEntrySet ? new ObjectIterable<MAP.Entry KEY_VALUE_GENERIC>() {
 			@Override
 			public ObjectIterator<MAP.Entry KEY_VALUE_GENERIC> iterator() { return ((MAP.FastEntrySet KEY_VALUE_GENERIC)entries).fastIterator(); }
+			// Per above, we can't use the fastIterator backed version.
+			@Override
+			public ObjectSpliterator<MAP.Entry KEY_VALUE_GENERIC> spliterator() { return entries.spliterator(); } 
 			@Override
 			public void forEach(final Consumer<? super MAP.Entry KEY_VALUE_GENERIC> consumer) { ((MAP.FastEntrySet KEY_VALUE_GENERIC)entries).fastForEach(consumer); }
 		} : entries;

--- a/drv/OpenHashMap.drv
+++ b/drv/OpenHashMap.drv
@@ -1504,12 +1504,11 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 	@Override
 	public KEY_COMPARATOR KEY_SUPER_GENERIC comparator() { return null; }
 
-
 	/** A list iterator over a linked map.
 	 *
 	 * <p>This class provides a list iterator over a linked hash map. The constructor runs in constant time.
 	 */
-	private class MapIterator {
+	private abstract class MapIterator<ConsumerType> {
 		/** The entry that will be returned by the next call to {@link java.util.ListIterator#previous()} (or {@code null} if no previous entry exists). */
 		int prev = -1;
 		/** The entry that will be returned by the next call to {@link java.util.ListIterator#next()} (or {@code null} if no next entry exists). */
@@ -1518,6 +1517,9 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 		int curr = -1;
 		/** The current index (in the sense of a {@link java.util.ListIterator}). Note that this value is not meaningful when this iterator has been created using the nonempty constructor.*/
 		int index = -1;
+
+		@SuppressWarnings("unused")
+		abstract void acceptOnIndex(final ConsumerType action, final int index);
 
 		protected MapIterator() {
 			next = first;
@@ -1612,6 +1614,18 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 			return curr;
 		}
 
+		public void forEachRemaining(final ConsumerType action) {
+			while (hasNext()) {
+				curr = next;
+				next = GET_NEXT(link[curr]);
+				prev = curr;
+
+				if (index >= 0) index++;
+
+				acceptOnIndex(action, curr);
+			}
+		}
+
 		public void remove() {
 			ensureIndexKnown();
 			if (curr == -1) throw new IllegalStateException();
@@ -1696,13 +1710,18 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 		}
 	}
 
-	private class EntryIterator extends MapIterator implements ObjectListIterator<MAP.Entry KEY_VALUE_GENERIC> {
+	private final class EntryIterator extends MapIterator<Consumer<? super MAP.Entry KEY_VALUE_GENERIC>> implements ObjectListIterator<MAP.Entry KEY_VALUE_GENERIC> {
 		private MapEntry entry;
 
 		public EntryIterator() {}
 
 		public EntryIterator(KEY_GENERIC_TYPE from) {
 			super(from);
+		}
+
+		@Override
+		final void acceptOnIndex(final Consumer<? super MAP.Entry KEY_VALUE_GENERIC> action, final int index) {
+			action.accept(new MapEntry(index));
 		}
 
 		@Override
@@ -1722,13 +1741,19 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 		}
 	}
 
-	private class FastEntryIterator extends MapIterator implements ObjectListIterator<MAP.Entry KEY_VALUE_GENERIC> {
+	private final class FastEntryIterator extends MapIterator<Consumer<? super MAP.Entry KEY_VALUE_GENERIC>> implements ObjectListIterator<MAP.Entry KEY_VALUE_GENERIC> {
 		final MapEntry entry = new MapEntry();
 
 		public FastEntryIterator() {}
 
 		public FastEntryIterator(KEY_GENERIC_TYPE from) {
 			super(from);
+		}
+
+		@Override
+		final void acceptOnIndex(final Consumer<? super MAP.Entry KEY_VALUE_GENERIC> action, final int index) {
+			entry.index = index;
+			action.accept(entry);
 		}
 
 		@Override
@@ -1748,7 +1773,7 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 
 	/** An iterator over a hash map. */
 
-	private class MapIterator<ConsumerType> {
+	private abstract class MapIterator<ConsumerType> {
 		/** The index of the last entry returned, if positive or zero; initially, {@link #n}. If negative, the last
 			entry returned was that of the key of index {@code - pos - 1} from the {@link #wrapped} list. */
 		int pos = n;
@@ -1764,9 +1789,7 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 		ARRAY_LIST KEY_GENERIC wrapped;
 
 		@SuppressWarnings("unused")
-		void acceptOnIndex(final ConsumerType action, int index) {
-			throw new UnsupportedOperationException("Raw MapIterator not meant for forEach operations.");
-		}
+		abstract void acceptOnIndex(final ConsumerType action, final int index);
 
 		public boolean hasNext() {
 			return c != 0;
@@ -1894,7 +1917,7 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 	}
 
 
-	private class EntryIterator extends MapIterator<java.util.function.Consumer<? super MAP.Entry KEY_VALUE_GENERIC>> implements ObjectIterator<MAP.Entry KEY_VALUE_GENERIC> {
+	private final class EntryIterator extends MapIterator<Consumer<? super MAP.Entry KEY_VALUE_GENERIC>> implements ObjectIterator<MAP.Entry KEY_VALUE_GENERIC> {
 		private MapEntry entry;
 
 		@Override
@@ -1903,7 +1926,7 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 		}
 
 		@Override
-		final void acceptOnIndex(final java.util.function.Consumer<? super MAP.Entry KEY_VALUE_GENERIC> action, int index) {
+		final void acceptOnIndex(final Consumer<? super MAP.Entry KEY_VALUE_GENERIC> action, final int index) {
 			action.accept(entry = new MapEntry(index));
 		}
 
@@ -1914,7 +1937,7 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 		}
 	}
 
-	private class FastEntryIterator extends MapIterator<java.util.function.Consumer<? super MAP.Entry KEY_VALUE_GENERIC>> implements ObjectIterator<MAP.Entry KEY_VALUE_GENERIC> {
+	private final class FastEntryIterator extends MapIterator<Consumer<? super MAP.Entry KEY_VALUE_GENERIC>> implements ObjectIterator<MAP.Entry KEY_VALUE_GENERIC> {
 		private final MapEntry entry = new MapEntry();
 
 		@Override
@@ -1924,7 +1947,7 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 		}
 
 		@Override
-		final void acceptOnIndex(final java.util.function.Consumer<? super MAP.Entry KEY_VALUE_GENERIC> action, int index) {
+		final void acceptOnIndex(final Consumer<? super MAP.Entry KEY_VALUE_GENERIC> action, final int index) {
 			entry.index = index;
 			action.accept(entry);
 		}
@@ -1952,7 +1975,7 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 			this.hasSplit = hasSplit;
 		}
 
-		abstract void acceptOnIndex(final ConsumerType action, int index);
+		abstract void acceptOnIndex(final ConsumerType action, final int index);
 
 		abstract SplitType makeForSplit(int pos, int max, boolean mustReturnNull);
 
@@ -2040,7 +2063,7 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 		}
 	}
 
-	private class EntrySpliterator extends MapSpliterator<java.util.function.Consumer<? super MAP.Entry KEY_VALUE_GENERIC>, EntrySpliterator> implements ObjectSpliterator<MAP.Entry KEY_VALUE_GENERIC> {
+	private final class EntrySpliterator extends MapSpliterator<Consumer<? super MAP.Entry KEY_VALUE_GENERIC>, EntrySpliterator> implements ObjectSpliterator<MAP.Entry KEY_VALUE_GENERIC> {
 
 		private static final int POST_SPLIT_CHARACTERISTICS = ObjectSpliterators.SET_SPLITERATOR_CHARACTERISTICS & ~java.util.Spliterator.SIZED;
 
@@ -2056,7 +2079,7 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 		}
 
 		@Override
-		final void acceptOnIndex(final java.util.function.Consumer<? super MAP.Entry KEY_VALUE_GENERIC> action, int index) {
+		final void acceptOnIndex(final Consumer<? super MAP.Entry KEY_VALUE_GENERIC> action, final int index) {
 			action.accept(new MapEntry(index));
 		}
 
@@ -2326,21 +2349,20 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 	 */
 
 #ifdef Linked
-	private final class KeyIterator extends MapIterator implements KEY_LIST_ITERATOR KEY_GENERIC {
+	private final class KeyIterator extends MapIterator<METHOD_ARG_KEY_CONSUMER> implements KEY_LIST_ITERATOR KEY_GENERIC {
 		public KeyIterator(final KEY_GENERIC_TYPE k) { super(k); }
 
 		@Override
 		public KEY_GENERIC_TYPE PREV_KEY() { return key[previousEntry()]; }
-
 #else
 	private final class KeyIterator extends MapIterator<METHOD_ARG_KEY_CONSUMER> implements KEY_ITERATOR KEY_GENERIC {
-
-		@Override
-		final void acceptOnIndex(final METHOD_ARG_KEY_CONSUMER action, int index) {
-			action.accept(key[index]);
-		}
 #endif
 		public KeyIterator() { super(); }
+
+		@Override
+		final void acceptOnIndex(final METHOD_ARG_KEY_CONSUMER action, final int index) {
+			action.accept(key[index]);
+		}
 
 		@Override
 		public KEY_GENERIC_TYPE NEXT_KEY() { return key[nextEntry()]; }
@@ -2363,7 +2385,7 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 		}
 
 		@Override
-		final void acceptOnIndex(final METHOD_ARG_KEY_CONSUMER action, int index) {
+		final void acceptOnIndex(final METHOD_ARG_KEY_CONSUMER action, final int index) {
 			action.accept(key[index]);
 		}
 
@@ -2394,6 +2416,16 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 				iterator(), it.unimi.dsi.fastutil.Size64.sizeOf(OPEN_HASH_MAP.this), SPLITERATOR_CHARACTERISTICS);
 		}
 
+		/** {@inheritDoc} */
+		@Override
+		public void forEach(final METHOD_ARG_KEY_CONSUMER consumer) {
+			for(int i = size, curr, next = first; i-- != 0;) {
+				curr = next;
+				next = GET_NEXT(link[curr]);
+				consumer.accept(key[curr]);
+			}
+		}
+
 #else
 	private final class KeySet extends ABSTRACT_SET KEY_GENERIC {
 
@@ -2402,7 +2434,6 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 
 		@Override
 		public KEY_SPLITERATOR KEY_GENERIC spliterator() { return new KeySpliterator(); }
-#endif
 
 		/** {@inheritDoc} */
 		@Override
@@ -2413,6 +2444,7 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 				if (! KEY_IS_NULL(k)) consumer.accept(k);
 			}
 		}
+#endif
 
 		@Override
 		public int size() { return size; }
@@ -2478,19 +2510,19 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 	 */
 
 #ifdef Linked
-	private final class ValueIterator extends MapIterator implements VALUE_LIST_ITERATOR VALUE_GENERIC {
+	private final class ValueIterator extends MapIterator<METHOD_ARG_VALUE_CONSUMER> implements VALUE_LIST_ITERATOR VALUE_GENERIC {
 		@Override
 		public VALUE_GENERIC_TYPE PREV_VALUE() { return value[previousEntry()]; }
-
 #else
 	private final class ValueIterator extends MapIterator<METHOD_ARG_VALUE_CONSUMER> implements VALUE_ITERATOR VALUE_GENERIC {
+#endif
+
+		public ValueIterator() { super(); }
 
 		@Override
-		final void acceptOnIndex(final METHOD_ARG_VALUE_CONSUMER action, int index) {
+		final void acceptOnIndex(final METHOD_ARG_VALUE_CONSUMER action, final int index) {
 			action.accept(value[index]);
 		}
-#endif
-		public ValueIterator() { super(); }
 
 		@Override
 		public VALUE_GENERIC_TYPE NEXT_VALUE() { return value[nextEntry()]; }
@@ -2513,7 +2545,7 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 		}
 
 		@Override
-		final void acceptOnIndex(final METHOD_ARG_VALUE_CONSUMER action, int index) {
+		final void acceptOnIndex(final METHOD_ARG_VALUE_CONSUMER action, final int index) {
 			action.accept(value[index]);
 		}
 
@@ -2528,7 +2560,7 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 	public VALUE_COLLECTION VALUE_GENERIC values() {
 		if (values == null) values = new VALUE_ABSTRACT_COLLECTION VALUE_GENERIC() {
 #ifdef Linked
-				private static final int SPLITERATOR_CHARACTERISTICS = SPLITERATORS.COLLECTION_SPLITERATOR_CHARACTERISTICS | java.util.Spliterator.ORDERED;
+				private static final int SPLITERATOR_CHARACTERISTICS = VALUE_SPLITERATORS.COLLECTION_SPLITERATOR_CHARACTERISTICS | java.util.Spliterator.ORDERED;
 #endif
 				@Override
 				public VALUE_ITERATOR VALUE_GENERIC iterator() { return new ValueIterator(); }
@@ -2541,16 +2573,19 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 					return VALUE_SPLITERATORS.asSpliterator(
 						iterator(), it.unimi.dsi.fastutil.Size64.sizeOf(OPEN_HASH_MAP.this), SPLITERATOR_CHARACTERISTICS);
 				}
+
+				/** {@inheritDoc} */
+				@Override
+				public void forEach(final METHOD_ARG_VALUE_CONSUMER consumer) {
+					for(int i = size, curr, next = first; i-- != 0;) {
+						curr = next;
+						next = GET_NEXT(link[curr]);
+						consumer.accept(value[curr]);
+					}
+				}
 #else
 				@Override
 				public VALUE_SPLITERATOR VALUE_GENERIC spliterator() { return new ValueSpliterator(); }
-#endif
-				@Override
-				public int size() { return size; }
-				@Override
-				public boolean contains(VALUE_TYPE v) { return containsValue(v); }
-				@Override
-				public void clear() { OPEN_HASH_MAP.this.clear(); }
 
 				/** {@inheritDoc} */
 				@Override
@@ -2559,7 +2594,13 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 					for(int pos = n; pos-- != 0;)
 						if (! KEY_IS_NULL(key[pos])) consumer.accept(value[pos]);
 				}
-
+#endif
+				@Override
+				public int size() { return size; }
+				@Override
+				public boolean contains(VALUE_TYPE v) { return containsValue(v); }
+				@Override
+				public void clear() { OPEN_HASH_MAP.this.clear(); }
 			};
 
 		return values;
@@ -2765,11 +2806,7 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 	private void writeObject(java.io.ObjectOutputStream s) throws java.io.IOException {
 		final KEY_GENERIC_TYPE key[] = this.key;
 		final VALUE_GENERIC_TYPE value[] = this.value;
-#ifdef Linked
-		final MapIterator i = new MapIterator();
-#else
-		final MapIterator<?> i = new MapIterator<>();
-#endif
+		final EntryIterator i = new EntryIterator();
 		s.defaultWriteObject();
 
 		for(int j = size, e; j-- != 0;) {

--- a/drv/OpenHashMap.drv
+++ b/drv/OpenHashMap.drv
@@ -1719,6 +1719,8 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 			super(from);
 		}
 
+		// forEachRemaining inherited from MapIterator superclass.
+
 		@Override
 		final void acceptOnIndex(final Consumer<? super MAP.Entry KEY_VALUE_GENERIC> action, final int index) {
 			action.accept(new MapEntry(index));
@@ -1749,6 +1751,8 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 		public FastEntryIterator(KEY_GENERIC_TYPE from) {
 			super(from);
 		}
+		
+		// forEachRemaining inherited from MapIterator superclass.
 
 		@Override
 		final void acceptOnIndex(final Consumer<? super MAP.Entry KEY_VALUE_GENERIC> action, final int index) {
@@ -1924,6 +1928,8 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 		public MapEntry next() {
 			return entry = new MapEntry(nextEntry());
 		}
+		
+		// forEachRemaining inherited from MapIterator superclass.
 
 		@Override
 		final void acceptOnIndex(final Consumer<? super MAP.Entry KEY_VALUE_GENERIC> action, final int index) {
@@ -1945,6 +1951,8 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 			entry.index = nextEntry();
 			return entry;
 		}
+
+		// forEachRemaining inherited from MapIterator superclass.
 
 		@Override
 		final void acceptOnIndex(final Consumer<? super MAP.Entry KEY_VALUE_GENERIC> action, final int index) {
@@ -2150,6 +2158,8 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 
 		@Override
 		public ObjectSpliterator<MAP.Entry KEY_VALUE_GENERIC> spliterator() { return new EntrySpliterator(); }
+		
+		// 
 #endif
 
 		@Override
@@ -2359,10 +2369,14 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 #endif
 		public KeyIterator() { super(); }
 
+		// forEachRemaining inherited from MapIterator superclass.
+		// Despite the superclass declared with generics, the way Java inherits and generates bridge methods avoid the boxing/unboxing
+
 		@Override
 		final void acceptOnIndex(final METHOD_ARG_KEY_CONSUMER action, final int index) {
 			action.accept(key[index]);
 		}
+		
 
 		@Override
 		public KEY_GENERIC_TYPE NEXT_KEY() { return key[nextEntry()]; }
@@ -2518,6 +2532,9 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 #endif
 
 		public ValueIterator() { super(); }
+
+		// forEachRemaining inherited from MapIterator superclass.
+		// Despite the superclass declared with generics, the way Java inherits and generates bridge methods avoid the boxing/unboxing
 
 		@Override
 		final void acceptOnIndex(final METHOD_ARG_VALUE_CONSUMER action, final int index) {

--- a/drv/OpenHashMap.drv
+++ b/drv/OpenHashMap.drv
@@ -2370,7 +2370,7 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 		public KeyIterator() { super(); }
 
 		// forEachRemaining inherited from MapIterator superclass.
-		// Despite the superclass declared with generics, the way Java inherits and generates bridge methods avoid the boxing/unboxing
+		// Despite the superclass declared with generics, the way Java inherits and generates bridge methods avoids the boxing/unboxing
 
 		@Override
 		final void acceptOnIndex(final METHOD_ARG_KEY_CONSUMER action, final int index) {
@@ -2534,7 +2534,7 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 		public ValueIterator() { super(); }
 
 		// forEachRemaining inherited from MapIterator superclass.
-		// Despite the superclass declared with generics, the way Java inherits and generates bridge methods avoid the boxing/unboxing
+		// Despite the superclass declared with generics, the way Java inherits and generates bridge methods avoids the boxing/unboxing
 
 		@Override
 		final void acceptOnIndex(final METHOD_ARG_VALUE_CONSUMER action, final int index) {

--- a/test/it/unimi/dsi/fastutil/ints/Int2IntMapGenericLinkedOpenHashTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/Int2IntMapGenericLinkedOpenHashTest.java
@@ -19,11 +19,15 @@ package it.unimi.dsi.fastutil.ints;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import org.junit.Test;
 import org.junit.runners.Parameterized.Parameters;
@@ -142,6 +146,137 @@ public class Int2IntMapGenericLinkedOpenHashTest extends Int2IntMapGenericTest<I
 		iterator.remove();
 		assertEquals(50, iterator.nextIndex());
 		assertEquals(52, iterator.nextInt());
+	}
+
+	private static <T> List<T> toList(Collection<T> c) {
+		if (c instanceof List) {
+			return (List<T>)c;
+		}
+		if (c instanceof IntCollection) {
+			// T is assured to be Integer in this case
+			@SuppressWarnings("unchecked")
+			List<T> ret = (List<T>)toList((IntCollection) c);
+			return ret;
+		}
+		return new ArrayList<>(c);
+	}
+
+	private static IntList toList(IntCollection c) {
+		if (c instanceof IntList) {
+			return (IntList)c;
+		}
+		return new IntArrayList(c);
+	}
+
+	@Test
+	public void testEntrySetSameOrder() {
+		List<Entry> expectedOrder = new ArrayList<>();
+		// Intentionally thrown off natural order
+		for (int i = 0; i < 100; i++) {
+			int k;
+			int v;
+			if (i == 0) {
+				k = 500;
+				v = i;
+			} else {
+				k = i;
+				v = i;
+			}
+			m.put(k, v);
+			expectedOrder.add(new AbstractInt2IntMap.BasicEntry(k, v));
+		}
+
+		List<Entry> entries = toList(m.int2IntEntrySet());
+		assertEquals(expectedOrder, entries);
+
+		List<Entry> entriesForEach = new ArrayList<>();
+		//noinspection UseBulkOperation
+		m.int2IntEntrySet().forEach(entriesForEach::add);
+		assertEquals(expectedOrder, entriesForEach);
+
+		List<Entry> entriesFromIterator = new ArrayList<>();
+		//noinspection UseBulkOperation
+		m.int2IntEntrySet().iterator().forEachRemaining(entriesFromIterator::add);
+		assertEquals(expectedOrder, entriesFromIterator);
+
+		List<Entry> entriesFromSpliterator = m.int2IntEntrySet().stream().collect(Collectors.toList());
+		assertEquals(expectedOrder, entriesFromSpliterator);
+	}
+
+	@Test
+	public void testKeySetSameOrder() {
+		IntList expectedOrder = new IntArrayList();
+		// Intentionally thrown off natural order
+		for (int i = 0; i < 100; i++) {
+			int k;
+			int v;
+			if (i == 0) {
+				k = 500;
+				v = i;
+			} else {
+				k = i;
+				v = i;
+			}
+    		m.put(k, v);
+    		expectedOrder.add(k);
+		}
+
+		IntList keys = toList(m.keySet());
+		assertEquals(expectedOrder, keys);
+		
+		IntList keysFromEntrySet = IntArrayList.toList(m.int2IntEntrySet().stream().mapToInt(Entry::getIntKey));
+		assertEquals(expectedOrder, keysFromEntrySet);
+
+		IntList keysForEach = new IntArrayList();
+		//noinspection UseBulkOperation
+		m.keySet().forEach(keysForEach::add);
+		assertEquals(expectedOrder, keysForEach);
+
+		IntList keysFromIterator = new IntArrayList();
+		//noinspection UseBulkOperation
+		m.keySet().iterator().forEachRemaining(keysFromIterator::add);
+		assertEquals(expectedOrder, keysFromIterator);
+
+		IntList keysFromSpliterator = IntArrayList.toList(m.keySet().intStream());
+		assertEquals(expectedOrder, keysFromSpliterator);
+	}
+	
+	@Test
+	public void testValuesSameOrder() {
+		IntList expectedOrder = new IntArrayList();
+		// Intentionally thrown off natural order
+		for (int i = 0; i < 100; i++) {
+			int k;
+			int v;
+			if (i == 0) {
+				k = 500;
+				v = 1000;
+			} else {
+				k = i;
+				v = i;
+			}
+    		m.put(k, v);
+    		expectedOrder.add(v);
+		}
+
+		IntList values = toList(m.values());
+		assertEquals(expectedOrder, values);
+
+		IntList valuesFromEntrySet = IntArrayList.toList(m.int2IntEntrySet().stream().mapToInt(Entry::getIntValue));
+		assertEquals(expectedOrder, valuesFromEntrySet);
+
+		IntList valuesForEach = new IntArrayList();
+		//noinspection UseBulkOperation
+		m.values().forEach(valuesForEach::add);
+		assertEquals(expectedOrder, valuesForEach);
+
+		IntList valuesFromIterator = new IntArrayList();
+		//noinspection UseBulkOperation
+		m.values().iterator().forEachRemaining(valuesFromIterator::add);
+		assertEquals(expectedOrder, valuesFromIterator);
+
+		IntList valuesFromSpliterator = IntArrayList.toList(m.values().intStream());
+		assertEquals(expectedOrder, valuesFromSpliterator);
 	}
 
 	@Test(expected = NoSuchElementException.class)


### PR DESCRIPTION
* Fix issues where not all the ways to iterate `keySet` or `values` in a LinkedOpenHashMap would follow the proper order (instead falling back to regular OpenHashMap order).
* Make sure all OpenHashMap's (and their Linked and Custom cousins) views have proper iterators and spliterators, as well as proper `forEachRemaining` methods. This saves a lot of implicit casts by the generics supporting bridge methods the compiler inserts.
* Add unit tests for these
* Give some views of AbstractMap better `spliterator()` methods