### PR TITLE
Fix bug in ImmutableSubList iterator

### DIFF
--- a/drv/ImmutableList.drv
+++ b/drv/ImmutableList.drv
@@ -535,10 +535,10 @@ public class IMMUTABLE_LIST KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENE
 
 		@Override
 		public KEY_LIST_ITERATOR KEY_GENERIC listIterator(final int index) {
-			ensureIndex(index);
+			ensureRestrictedIndex(index + from);
 
 			return new KEY_LIST_ITERATOR KEY_GENERIC() {
-					int pos = index;
+					int pos = index + from;
 
 					@Override
 					public boolean hasNext() { return pos < to; }

--- a/test/it/unimi/dsi/fastutil/ints/IntImmutableListTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntImmutableListTest.java
@@ -239,6 +239,15 @@ public class IntImmutableListTest {
 	}
 
 	@Test
+	public void testSublist_testListIterator() {
+		final IntImmutableList l = IntImmutableList.of(0, 1, 2, 3);
+		final IntList sl = l.subList(1, 3);
+		final IntListIterator li = sl.listIterator(1);
+		assertEquals(2, li.nextInt());
+		assertFalse(li.hasNext());
+	}
+
+	@Test
 	public void testSubList_testSubSubList() {
 		final IntImmutableList l = IntImmutableList.of(0, 1, 2, 3, 4);
 		final IntList sl = l.subList(1, 4);


### PR DESCRIPTION
listIterator() on a sublist needs to correct its index to add "from" to it.