### PR TITLE
OpenHashMaps.mergePRIMITIVE: Avoid double-hashing key

### DIFF
--- a/drv/OpenHashMap.drv
+++ b/drv/OpenHashMap.drv
@@ -1253,6 +1253,25 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 		return value[pos] = newVal;
 	}
 
+#if VALUES_PRIMITIVE && ! VALUE_CLASS_Boolean
+	/** {@inheritDoc} */
+	@Override
+	public VALUE_GENERIC_TYPE MERGE_VALUE(final KEY_GENERIC_TYPE k, final VALUE_GENERIC_TYPE v, METHOD_ARG_VALUE_BINARY_OPERATOR remappingFunction) {
+		java.util.Objects.requireNonNull(remappingFunction);
+		REQUIRE_VALUE_NON_NULL(v)
+
+		final int pos = find(k);
+		if (pos < 0) {
+			insert(-pos - 1, k, v);
+			return v;
+		}
+
+		final VALUE_GENERIC_TYPE newValue = remappingFunction.VALUE_OPERATOR_APPLY(value[pos], v);
+
+		return value[pos] = newValue;
+	}
+#endif
+
 	/** {@inheritDoc} */
 	@Override
 	public VALUE_GENERIC_TYPE merge(final KEY_GENERIC_TYPE k, final VALUE_GENERIC_TYPE v, final java.util.function.BiFunction<? super VALUE_GENERIC_CLASS, ? super VALUE_GENERIC_CLASS, ? extends VALUE_GENERIC_CLASS> remappingFunction) {

--- a/test/it/unimi/dsi/fastutil/objects/Object2IntOpenHashMapTest.java
+++ b/test/it/unimi/dsi/fastutil/objects/Object2IntOpenHashMapTest.java
@@ -16,6 +16,7 @@
 
 package it.unimi.dsi.fastutil.objects;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -214,6 +215,24 @@ public class Object2IntOpenHashMapTest {
 	@Test
 	public void testLegacyMainMethodTests() throws Exception {
 		MainRunner.callMainIfExists(Object2IntOpenHashMap.class, "test", /*num=*/"500", /*loadFactor=*/"0.75", /*seed=*/"383454");
+	}
+
+	/** Counts times hashCode() is called, so we can test double-hashing. */
+	private static final class HashCounter {
+		int hashCount = 0;
+		@Override
+		public int hashCode() {
+			hashCount++;
+			return super.hashCode();
+		}
+	}
+
+	@Test
+	public void testMergeIntHashesKeyMultipleTimes() {
+		Object2IntOpenHashMap m = new Object2IntOpenHashMap(Hash.DEFAULT_INITIAL_SIZE);
+		HashCounter hc = new HashCounter();
+		m.mergeInt(hc, 0, Math::max);
+		assertEquals(3, hc.hashCount);
 	}
 }
 

--- a/test/it/unimi/dsi/fastutil/objects/Object2IntOpenHashMapTest.java
+++ b/test/it/unimi/dsi/fastutil/objects/Object2IntOpenHashMapTest.java
@@ -227,12 +227,13 @@ public class Object2IntOpenHashMapTest {
 		}
 	}
 
+	// Regression test for https://github.com/vigna/fastutil/pull/337.
 	@Test
-	public void testMergeIntHashesKeyMultipleTimes() {
+	public void testMergeIntHashesKeyOnce() {
 		Object2IntOpenHashMap m = new Object2IntOpenHashMap(Hash.DEFAULT_INITIAL_SIZE);
 		HashCounter hc = new HashCounter();
 		m.mergeInt(hc, 0, Math::max);
-		assertEquals(3, hc.hashCount);
+		assertEquals(1, hc.hashCount);
 	}
 }
 


### PR DESCRIPTION
The `#if VALUES_PRIMITIVE && ! VALUE_CLASS_Boolean` comes from the superclass in Map.drv: https://github.com/vigna/fastutil/blob/355d8ebfaf2bcc4032cc1c25bec9f3fe827f8175/drv/Map.drv#L649

The implementation mostly is copied from the method below (`merge`), with dead code removed because `VALUES_PRIMITIVE` is always true.

I'm using the `METHOD_ARG_VALUE_BINARY_OPERATOR` so that we prefer using the JDK ${Primitive}BinaryOperator classes, and fall back to the fastutil primitive-BinaryOperators where not present in the JDK.

I ran the junit tests locally and they pass.

Towards #336