### PR TITLE
Fix error passing oversized array to PrimitiveImmutableList

### DIFF
--- a/drv/ImmutableList.drv
+++ b/drv/ImmutableList.drv
@@ -274,7 +274,7 @@ public class IMMUTABLE_LIST KEY_GENERIC extends LISTS.ImmutableListBase KEY_GENE
 	@Override
 	public KEY_TYPE[] toArray(KEY_TYPE[] a) {
 		if (a == null || a.length < size()) a = new KEY_TYPE[this.a.length];
-		System.arraycopy(this.a, 0, a, 0, a.length);
+		System.arraycopy(this.a, 0, a, 0, size());
 		return a;
 	}
 #else // KEYS_REFERENCE

--- a/test/it/unimi/dsi/fastutil/ints/IntArrayListTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntArrayListTest.java
@@ -16,6 +16,7 @@
 
 package it.unimi.dsi.fastutil.ints;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -604,5 +605,11 @@ public class IntArrayListTest {
 	@Test
 	public void testZeroLengthToArray() {
 		assertSame(IntArrays.EMPTY_ARRAY, new IntArrayList().toIntArray());
+	}
+
+	@Test
+	public void testOversizedToArray() {
+		final IntArrayList l = IntArrayList.of(0, 1, 2, 3);
+		assertArrayEquals(new int[]{0, 1, 2, 3, 0}, l.toArray(new int[5]));
 	}
 }

--- a/test/it/unimi/dsi/fastutil/ints/IntImmutableListTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntImmutableListTest.java
@@ -439,4 +439,10 @@ public class IntImmutableListTest {
 	public void testZeroLengthToArray() {
 		assertSame(IntArrays.EMPTY_ARRAY, IntImmutableList.of().toIntArray());
 	}
+
+	@Test
+	public void testOversizedToArray() {
+		final IntImmutableList l = IntImmutableList.of(0, 1, 2, 3);
+		assertArrayEquals(new int[]{0, 1, 2, 3, 0}, l.toArray(new int[5]));
+	}
 }


### PR DESCRIPTION
\*ImmutableList for primitives can produce an ArrayIndexOutOfBoundsException via System.arraycopy due to using `a.length` rather than `this.a.length` or `size()` within context of the parameter being named `a` as well.

This also introduces testcases in IntImmutableListTest and IntArrayListTest to ensure that the check does not regress.