### PR TITLE
Fix toXWithExpected size overallocating in parallel stream.

### DIFF
--- a/drv/ArrayList.drv
+++ b/drv/ArrayList.drv
@@ -40,7 +40,7 @@ import java.util.function.Consumer;
  * <em>never</em> made smaller (even on a {@link #clear()}). A family of
  * {@linkplain #trim() trimming methods} lets you control the size of the
  * backing array; this is particularly useful if you reuse instances of this class.
- * Range checks are equivalent to those of {@link java.util}'s classes, but
+ * Range checks are equivalent to those of {@code java.util}'s classes, but
  * they are delayed as much as possible. The backing array is exposed by the
  * {@link #elements()} method.
  *
@@ -340,7 +340,7 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 		return wrap(a, a.length);
 	}
 
-	/** Creates a new empty array list. 
+	/** Creates a new empty array list.
 	 *
 	 * @return a new empty array list.
 	 */
@@ -374,20 +374,28 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 	 		ARRAY_LIST::add,
 	 		ARRAY_LIST::addAll);
 	 }
-	 
-	/** Collects the result of a primitive {@code Stream} into a new ArrayList.
+
+	/** Collects the result of a primitive {@code Stream} into a new ArrayList, potentially pre-allocated to handle the given size.
 	 *
 	 * <p>This method performs a terminal operation on the given {@code Stream}
 	 *
 	 * @apiNote Taking a primitive stream instead returning something like a
 	 * {@link java.util.stream.Collector Collector} is necessary because there is no
 	 * primitive {@code Collector} equivalent in the Java API.
-	 * @implNote The current implementation preallocates the full size for every worker thread when used on parallel streams.
-	 *   This can be quite wasteful, as worker threads other then the first don't usually handle the contents of the full stream.
 	 */
 	public static KEY_GENERIC ARRAY_LIST KEY_GENERIC toListWithExpectedSize(JDK_PRIMITIVE_STREAM stream, int expectedSize) {
+ 		if (expectedSize <= DEFAULT_INITIAL_CAPACITY) {
+ 			// Already below default capacity. Just use all default construction instead of fiddling with atomics in SizeDecreasingSupplier
+ 			return toList(stream);
+		}
 		return stream.collect(
-			() -> new ARRAY_LIST KEY_GENERIC(expectedSize),
+			new COLLECTIONS.SizeDecreasingSupplier<
+#if KEYS_REFERENCE
+					K,
+#endif
+					ARRAY_LIST KEY_GENERIC>(
+				expectedSize, (int size) ->
+					size <= DEFAULT_INITIAL_CAPACITY ? new ARRAY_LIST KEY_GENERIC() : new ARRAY_LIST KEY_GENERIC(size)),
 			ARRAY_LIST::add,
 			ARRAY_LIST::addAll);
 	}
@@ -402,7 +410,7 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 		Collector.of(
 			ARRAY_LIST::new,
 			ARRAY_LIST::add,
-			ARRAY_LIST::combine); 
+			ARRAY_LIST::combine);
 
 	/** Returns a {@link Collector} that collects a {@code Stream}'s elements into a new ArrayList. */
 	SUPPRESS_WARNINGS_KEY_UNCHECKED_RAWTYPES
@@ -410,14 +418,20 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 		return (Collector) TO_LIST_COLLECTOR;
 	}
 
- 	/**
- 	 * Returns a {@link Collector} that collects a {@code Stream}'s elements into a new ArrayList.
-	 * @implNote The current implementation preallocates the full size for every worker thread when used on parallel streams.
-	 *   This can be quite wasteful, as worker threads other then the first don't usually handle the contents of the full stream.
- 	 */
+ 	/** Returns a {@link Collector} that collects a {@code Stream}'s elements into a new ArrayList, potentially pre-allocated to handle the given size. */
  	public static KEY_GENERIC Collector<KEY_GENERIC_TYPE, ?, ARRAY_LIST KEY_GENERIC> toListWithExpectedSize(int expectedSize) {
+ 		if (expectedSize <= DEFAULT_INITIAL_CAPACITY) {
+ 			// Already below default capacity. Just use all default construction instead of fiddling with atomics in SizeDecreasingSupplier
+ 			return toList();
+		}
  		return Collector.of(
-		() -> new ARRAY_LIST KEY_GENERIC_DIAMOND(expectedSize),
+ 			new COLLECTIONS.SizeDecreasingSupplier<
+#if KEYS_REFERENCE
+				K,
+#endif
+				ARRAY_LIST KEY_GENERIC>(
+			expectedSize, (int size) ->
+				size <= DEFAULT_INITIAL_CAPACITY ? new ARRAY_LIST KEY_GENERIC() : new ARRAY_LIST KEY_GENERIC(size)),
 		ARRAY_LIST::add,
 		ARRAY_LIST::combine);
 	}
@@ -694,7 +708,7 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 		public KEY_SPLITERATOR KEY_GENERIC spliterator() {
 			return new SubListSpliterator();
 		}
