### PR TITLE
Fix FastBufferedOutputStream.close() exception

### DIFF
--- a/src/it/unimi/dsi/fastutil/io/FastBufferedOutputStream.java
+++ b/src/it/unimi/dsi/fastutil/io/FastBufferedOutputStream.java
@@ -125,6 +125,7 @@ public class FastBufferedOutputStream extends MeasurableOutputStream implements 
 	}
 
 	private void dumpBuffer(final boolean ifFull) throws IOException {
+		if (pos == 0) return; // nothing to dump
 		if (! ifFull || avail == 0) {
 			os.write(buffer, 0, pos);
 			pos = 0;


### PR DESCRIPTION
If the output is closed before `FastBufferedOutputStream` is closed, then `close()` would throw because `close()` calls `flush()`, and it would try to write the buffer, even if there's nothing to write, and zero-length `write()` on a closed stream throws in some `OutputStream` implementations.

This can happen if the output is a socket, for example, that is managed separately from the output stream.

Fix by not calling `write()` from `flush()` at all if there is nothing to write.

If the buffer is not empty, then it would still try to write it, and would throw, which is probably correct.