### PR TITLE
Add CI pipeline

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: '8'
+      - name: Make sources
+        run: make sources
+      - name: Run tests
+        run: ant ci-tests

--- a/build.xml
+++ b/build.xml
@@ -276,7 +276,7 @@
 	</target>
 
 	<target name="junit" depends="compile-tests" description="Runs JUnit tests">
-		<junit printsummary="yes" fork="yes" haltonfailure="off"  haltonerror="off">
+		<junit printsummary="yes" fork="yes" haltonfailure="off"  haltonerror="off" failureProperty="tests.failed">
 			<classpath location="${build}"/>
 			<classpath location="${src}"/>
 			<classpath location="lib/junit-4.13.jar"/>
@@ -301,6 +301,12 @@
 			</fileset>
 			<report todir="reports/html"/>
 		</junitreport>
+	</target>
+
+	<target name="ci-tests" depends="junit">
+		<fail if="tests.failed">
+			There are failed tests. Please check the test reports.
+		</fail>
 	</target>
 
 	<!-- ************		CLEAN		********************* -->


### PR DESCRIPTION
Hi, 

I was surfing around and I noticed there is no CI in place. In case you want to add it, here's the contribution :) 

You can find the example here https://github.com/r00ta/fastutil/pull/2 . 

The pipeline can be then improved to upload the tests results in order to get additional information regarding the test failures.

Cheers!