### PR TITLE
faster `HashCommon.nextPowerOf2`

### DIFF
--- a/src/it/unimi/dsi/fastutil/HashCommon.java
+++ b/src/it/unimi/dsi/fastutil/HashCommon.java
@@ -157,13 +157,7 @@ public class HashCommon {
 	 * @return the least power of two greater than or equal to the specified value.
 	 */
 	public static int nextPowerOfTwo(int x) {
-		if (x == 0) return 1;
-		x--;
-		x |= x >> 1;
-		x |= x >> 2;
-		x |= x >> 4;
-		x |= x >> 8;
-		return (x | x >> 16) + 1;
+		return 1 << (32 - Integer.numberOfLeadingZeros(x - 1));
 	}
 
 	/** Returns the least power of two greater than or equal to the specified value.
@@ -174,14 +168,7 @@ public class HashCommon {
 	 * @return the least power of two greater than or equal to the specified value.
 	 */
 	public static long nextPowerOfTwo(long x) {
-		if (x == 0) return 1;
-		x--;
-		x |= x >> 1;
-		x |= x >> 2;
-		x |= x >> 4;
-		x |= x >> 8;
-		x |= x >> 16;
-		return (x | x >> 32) + 1;
+		return 1L << (64 - Long.numberOfLeadingZeros(x - 1));
 	}
 
 


### PR DESCRIPTION
The integer version of this method showed up in a profile, and I was curious enough to look at its implementation. This provides a slightly faster implementation of `HashCommon.nextPowerOf2` which takes advantage of `numberOfLeadingZeros` intrinsics.

I wrote a very simple benchmark to justify the change. While it shows that the existing code is hardly worth optimising, the new code is indeed faster:

```
Benchmark                     Mode  Cnt  Score   Error  Units
NextPowerOf2Benchmark.after   avgt    5  0.553 ± 0.007  ns/op
NextPowerOf2Benchmark.before  avgt    5  0.916 ± 0.002  ns/op
```