### PR TITLE
Add ofEntries static method to Map interfaces

### DIFF
--- a/drv/Map.drv
+++ b/drv/Map.drv
@@ -823,6 +823,41 @@ public interface MAP KEY_VALUE_GENERIC extends FUNCTION KEY_VALUE_GENERIC, Map<K
 
 #endif
 
+	/** Returns an unmodifiable, type-specific map with the specified entries.
+	 * See {@link java.util.Map#ofEntries(Map.Entry[])} */
+#if !KEYS_PRIMITIVE || !VALUES_PRIMITIVE
+	@SafeVarargs
+	@SuppressWarnings({"varargs", "unchecked"})
+#else
+	@SuppressWarnings("varargs")
+#endif
+	static KEY_VALUE_GENERIC MAP KEY_VALUE_GENERIC ofEntries(MAP.Entry KEY_VALUE_GENERIC ... entries) {
+		if (entries.length == 0) return MAPS.EMPTY_MAP;
+		if (entries.length == 1) return MAPS.singleton(entries[0].ENTRY_GET_KEY(), entries[0].ENTRY_GET_VALUE());
+
+		KEY_GENERIC_TYPE[] keys = KEY_GENERIC_ARRAY_CAST new KEY_TYPE[entries.length];
+		VALUE_GENERIC_TYPE[] vals = VALUE_GENERIC_ARRAY_CAST new VALUE_TYPE[entries.length];
+
+		for (int i = 0; i < entries.length; ++i) {
+			MAP.Entry KEY_VALUE_GENERIC entry = entries[i];
+			keys[i] = entry.ENTRY_GET_KEY();
+			// Prevent duplicate keys
+			for (int j = 0; j < i; ++j) if (KEY_EQUALS(keys[j], keys[i])) throw new IllegalArgumentException("duplicate key: " + keys[i]);
+			vals[i] = entry.ENTRY_GET_VALUE();
+		}
+		if (entries.length <= 8) {
+			return MAPS.unmodifiable(new ARRAY_MAP KEY_VALUE_GENERIC_DIAMOND(keys, vals, entries.length));
+		} else {
+			return MAPS.unmodifiable(new OPEN_HASH_MAP KEY_VALUE_GENERIC_DIAMOND(keys, vals, 0.75f));
+		}
+	}
+
+	/** Returns an unmodifiable, type-specific entry.
+	 * See {@link java.util.Map#entry(Object, Object)} */
+	static KEY_VALUE_GENERIC Entry KEY_VALUE_GENERIC entry(KEY_GENERIC_TYPE key, VALUE_GENERIC_TYPE value) {
+    	return new ABSTRACT_MAP.BasicEntry KEY_VALUE_GENERIC_DIAMOND(key, value);
+    }
+
 	/** A type-specific {@link java.util.Map.Entry}; provides some additional methods
 	 *  that use polymorphism to avoid (un)boxing.
 	 *

--- a/drv/Map.drv
+++ b/drv/Map.drv
@@ -835,28 +835,32 @@ public interface MAP KEY_VALUE_GENERIC extends FUNCTION KEY_VALUE_GENERIC, Map<K
 		if (entries.length == 0) return MAPS.EMPTY_MAP;
 		if (entries.length == 1) return MAPS.singleton(entries[0].ENTRY_GET_KEY(), entries[0].ENTRY_GET_VALUE());
 
-		KEY_GENERIC_TYPE[] keys = KEY_GENERIC_ARRAY_CAST new KEY_TYPE[entries.length];
-		VALUE_GENERIC_TYPE[] vals = VALUE_GENERIC_ARRAY_CAST new VALUE_TYPE[entries.length];
-
-		for (int i = 0; i < entries.length; ++i) {
-			MAP.Entry KEY_VALUE_GENERIC entry = entries[i];
-			keys[i] = entry.ENTRY_GET_KEY();
-			// Prevent duplicate keys
-			for (int j = 0; j < i; ++j) if (KEY_EQUALS(keys[j], keys[i])) throw new IllegalArgumentException("duplicate key: " + keys[i]);
-			vals[i] = entry.ENTRY_GET_VALUE();
-		}
 		if (entries.length <= 8) {
+			KEY_GENERIC_TYPE[] keys = KEY_GENERIC_ARRAY_CAST new KEY_TYPE[entries.length];
+			VALUE_GENERIC_TYPE[] vals = VALUE_GENERIC_ARRAY_CAST new VALUE_TYPE[entries.length];
+
+			for (int i = 0; i < entries.length; ++i) {
+				MAP.Entry KEY_VALUE_GENERIC entry = entries[i];
+				keys[i] = entry.ENTRY_GET_KEY();
+				// Prevent duplicate keys
+				for (int j = 0; j < i; ++j) if (KEY_EQUALS(keys[j], keys[i])) throw new IllegalArgumentException("duplicate key: " + keys[i]);
+				vals[i] = entry.ENTRY_GET_VALUE();
+			}
 			return MAPS.unmodifiable(new ARRAY_MAP KEY_VALUE_GENERIC_DIAMOND(keys, vals, entries.length));
 		} else {
-			return MAPS.unmodifiable(new OPEN_HASH_MAP KEY_VALUE_GENERIC_DIAMOND(keys, vals, 0.75f));
+			MAP KEY_VALUE_GENERIC newMap = new OPEN_HASH_MAP KEY_VALUE_GENERIC_DIAMOND(entries.length, 0.75f);
+			for (MAP.Entry KEY_VALUE_GENERIC entry : entries) {
+				if (!VALUE_IS_NULL(newMap.put(entry.ENTRY_GET_KEY(), entry.ENTRY_GET_VALUE()))) throw new IllegalArgumentException("duplicate key: " + entry.ENTRY_GET_KEY());
+			}
+			return MAPS.unmodifiable(newMap);
 		}
 	}
 
 	/** Returns an unmodifiable, type-specific entry.
 	 * See {@link java.util.Map#entry(Object, Object)} */
 	static KEY_VALUE_GENERIC Entry KEY_VALUE_GENERIC entry(KEY_GENERIC_TYPE key, VALUE_GENERIC_TYPE value) {
-    	return new ABSTRACT_MAP.BasicEntry KEY_VALUE_GENERIC_DIAMOND(key, value);
-    }
+		return new ABSTRACT_MAP.BasicEntry KEY_VALUE_GENERIC_DIAMOND(key, value);
+	}
 
 	/** A type-specific {@link java.util.Map.Entry}; provides some additional methods
 	 *  that use polymorphism to avoid (un)boxing.

--- a/test/it/unimi/dsi/fastutil/objects/Object2ObjectMapTest.java
+++ b/test/it/unimi/dsi/fastutil/objects/Object2ObjectMapTest.java
@@ -1,0 +1,27 @@
+package it.unimi.dsi.fastutil.objects;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class Object2ObjectMapTest {
+
+	@Test
+	public void testSmallMaps() {
+		assertTrue(Object2ObjectMap.ofEntries() instanceof Object2ObjectMaps.EmptyMap);
+		assertTrue(Object2ObjectMap.ofEntries(Object2ObjectMap.entry(new Object(), new Object())) instanceof Object2ObjectMaps.Singleton);
+	}
+
+	@Test
+	public void testThrowOnDuplicate() {
+		assertThrows(IllegalArgumentException.class, () -> Object2ObjectMap.ofEntries(
+				Object2ObjectMap.entry("dupe", "foo"),
+				Object2ObjectMap.entry("not a dupe", "bar"),
+				Object2ObjectMap.entry("dupe", "exception")
+				)
+		);
+	}
+
+
+}


### PR DESCRIPTION
Pretty simple PR, I think
Things to note:
- Java doc is a bit quaint because I thought it was useless to copy paste the original methods
- an `entry(key, value)` static method was also added to make it easier to use, just like `java.util.Map`
- I did not include `Int2IntMapTest` because I would have put the same things I did in `Object2ObjectMapTest`
- More tests could probably be added but I have no idea what they could be

Close #329 