### PR TITLE
ArrayList iterator back() bug fix, compute remaining correctly

### DIFF
--- a/drv/ArrayList.drv
+++ b/drv/ArrayList.drv
@@ -1001,7 +1001,7 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 				@Override
 				public int back(int n) {
 					if (n < 0) throw new IllegalArgumentException("Argument must be nonnegative: " + n);
-					final int remaining = size - pos;
+					final int remaining = pos;
 					if (n < remaining) {
 						pos -= n;
 					} else {


### PR DESCRIPTION
The current implementation of ArrayList.iterator().back(int n) compute the number of remaining elements wrongly.
It compute `size-pos`, which is correct for the skip(int n) method, but wrong for the back(int n) method.