### PR TITLE
Fix AbstractMap containing a stack overflow containsValue

### DIFF
--- a/drv/AbstractMap.drv
+++ b/drv/AbstractMap.drv
@@ -307,7 +307,7 @@ public abstract class ABSTRACT_MAP KEY_VALUE_GENERIC extends ABSTRACT_FUNCTION K
 				@Override
 				public KEY_SPLITERATOR KEY_GENERIC spliterator() {
 					return SPLITERATORS.asSpliterator(
-	 					iterator(), sizeOf(ABSTRACT_MAP.this), SPLITERATORS.SET_SPLITERATOR_CHARACTERISTICS);
+						iterator(), sizeOf(ABSTRACT_MAP.this), SPLITERATORS.SET_SPLITERATOR_CHARACTERISTICS);
 				}
 			};
 	}
@@ -352,7 +352,7 @@ public abstract class ABSTRACT_MAP KEY_VALUE_GENERIC extends ABSTRACT_FUNCTION K
 				@Override
 				public VALUE_SPLITERATOR VALUE_GENERIC spliterator() {
 					return VALUE_SPLITERATORS.asSpliterator(
-	 					iterator(), sizeOf(ABSTRACT_MAP.this), VALUE_SPLITERATORS.COLLECTION_SPLITERATOR_CHARACTERISTICS);
+						iterator(), sizeOf(ABSTRACT_MAP.this), VALUE_SPLITERATORS.COLLECTION_SPLITERATOR_CHARACTERISTICS);
 				}
 			};
 	}

--- a/drv/AbstractMap.drv
+++ b/drv/AbstractMap.drv
@@ -63,16 +63,35 @@ public abstract class ABSTRACT_MAP KEY_VALUE_GENERIC extends ABSTRACT_FUNCTION K
 
 	protected ABSTRACT_MAP() {}
 
