### PR TITLE
Implicit narrowing conversion in compound assignment

### DIFF
--- a/src/it/unimi/dsi/fastutil/io/FastBufferedInputStream.java
+++ b/src/it/unimi/dsi/fastutil/io/FastBufferedInputStream.java
@@ -101,7 +101,7 @@ public class FastBufferedInputStream extends MeasurableInputStream implements Re
 	protected byte buffer[];
 
 	/** The current position in the buffer. */
-	protected int pos;
+	protected long pos;
 
 	/** The number of bytes ever read (reset upon a call to {@link #position(long)}).
 	 * In particular, this will always represent the index (in the underlying input stream)


### PR DESCRIPTION
Compound assignment statements of the form x += y or x *= y perform an implicit narrowing conversion if the type of x is narrower than the type of y. For example, x += y is equivalent to x = (T)(x + y), where T is the type of x. This can result in information loss and numeric errors such as overflows.