### PR TITLE
Make OpenHashSet a bit more concurrent friendly

### DIFF
--- a/drv/OpenHashSet.drv
+++ b/drv/OpenHashSet.drv
@@ -971,7 +971,13 @@ public class OPEN_HASH_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implemen
 		if (KEY_EQUALS_NULL(KEY_GENERIC_CAST k)) return containsNull;
 
 		KEY_GENERIC_TYPE curr;
-		final KEY_GENERIC_TYPE[] key = this.key;
+		KEY_GENERIC_TYPE[] key = this.key;
+		int mask = this.mask;
+		while ((mask + 2) != key.length) {
+			Thread.yield();
+			key = this.key;
+			mask = this.mask;
+		}
 		int pos;
 
 		// The starting point.


### PR DESCRIPTION
Here a quite trivial reorganization of `OpenHashSet` which allows it to be used on that way:
```
    public static void main(String[] args) {
        LongSet original = new LongOpenHashSet();
        LongSet readOnly = LongSets.unmodifiable(original);
        LongSet writable = LongSets.synchronize(original);

        SplittableRandom random = new SplittableRandom();

        AtomicBoolean failure = new AtomicBoolean();
        new Thread(() -> {
            while (true) {
                try {
                    readOnly.contains(random.nextLong());
                } catch (Throwable th) {
                    failure.set(true);
                    break;
                }
            }
        }).start();
        new Thread(() -> {
            while (!failure.get()) {
                writable.add(random.nextLong());
            }
        }).start();
    }
```

The goal is crash at OutOfMemory, and not because of concurent access.