-		
+
 		boolean contentsEquals(KEY_GENERIC_TYPE[] otherA, int otherAFrom, int otherATo) {
 			if (a == otherA && from == otherAFrom && to == otherATo) return true;
 			if (otherATo - otherAFrom != size()) {
@@ -1151,7 +1165,7 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 		final KEY_GENERIC_TYPE[] a1 = a;
 		final KEY_GENERIC_TYPE[] a2 = l.a;
 
-		if (a1 == a2 && s == l.size()) return true; 
+		if (a1 == a2 && s == l.size()) return true;
 
 #if KEY_CLASS_Object
 		while(s-- !=  0) if (! java.util.Objects.equals(a1[s], a2[s])) return false;
@@ -1177,7 +1191,7 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 		}
 		if (o instanceof ARRAY_LIST.SubList) {
 			// Safe cast because we are only going to take elements from other list, never give them
-			// Sublist has an optimized sub-array based comparison, reuse that. 
+			// Sublist has an optimized sub-array based comparison, reuse that.
 			return ((ARRAY_LIST KEY_GENERIC.SubList)o).equals(this);
 		}
 		return super.equals(o);
@@ -1202,7 +1216,7 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 #if KEYS_PRIMITIVE // Can't make this assumption for reference types in case we have a goofy Comparable that doesn't compare itself equal
 		if (a1 == a2 && s1 == s2) return 0;
 #endif
-		
+
 		// TODO When minimum version of Java becomes Java 9, use Arrays.compare, which vectorizes.
 		KEY_GENERIC_TYPE e1, e2;
 		int r, i;

--- a/drv/Collections.drv
+++ b/drv/Collections.drv
@@ -20,6 +20,9 @@ package PACKAGE;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.IntFunction;
+import java.util.function.Supplier;
 #if KEYS_BYTE_CHAR_SHORT_FLOAT
 import WIDENED_PACKAGE.KEY_WIDENED_ITERATOR;
 import WIDENED_PACKAGE.WIDENED_ITERATORS;
@@ -536,4 +539,69 @@ public final class COLLECTIONS {
 		return new IterableCollection KEY_GENERIC_DIAMOND(iterable);
 	}
 
+#if KEYS_INT_LONG_DOUBLE || KEYS_REFERENCE  // Currently used for the collector methods, which only exist for the "first-class" primitives and object types.
+	/** Helper class for size decreasing size estimation.
+	 *
+	 * <p>Used to implement {@code toXWithExpectedSize} to prevent allocating a data structure big enough for the full stream in every thread, when only one thread
+	 * (typically the first one) is going to need to "see" all of it at some point.
+	 *
+	 * <p>Currently set to always assume a roughly split-by-two strategy from the {@link java.util.Spliterator} backing the
+	 * {@link java.util.stream.Stream} (or primitive equivalant). This may perform worse for {@code Spliterator}s that don't
+	 * (for example the ones that wrap an {@link java.util.Iterator} as a {@code Spliterator}). This is quite rare in practice however.
+	 * But note that even in such cases, this would <em>still</em> perform no worse (modulo some trivial amount) then the default
+	 * "flat size for every list" method of combining.
+ 	 * A way to detect such cases a different size estimation strategy may come in the future.
+ 	 *
+ 	 * <p>See the constructor for requirements of the {@link #builder} functor.
+	 */
+	static class SizeDecreasingSupplier<
+#if KEYS_REFERENCE
+			K,
+#endif
+			C extends COLLECTION KEY_GENERIC> implements Supplier<C> {
+		static final int RECOMMENDED_MIN_SIZE = 8;
+
+		final AtomicInteger suppliedCount = new AtomicInteger(0);
+		final int expectedFinalSize;
+		final IntFunction<C> builder;
+
+		/**
+		 * Construct the proper empty collection preallocated to the given size.
+		 *
+		 * @param expectedFinalSize The expected size of the entire remaining contents of the {@code Stream}
+		 *   and thus what the holding the final results should  size what size to try to preallocate to.
+		 * @param builder the builder function.
+		 *   <p>The input integer will be the size of the collection to preallocate.
+		 *   <p>The subclass is free to use the default constructor for the Collection contruction
+		 *     instead of the {@code size} given
+		 *     if {@code size} falls below the default size used for the default initial capacity for
+		 *     that Collection implementation. Often such default constructors contain additional
+		 *     optimizations that giving an explicit initial capacity would not do (even if given
+		 *     the default capacity as the initial capacity explicitly).
+		 *   <p>Even if the Collection type being constructed doesn't, it is recommended that you allocate a
+		 *     minimum size if the given {@code size} ({@link #RECOMMENDED_MIN_SIZE} gives a good enough ballpark for most cases).
+		 *   <p>{@link Supplier#get() get()} of the {@link Supplier} must return non-{@code null}.
+		 */
+		SizeDecreasingSupplier(int expectedFinalSize, IntFunction<C> builder) {
+			this.expectedFinalSize = expectedFinalSize;
+			this.builder = builder;
+		}
+
+		// This method may be worth pulling into a shared superclass.
+		@Override
+		public C get() {
+			// The "correct" splitting (assuming split by two) would be
+			// expectedFinalSize / floor(ln_2(++suppliedCount)). But that seems too much trouble to be worth it.
+			// Instead we will take a simple harmonically decreasing ratio (1, 1/2, 1/3, 1/4)
+			//
+			// Round up int math (to round up, not down) adapted from https://stackoverflow.com/a/503201.
+			int expectedNeededNextSize = 1 + ((expectedFinalSize - 1) / suppliedCount.incrementAndGet());
+			if (expectedNeededNextSize < 0) {
+				// Overflow (and weird below zero results) failsafe
+				expectedNeededNextSize = RECOMMENDED_MIN_SIZE;
+			}
+			return builder.apply(expectedNeededNextSize);
+		}
+	}
+#endif  // KEYS_INT_LONG_DOUBLE || KEYS_REFERENCE
 }