-	@Override
-	public boolean containsValue(final VALUE_TYPE v) {
-		return values().contains(v);
-	}
-
+	/**
+	 * {@inheritDoc}
+	 * @implSpec This implementation does a linear search over the entry set, finding an entry that has the key specified.
+	 *   <p>If you override {@link #keySet()}, you should probably override this method too
+	 *   to take advantage of the (presumably) faster {@linkplain java.util.Set#contains key membership test} your {@link #keySet()} provides.
+	 *   <p>If you override this method but not {@link #keySet()}, then the returned key set will take advantage of this method.
+	 */
 	@Override
 	public boolean containsKey(final KEY_TYPE k) {
 		final ObjectIterator<MAP.Entry KEY_VALUE_GENERIC> i = ENTRYSET().iterator();
 		while(i.hasNext())
 			if (i.next().ENTRY_GET_KEY() == k)
+				return true;
+
+		return false;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * @implSpec This implementation does a linear search over the entry set, finding an entry that has the value specified.
+	 *   <p>If you override {@link #values()}, you should probably override this method too
+	 *   to take advantage of the (presumably) faster {@linkplain java.util.Collection#contains value membership test} your {@link #values()} provides.
+	 *   <p>If you override this method but not {@link #values()}, then the returned values collection will take advantage of this method.
+	 */
+	@Override
+	public boolean containsValue(final VALUE_TYPE v) {
+		final ObjectIterator<MAP.Entry KEY_VALUE_GENERIC> i = ENTRYSET().iterator();
+		while(i.hasNext())
+			if (i.next().ENTRY_GET_VALUE() == v)
 				return true;
 
 		return false;
@@ -308,7 +327,9 @@ public abstract class ABSTRACT_MAP KEY_VALUE_GENERIC extends ABSTRACT_FUNCTION K
 	public VALUE_COLLECTION VALUE_GENERIC values() {
 		return new VALUE_ABSTRACT_COLLECTION VALUE_GENERIC() {
 				@Override
-				public boolean contains(final VALUE_TYPE k) { return containsValue(k); }
+				public boolean contains(final VALUE_TYPE k) {
+					return containsValue(k);
+				}
 				@Override
 				public int size() { return ABSTRACT_MAP.this.size(); }
 				@Override
@@ -322,6 +343,8 @@ public abstract class ABSTRACT_MAP KEY_VALUE_GENERIC extends ABSTRACT_FUNCTION K
 							public VALUE_GENERIC_TYPE NEXT_VALUE() { return i.next().ENTRY_GET_VALUE(); }
 							@Override
 							public boolean hasNext() { return i.hasNext(); }
+							@Override
+							public void remove() { i.remove(); }
 							@Override
 							public void forEachRemaining(final METHOD_ARG_VALUE_CONSUMER action) {
 								i.forEachRemaining(entry -> action.accept(entry.ENTRY_GET_VALUE()));

--- a/drv/AbstractMap.drv
+++ b/drv/AbstractMap.drv
@@ -328,7 +328,6 @@ public abstract class ABSTRACT_MAP KEY_VALUE_GENERIC extends ABSTRACT_FUNCTION K
 		return new VALUE_ABSTRACT_COLLECTION VALUE_GENERIC() {
 				@Override
 				public boolean contains(final VALUE_TYPE k) { return containsValue(k); }
-				}
 				@Override
 				public int size() { return ABSTRACT_MAP.this.size(); }
 				@Override

--- a/drv/AbstractMap.drv
+++ b/drv/AbstractMap.drv
@@ -327,8 +327,7 @@ public abstract class ABSTRACT_MAP KEY_VALUE_GENERIC extends ABSTRACT_FUNCTION K
 	public VALUE_COLLECTION VALUE_GENERIC values() {
 		return new VALUE_ABSTRACT_COLLECTION VALUE_GENERIC() {
 				@Override
-				public boolean contains(final VALUE_TYPE k) {
-					return containsValue(k);
+				public boolean contains(final VALUE_TYPE k) { return containsValue(k); }
 				}
 				@Override
 				public int size() { return ABSTRACT_MAP.this.size(); }

--- a/test/it/unimi/dsi/fastutil/ints/AbstractInt2IntMapTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/AbstractInt2IntMapTest.java
@@ -88,24 +88,24 @@ public class AbstractInt2IntMapTest extends Int2IntMapGenericTest<AbstractInt2In
 				@Override
 				public ObjectIterator<Entry> iterator() {
 					return new ObjectIterator<Entry>() {
-    					final IntIterator keyIter = keys.iterator();
-    					final IntIterator valueIter = values.iterator();
-    					
-    					@Override
-    					public boolean hasNext() {
-    						return keyIter.hasNext();
-    					}
+					final IntIterator keyIter = keys.iterator();
+					final IntIterator valueIter = values.iterator();
+					
+					@Override
+					public boolean hasNext() {
+						return keyIter.hasNext();
+					}
 
 						@Override
 						public Entry next() {
 							return new AbstractInt2IntMap.BasicEntry(keyIter.nextInt(), valueIter.nextInt());
 						}
 
-    					@Override
-    					public void remove() {
-    						keyIter.remove();
-    						valueIter.remove();
-    					}
+					@Override
+					public void remove() {
+						keyIter.remove();
+						valueIter.remove();
+					}
 					};
 				}
 			};


### PR DESCRIPTION
If both the default `containsValue` and the default `values` methods are
inherited by an implementating class, they will get a `StackOverflowError`
on trying to test for a value being present.

This is because the default `values().contains` calls `containsValue`, but
the default `containsValue` calls `values().contains`.

Now make the default `containsValues` loop over the entry set.

Add a comment that you should probably override this is your `values()`
has a better implementation. Same also retroactively applied to `containsKey`
and `keySet()`.

Finally, retrofits `AbstractInt2IntMapTest` to extend`Int2IntMapGenericTest`, with a dummy testonly implementation that implements the bare minimum for a mutable Int2Int map. This is to test as many of the `AbstractInt2IntMap`'s default methods as possible. This gives it the set of tests we apply to all other `Int2IntMap`  impls.