### PR TITLE
`TypeSortedSets.emptySet()` should return `SortedSet`

### DIFF
--- a/drv/SortedSets.drv
+++ b/drv/SortedSets.drv
@@ -125,7 +125,7 @@ public final class SORTED_SETS {
 	 * @return an empty sorted set (immutable).
 	 */
 	@SuppressWarnings("unchecked")
-	public static KEY_GENERIC SET KEY_GENERIC emptySet() {
+	public static KEY_GENERIC SORTED_SET KEY_GENERIC emptySet() {
 		return EMPTY_SET;
 	}
 #endif


### PR DESCRIPTION
Here a quite anoyed small bugfix.