--- a/drv/Collections.drv
+++ b/drv/Collections.drv
@@ -546,11 +546,11 @@ public final class COLLECTIONS {
 	 * (typically the first one) is going to need to "see" all of it at some point.
 	 *
 	 * <p>Currently set to always assume a roughly split-by-two strategy from the {@link java.util.Spliterator} backing the
-	 * {@link java.util.stream.Stream} (or primitive equivalant). This may perform worse for {@code Spliterator}s that don't
+	 * {@link java.util.stream.Stream} (or primitive equivalent). This may perform worse for {@code Spliterator}s that don't
 	 * (for example the ones that wrap an {@link java.util.Iterator} as a {@code Spliterator}). This is quite rare in practice however.
 	 * But note that even in such cases, this would <em>still</em> perform no worse (modulo some trivial amount) then the default
 	 * "flat size for every list" method of combining.
-	 * A way to detect such cases a different size estimation strategy may come in the future.
+	 * A way to detect such cases and use a different size estimation strategy may come in the future.
 	 *
 	 * <p>See the {@linkplain #SizeDecreasingSupplier constructor} for requirements of the {@link #builder} functor.
 	 */
@@ -580,7 +580,7 @@ public final class COLLECTIONS {
 		 *     that Collection implementation. Often such default constructors contain additional
 		 *     optimizations that giving an explicit initial capacity would not do (even if given
 		 *     the default capacity as the initial capacity explicitly).
-		 *   <p>{@link Supplier#get() get()} of the {@link Supplier} must return non-{@code null}.
+		 *   <p>{@link Supplier#get() get()} of the {@link IntFunction} must return non-{@code null}.
 		 */
 		SizeDecreasingSupplier(int expectedFinalSize, IntFunction<C> builder) {
 			this.expectedFinalSize = expectedFinalSize;

--- a/drv/Collections.drv
+++ b/drv/Collections.drv
@@ -550,9 +550,9 @@ public final class COLLECTIONS {
 	 * (for example the ones that wrap an {@link java.util.Iterator} as a {@code Spliterator}). This is quite rare in practice however.
 	 * But note that even in such cases, this would <em>still</em> perform no worse (modulo some trivial amount) then the default
 	 * "flat size for every list" method of combining.
- 	 * A way to detect such cases a different size estimation strategy may come in the future.
- 	 *
- 	 * <p>See the constructor for requirements of the {@link #builder} functor.
+	 * A way to detect such cases a different size estimation strategy may come in the future.
+	 *
+	 * <p>See the {@linkplain #SizeDecreasingSupplier constructor} for requirements of the {@link #builder} functor.
 	 */
 	static class SizeDecreasingSupplier<
 #if KEYS_REFERENCE
@@ -566,20 +566,20 @@ public final class COLLECTIONS {
 		final IntFunction<C> builder;
 
 		/**
-		 * Construct the proper empty collection preallocated to the given size.
+		 * Construct this {@link SizeDecreasingSupplier}.
 		 *
 		 * @param expectedFinalSize The expected size of the entire remaining contents of the {@code Stream}
-		 *   and thus what the holding the final results should  size what size to try to preallocate to.
+		 *   and thus what size the Collection holding the final results should try to be preallocated to.
 		 * @param builder the builder function.
 		 *   <p>The input integer will be the size of the collection to preallocate.
-		 *   <p>The subclass is free to use the default constructor for the Collection contruction
+		 *   <p>It is recommended that you allocate a minimum size if the given {@code size} is small.
+		 *     {@link #RECOMMENDED_MIN_SIZE} gives a good enough ballpark for most cases.
+		 *   <p>The subclass is free to use the default constructor for the Collection construction
 		 *     instead of the {@code size} given
 		 *     if {@code size} falls below the default size used for the default initial capacity for
 		 *     that Collection implementation. Often such default constructors contain additional
 		 *     optimizations that giving an explicit initial capacity would not do (even if given
 		 *     the default capacity as the initial capacity explicitly).
-		 *   <p>Even if the Collection type being constructed doesn't, it is recommended that you allocate a
-		 *     minimum size if the given {@code size} ({@link #RECOMMENDED_MIN_SIZE} gives a good enough ballpark for most cases).
 		 *   <p>{@link Supplier#get() get()} of the {@link Supplier} must return non-{@code null}.
 		 */
 		SizeDecreasingSupplier(int expectedFinalSize, IntFunction<C> builder) {

--- a/drv/ImmutableList.drv
+++ b/drv/ImmutableList.drv
@@ -41,7 +41,7 @@ import java.util.stream.Collector;
 
 public class IMMUTABLE_LIST KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENERIC implements LIST KEY_GENERIC, RandomAccess, Cloneable, java.io.Serializable {
 	private static final long serialVersionUID = 0L;
-	
+
 	SUPPRESS_WARNINGS_KEY_UNCHECKED_RAWTYPES
 	static final IMMUTABLE_LIST EMPTY = new IMMUTABLE_LIST(ARRAYS.EMPTY_ARRAY);
 
@@ -119,7 +119,7 @@ public class IMMUTABLE_LIST KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENE
 	public IMMUTABLE_LIST(final KEY_ITERATOR KEY_EXTENDS_GENERIC i) {
 		this(i.hasNext() ? ITERATORS.unwrap(i) : _EMPTY_ARRAY);
 	}
-	
+
 	/**
 	 * Returns an empty immutable list.
 	 * @return an immutable list (possibly shared) that is empty.
@@ -167,15 +167,13 @@ public class IMMUTABLE_LIST KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENE
 		return convertTrustedToImmutableList(ARRAY_LIST.toList(stream));
 	}
 
-	/** Collects the result of a primitive {@code Stream} into a new ImmutableList.
+	/** Collects the result of a primitive {@code Stream} into a new ImmutableList, potentially pre-allocated to handle the given size.
 	 *
 	 * <p>This method performs a terminal operation on the given {@code Stream}
 	 *
 	 * @apiNote Taking a primitive stream instead returning something like a
 	 * {@link java.util.stream.Collector Collector} is necessary because there is no
 	 * primitive {@code Collector} equivalent in the Java API.
-	 * @implNote The current implementation preallocates the full size for every worker thread when used on parallel streams.
-	 *   This can be quite wasteful, as worker threads other then the first don't usually handle the full stream.
 	 */
 	public static KEY_GENERIC IMMUTABLE_LIST KEY_GENERIC toListWithExpectedSize(JDK_PRIMITIVE_STREAM stream, int expectedSize) {
 		return convertTrustedToImmutableList(ARRAY_LIST.toListWithExpectedSize(stream, expectedSize));
@@ -194,14 +192,20 @@ public class IMMUTABLE_LIST KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENE
 		return (Collector) TO_LIST_COLLECTOR;
 	}
 
- 	/**
- 	 * Returns a {@link Collector} that collects a {@code Stream}'s elements into a new ImmutableList.
- 	 * @implNote The current implementation preallocates the full size for every worker thread when used on parallel streams.
-	 *   This can be quite wasteful, as worker threads other then the first don't usually handle the full stream.
- 	 */
+ 	/** Returns a {@link Collector} that collects a {@code Stream}'s elements into a new ImmutableList, potentially pre-allocated to handle the given size. */
  	public static KEY_GENERIC Collector<KEY_GENERIC_TYPE, ?, IMMUTABLE_LIST KEY_GENERIC> toListWithExpectedSize(int expectedSize) {
+ 		if (expectedSize <= ARRAY_LIST.DEFAULT_INITIAL_CAPACITY) {
+ 			// Already below default capacity. Just use all default construction instead of fiddling with atomics in SizeDecreasingSupplier
+ 			return toList();
+		}
  		return Collector.<KEY_GENERIC_TYPE, ARRAY_LIST KEY_GENERIC, IMMUTABLE_LIST KEY_GENERIC>of(
-			() -> new ARRAY_LIST KEY_GENERIC_DIAMOND(expectedSize),
+			new COLLECTIONS.SizeDecreasingSupplier<
+#if KEYS_REFERENCE
+					K,
+#endif
+					ARRAY_LIST KEY_GENERIC>(
+				expectedSize, (int size) ->
+					size <= ARRAY_LIST.DEFAULT_INITIAL_CAPACITY ? new ARRAY_LIST KEY_GENERIC() : new ARRAY_LIST KEY_GENERIC(size)),
 			ARRAY_LIST::add,
 			ARRAY_LIST::combine,
 			IMMUTABLE_LIST::convertTrustedToImmutableList);
@@ -428,7 +432,7 @@ public class IMMUTABLE_LIST KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENE
 	public KEY_SPLITERATOR KEY_GENERIC spliterator() {
 		return new Spliterator();
 	}
-	
+
 	private final static class ImmutableSubList KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENERIC implements java.util.RandomAccess, java.io.Serializable {
 		private static final long serialVersionUID = 7054639518438982401L;
 		final IMMUTABLE_LIST KEY_GENERIC innerList;
@@ -466,12 +470,12 @@ public class IMMUTABLE_LIST KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENE
 			for(int i = to; i-- != from;) if (KEY_EQUALS(k, a[i])) return i - from;
 			return -1;
 		}
-	
+
 		@Override
 		public int size() {
 			return to - from;
 		}
-	
+
 		@Override
 		public boolean isEmpty() {
 			return to <= from;
@@ -481,11 +485,11 @@ public class IMMUTABLE_LIST KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENE
 		public void getElements(final int fromSublistIndex, final KEY_TYPE[] a, final int offset, final int length) {
 			ARRAYS.ensureOffsetLength(a, offset, length);
 			ensureRestrictedIndex(fromSublistIndex);
-			if (from + length > to) 
+			if (from + length > to)
 				throw new IndexOutOfBoundsException("Final index " + (from + length) + " (startingIndex: " + from + " + length: " + length + ") is greater then list length " + size());
 			System.arraycopy(this.a, fromSublistIndex + from, a, offset, length);
 		}
-	
+
 		@Override
 		public void forEach(final METHOD_ARG_KEY_CONSUMER action) {
 			for (int i = from; i < to; ++i) {
@@ -496,9 +500,9 @@ public class IMMUTABLE_LIST KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENE
 #if KEYS_PRIMITIVE
 		@Override
 		public KEY_TYPE[] TO_KEY_ARRAY() {
-			return java.util.Arrays.copyOfRange(a, from, to); 
+			return java.util.Arrays.copyOfRange(a, from, to);
 		}
-	
+
 		@Override
 		public KEY_TYPE[] toArray(KEY_TYPE a[]) {
 			if (a == null || a.length < size()) a = new KEY_TYPE[size()];
@@ -511,7 +515,7 @@ public class IMMUTABLE_LIST KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENE
 			// A subtle part of the spec says the returned array must be Object[] exactly.
 			return java.util.Arrays.copyOfRange(a, from, to, Object[].class);
 		}
-	
+
 		SUPPRESS_WARNINGS_KEY_UNCHECKED
 		@Override
 		public KEY_GENERIC KEY_GENERIC_TYPE[] toArray(KEY_GENERIC_TYPE a[]) {
@@ -532,10 +536,10 @@ public class IMMUTABLE_LIST KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENE
 		@Override
 		public KEY_LIST_ITERATOR KEY_GENERIC listIterator(final int index) {
 			ensureIndex(index);
-	
+
 			return new KEY_LIST_ITERATOR KEY_GENERIC() {
 					int pos = index;
-	
+
 					@Override
 					public boolean hasNext() { return pos < to; }
 					@Override
@@ -748,8 +752,8 @@ public class IMMUTABLE_LIST KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENE
 		if (from > to) throw new IllegalArgumentException("Start index (" + from + ") is greater than end index (" + to + ")");
 		return new ImmutableSubList KEY_GENERIC_DIAMOND(this, from, to);
 	}
-		
-	
+
+
 	@Override
 	public IMMUTABLE_LIST KEY_GENERIC clone() {
 		return this;
@@ -793,7 +797,7 @@ public class IMMUTABLE_LIST KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENE
 			return equals((IMMUTABLE_LIST KEY_GENERIC) o);
 		}
 		if (o instanceof ImmutableSubList) {
-			// Sublist has an optimized sub-array based comparison, reuse that. 
+			// Sublist has an optimized sub-array based comparison, reuse that.
 			return ((ImmutableSubList KEY_GENERIC)o).equals(this);
 		}
 		return super.equals(o);

--- a/drv/OpenHashSet.drv
+++ b/drv/OpenHashSet.drv
@@ -575,14 +575,14 @@ public class OPEN_HASH_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implemen
 		this(a, DEFAULT_LOAD_FACTOR);
 	}
 
-	/** Creates a new empty hash set. 
+	/** Creates a new empty hash set.
 	 *
 	 * @return a new empty hash set.
 	 */
 	public static KEY_GENERIC OPEN_HASH_SET KEY_GENERIC of() {
 		return new OPEN_HASH_SET KEY_GENERIC_DIAMOND();
 	}
-	
+
 	/** Creates a new hash set with {@link Hash#DEFAULT_LOAD_FACTOR} as load factor
 	 * using the given element.
 	 *
@@ -648,7 +648,7 @@ public class OPEN_HASH_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implemen
 				throw new IllegalArgumentException("Duplicate element " + element);
 			}
 		}
-		return result; 
+		return result;
 	}
 #endif
 
@@ -668,20 +668,28 @@ public class OPEN_HASH_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implemen
 	 		OPEN_HASH_SET::add,
 	 		OPEN_HASH_SET::addAll);
 	 }
-	 
-	/** Collects the result of a primitive {@code Stream} into a new hash set.
+
+	/** Collects the result of a primitive {@code Stream} into a new hash set, potentially pre-allocated to handle the given size.
 	 *
 	 * <p>This method performs a terminal operation on the given {@code Stream}
 	 *
 	 * @apiNote Taking a primitive stream instead returning something like a
 	 * {@link java.util.stream.Collector Collector} is necessary because there is no
 	 * primitive {@code Collector} equivalent in the Java API.
-	 * @implNote The current implementation preallocates the full size for every worker thread when used on parallel streams.
-	 *   This can be quite wasteful, as worker threads other then the first don't usually handle the full stream.
 	 */
 	public static KEY_GENERIC OPEN_HASH_SET KEY_GENERIC toSetWithExpectedSize(JDK_PRIMITIVE_STREAM stream, int expectedSize) {
+ 		if (expectedSize <= Hash.DEFAULT_INITIAL_SIZE) {
+ 			// Already below default capacity. Just use all default construction instead of fiddling with atomics in SizeDecreasingSupplier
+ 			return toSet(stream);
+		}
 		return stream.collect(
-			() -> new OPEN_HASH_SET KEY_GENERIC(expectedSize),
+			new COLLECTIONS.SizeDecreasingSupplier<
+#if KEYS_REFERENCE
+					K,
+#endif
+					OPEN_HASH_SET KEY_GENERIC>(
+				expectedSize, (int size) ->
+					size <= Hash.DEFAULT_INITIAL_SIZE ? new OPEN_HASH_SET KEY_GENERIC() : new OPEN_HASH_SET KEY_GENERIC(size)),
 			OPEN_HASH_SET::add,
 			OPEN_HASH_SET::addAll);
 	}
@@ -696,7 +704,7 @@ public class OPEN_HASH_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implemen
 		Collector.of(
 			OPEN_HASH_SET::new,
 			OPEN_HASH_SET::add,
-			OPEN_HASH_SET::combine); 
+			OPEN_HASH_SET::combine);
 
 	/** Returns a {@link Collector} that collects a {@code Stream}'s elements into a new hash set. */
 	SUPPRESS_WARNINGS_KEY_UNCHECKED_RAWTYPES
@@ -704,14 +712,20 @@ public class OPEN_HASH_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implemen
 		return (Collector) TO_SET_COLLECTOR;
 	}
 
- 	/**
- 	 * Returns a {@link Collector} that collects a {@code Stream}'s elements into a new hash set.
- 	 * @implNote The current implementation preallocates the full size for every worker thread when used on parallel streams.
-	 *   This can be quite wasteful, as worker threads other then the first don't usually handle the full stream.
- 	 */
+ 	/** Returns a {@link Collector} that collects a {@code Stream}'s elements into a new hash set, potentially pre-allocated to handle the given size. */
  	public static KEY_GENERIC Collector<KEY_GENERIC_TYPE, ?, OPEN_HASH_SET KEY_GENERIC> toSetWithExpectedSize(int expectedSize) {
+ 		if (expectedSize <= Hash.DEFAULT_INITIAL_SIZE) {
+ 			// Already below default capacity. Just use all default construction instead of fiddling with atomics in SizeDecreasingSupplier
+ 			return toSet();
+		}
  		return Collector.of(
-		() -> new OPEN_HASH_SET KEY_GENERIC(expectedSize),
+ 			new COLLECTIONS.SizeDecreasingSupplier<
+#if KEYS_REFERENCE
+					K,
+#endif
+					OPEN_HASH_SET KEY_GENERIC>(
+			expectedSize, (int size) ->
+				size <= Hash.DEFAULT_INITIAL_SIZE ? new OPEN_HASH_SET KEY_GENERIC() : new OPEN_HASH_SET KEY_GENERIC(size)),
 		OPEN_HASH_SET::add,
 		OPEN_HASH_SET::combine);
 	}

--- a/test/it/unimi/dsi/fastutil/ints/IntArrayListTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntArrayListTest.java
@@ -430,6 +430,46 @@ public class IntArrayListTest {
 	}
 
 	@Test
+	public void testToListWithExpectedSize() {
+		final IntArrayList baseList = IntArrayList.toList(java.util.stream.IntStream.range(0, 100));
+		IntArrayList transformed = IntArrayList.toListWithExpectedSize(baseList.intStream().map(i -> i + 40), 100);
+		final IntArrayList expectedList = IntArrayList.toList(baseList.intStream().map(i -> i + 40));
+		assertEquals(expectedList, transformed);
+
+		// Test undersized below default capacity
+		transformed = IntArrayList.toListWithExpectedSize(baseList.intStream().map(i -> i + 40), 5);
+		assertEquals(expectedList, transformed);
+
+		// Test undersized above default capacity
+		transformed = IntArrayList.toListWithExpectedSize(baseList.intStream().map(i -> i + 40), 50);
+		assertEquals(expectedList, transformed);
+
+		// Test oversized
+		transformed = IntArrayList.toListWithExpectedSize(baseList.intStream().map(i -> i + 40), 50000);
+		assertEquals(expectedList, transformed);
+	}
+
+	@Test
+	public void testToListWithExpectedSize_parallel() {
+		final IntArrayList baseList = IntArrayList.toList(java.util.stream.IntStream.range(0, 5000).parallel());
+		IntArrayList transformed = IntArrayList.toListWithExpectedSize(baseList.intParallelStream().map(i -> i + 40), 5000);
+		final IntArrayList expectedList = IntArrayList.toList(baseList.intParallelStream().map(i -> i + 40));
+		assertEquals(expectedList, transformed);
+
+		// Test undersized below default capacity
+		transformed = IntArrayList.toListWithExpectedSize(baseList.intParallelStream().map(i -> i + 40), 5);
+		assertEquals(expectedList, transformed);
+
+		// Test undersized above default capacity
+		transformed = IntArrayList.toListWithExpectedSize(baseList.intParallelStream().map(i -> i + 40), 50);
+		assertEquals(expectedList, transformed);
+
+		// Test oversized
+		transformed = IntArrayList.toListWithExpectedSize(baseList.intParallelStream().map(i -> i + 40), 50000);
+		assertEquals(expectedList, transformed);
+	}
+
+	@Test
 	public void testSpliteratorTrySplit() {
 		final IntArrayList baseList = IntArrayList.of(0, 1, 2, 3, 72, 5, 6);
 		final IntSpliterator willBeSuffix = baseList.spliterator();

--- a/test/it/unimi/dsi/fastutil/ints/IntImmutableListTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntImmutableListTest.java
@@ -70,7 +70,47 @@ public class IntImmutableListTest {
 		final IntImmutableList transformed = IntImmutableList.toList(baseList.intStream().map(i -> i + 40));
 		assertEquals(IntImmutableList.of(42, 420, 1337), transformed);
 	}
-	
+
+	@Test
+	public void testToListWithExpectedSize() {
+		final IntImmutableList baseList = IntImmutableList.toList(java.util.stream.IntStream.range(0, 100));
+		IntImmutableList transformed = IntImmutableList.toListWithExpectedSize(baseList.intStream().map(i -> i + 40), 100);
+		final IntImmutableList expectedList = IntImmutableList.toList(baseList.intStream().map(i -> i + 40));
+		assertEquals(expectedList, transformed);
+
+		// Test undersized below default capacity
+		transformed = IntImmutableList.toListWithExpectedSize(baseList.intStream().map(i -> i + 40), 5);
+		assertEquals(expectedList, transformed);
+
+		// Test undersized above default capacity
+		transformed = IntImmutableList.toListWithExpectedSize(baseList.intStream().map(i -> i + 40), 50);
+		assertEquals(expectedList, transformed);
+
+		// Test oversized
+		transformed = IntImmutableList.toListWithExpectedSize(baseList.intStream().map(i -> i + 40), 50000);
+		assertEquals(expectedList, transformed);
+	}
+
+	@Test
+	public void testToListWithExpectedSize_parallel() {
+		final IntImmutableList baseList = IntImmutableList.toList(java.util.stream.IntStream.range(0, 5000).parallel());
+		IntImmutableList transformed = IntImmutableList.toListWithExpectedSize(baseList.intParallelStream().map(i -> i + 40), 5000);
+		final IntImmutableList expectedList = IntImmutableList.toList(baseList.intParallelStream().map(i -> i + 40));
+		assertEquals(expectedList, transformed);
+
+		// Test undersized below default capacity
+		transformed = IntImmutableList.toListWithExpectedSize(baseList.intParallelStream().map(i -> i + 40), 5);
+		assertEquals(expectedList, transformed);
+
+		// Test undersized above default capacity
+		transformed = IntImmutableList.toListWithExpectedSize(baseList.intParallelStream().map(i -> i + 40), 50);
+		assertEquals(expectedList, transformed);
+
+		// Test oversized
+		transformed = IntImmutableList.toListWithExpectedSize(baseList.intParallelStream().map(i -> i + 40), 50000);
+		assertEquals(expectedList, transformed);
+	}
+
 	@Test
 	public void testEquals_AnotherImmutableList() {
 		final IntImmutableList baseList = IntImmutableList.of(2, 380, 1297);
@@ -196,7 +236,7 @@ public class IntImmutableListTest {
 		final IntList sl = l.subList(0, 3);
 		assertArrayEquals(new int[] { 0, 1, 2 }, sl.toIntArray());
 	}
-	
+
 	@Test
 	public void testSubList_testSubSubList() {
 		final IntImmutableList l = IntImmutableList.of(0, 1, 2, 3, 4);

--- a/test/it/unimi/dsi/fastutil/ints/IntOpenHashSetTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntOpenHashSetTest.java
@@ -364,6 +364,46 @@ public class IntOpenHashSetTest {
 	}
 
 	@Test
+	public void testToSetWithExpectedSize() {
+		final IntOpenHashSet baseSet = IntOpenHashSet.toSet(java.util.stream.IntStream.range(0, 100));
+		IntOpenHashSet transformed = IntOpenHashSet.toSetWithExpectedSize(baseSet.intStream().map(i -> i + 40), 100);
+		final IntOpenHashSet expectedSet = IntOpenHashSet.toSet(baseSet.intStream().map(i -> i + 40));
+		assertEquals(expectedSet, transformed);
+
+		// Test undersized below default capacity
+		transformed = IntOpenHashSet.toSetWithExpectedSize(baseSet.intStream().map(i -> i + 40), 5);
+		assertEquals(expectedSet, transformed);
+
+		// Test undersized above default capacity
+		transformed = IntOpenHashSet.toSetWithExpectedSize(baseSet.intStream().map(i -> i + 40), 50);
+		assertEquals(expectedSet, transformed);
+
+		// Test oversized
+		transformed = IntOpenHashSet.toSetWithExpectedSize(baseSet.intStream().map(i -> i + 40), 50000);
+		assertEquals(expectedSet, transformed);
+	}
+
+	@Test
+	public void testToSetWithExpectedSize_parallel() {
+		final IntOpenHashSet baseSet = IntOpenHashSet.toSet(java.util.stream.IntStream.range(0, 5000).parallel());
+		IntOpenHashSet transformed = IntOpenHashSet.toSetWithExpectedSize(baseSet.intParallelStream().map(i -> i + 40), 5000);
+		final IntOpenHashSet expectedSet = IntOpenHashSet.toSet(baseSet.intParallelStream().map(i -> i + 40));
+		assertEquals(expectedSet, transformed);
+
+		// Test undersized below default capacity
+		transformed = IntOpenHashSet.toSetWithExpectedSize(baseSet.intParallelStream().map(i -> i + 40), 5);
+		assertEquals(expectedSet, transformed);
+
+		// Test undersized above default capacity
+		transformed = IntOpenHashSet.toSetWithExpectedSize(baseSet.intParallelStream().map(i -> i + 40), 50);
+		assertEquals(expectedSet, transformed);
+
+		// Test oversized
+		transformed = IntOpenHashSet.toSetWithExpectedSize(baseSet.intParallelStream().map(i -> i + 40), 50000);
+		assertEquals(expectedSet, transformed);
+	}
+
+	@Test
 	public void testSpliteratorTrySplit() {
 		final IntOpenHashSet baseSet = IntOpenHashSet.of(0, 1, 2, 3, 72, 5, 6);
 		final IntSpliterator spliterator1 = baseSet.spliterator();

--- a/test/it/unimi/dsi/fastutil/objects/ObjectArrayListTest.java
+++ b/test/it/unimi/dsi/fastutil/objects/ObjectArrayListTest.java
@@ -177,6 +177,26 @@ public class ObjectArrayListTest {
 	}
 
 	@Test
+	public void testToListWithExpectedSize() {
+		final ObjectArrayList<String> baseList = ObjectArrayList.of("wood", "board", "glass", "metal");
+		ObjectArrayList<String> transformed = baseList.stream().map(s -> "ply" + s).collect(ObjectArrayList.toListWithExpectedSize(4));
+		final ObjectArrayList<String> expectedList = ObjectArrayList.of("plywood", "plyboard", "plyglass", "plymetal");
+		assertEquals(expectedList, transformed);
+
+		// Test undersized below default capacity
+		transformed = baseList.stream().map(s -> "ply" + s).collect(ObjectArrayList.toListWithExpectedSize(2));
+		assertEquals(expectedList, transformed);
+
+		// Test oversized below default capacity
+		transformed = baseList.stream().map(s -> "ply" + s).collect(ObjectArrayList.toListWithExpectedSize(8));
+		assertEquals(expectedList, transformed);
+
+		// Test oversized
+		transformed = baseList.stream().map(s -> "ply" + s).collect(ObjectArrayList.toListWithExpectedSize(50));
+		assertEquals(expectedList, transformed);
+	}
+
+	@Test
 	public void testSpliteratorTrySplit() {
 		final ObjectArrayList<String> baseList = ObjectArrayList
 				.of("0", "1", "2", "3", "4", "5", "bird");

--- a/test/it/unimi/dsi/fastutil/objects/ObjectOpenHashSetTest.java
+++ b/test/it/unimi/dsi/fastutil/objects/ObjectOpenHashSetTest.java
@@ -122,6 +122,26 @@ public class ObjectOpenHashSetTest {
 	}
 
 	@Test
+	public void testToSetWithExpectedSize() {
+		final ObjectOpenHashSet<String> baseSet = ObjectOpenHashSet.of("wood", "board", "glass", "metal");
+		ObjectOpenHashSet<String> transformed = baseSet.stream().map(s -> "ply" + s).collect(ObjectOpenHashSet.toSetWithExpectedSize(4));
+		final ObjectOpenHashSet<String> expectedSet = ObjectOpenHashSet.of("plywood", "plyboard", "plyglass", "plymetal");
+		assertEquals(expectedSet, transformed);
+
+		// Test undersized below default capacity
+		transformed = baseSet.stream().map(s -> "ply" + s).collect(ObjectOpenHashSet.toSetWithExpectedSize(2));
+		assertEquals(expectedSet, transformed);
+
+		// Test oversized below default capacity
+		transformed = baseSet.stream().map(s -> "ply" + s).collect(ObjectOpenHashSet.toSetWithExpectedSize(8));
+		assertEquals(expectedSet, transformed);
+
+		// Test oversized
+		transformed = baseSet.stream().map(s -> "ply" + s).collect(ObjectOpenHashSet.toSetWithExpectedSize(50));
+		assertEquals(expectedSet, transformed);
+	}
+
+	@Test
 	public void testSpliteratorTrySplit() {
 		final ObjectOpenHashSet<String> baseSet = ObjectOpenHashSet
 				.of("0", "1", "2", "3", "4", "5", "bird");


### PR DESCRIPTION
 Fix toXWithExpected size overallocating in parallel stream.

This is accomplished by having the `Supplier` preallocate a `Collection`
of full expected size for the first collection allocation in the first thread,
1/2 expected size for the second, 1/3 for the third, etc.

Fixes #211

This reduces the minimum _memory_ allocated when using this in a parallel stream from
Ω(threads \* expectedSize) -> Ω(threads \* H_expectedSize) = Ω(threads \* ln(expectedSize)).
(The worst case memory usage is still O(threads \* expectedSize), but that requires some truly pathological splitting decisions by the backing `Spliterator`, and is a problem the non-sizing logic would have too)

Where Ω is the min asymptotically bounding function (Think O notation but for the min instead of max)
threads is the number of threads the `Stream` will use
expectedSize is the value of the expectedSize parameter given to `toXWithExpectedSize`
and H_n is the nth harmonic number, 1 + 1/2 + 1/3 + ... + 1/n
  For a more familiar complexity comparison, Θ(H_n) = Θ(ln(n)) (Θ is like O notation but bounded above and below)
  as the difference between H_n and ln(n) approaches a constant as n->∞ (the Euler–Mascheroni constant for those interested)

<sub><sub>...What are you talking about, I'm not just flexing math knowledge. <\_< &nbsp; >\_> </sub></sub>

It's certainly not perfect. The 4nd thread isn't assured to be the 4th to allocate for example. And not all Spliterators take a split-by-two approach. But it shouldn't be any worse in performance then not providing a size estimate at all (unless you radically overestimate)