### PR TITLE
Removed excessive init in HeapIndirectPriorityQueue constructor

### DIFF
--- a/drv/HeapIndirectPriorityQueue.drv
+++ b/drv/HeapIndirectPriorityQueue.drv
@@ -51,9 +51,6 @@ public class HEAP_INDIRECT_PRIORITY_QUEUE KEY_GENERIC extends HEAP_SEMI_INDIRECT
 	 */
 	public HEAP_INDIRECT_PRIORITY_QUEUE(KEY_GENERIC_TYPE[] refArray, int capacity, KEY_COMPARATOR KEY_SUPER_GENERIC c) {
 		super(refArray, capacity, c);
-		if (capacity > 0) this.heap = new int[capacity];
-
-		this.c = c;
 
 		this.inv = new int[refArray.length];
 		Arrays.fill(inv, -1);


### PR DESCRIPTION
Hi!

It looks like the work is already done in super constructor