### PR TITLE
Use static hashCode() methods

### DIFF
--- a/gencsource.sh
+++ b/gencsource.sh
@@ -874,17 +874,17 @@ $(if [[ "${CLASS[$k]}" != "" && "${CLASS[$v]}" != "" ]]; then\
 "#else\n"\
 \
 "#if KEY_CLASS_Float\n"\
-"#define KEY2JAVAHASH_NOT_NULL(x) it.unimi.dsi.fastutil.HashCommon.float2int(x)\n"\
-"#define KEY2INTHASH(x) it.unimi.dsi.fastutil.HashCommon.mix( it.unimi.dsi.fastutil.HashCommon.float2int(x) )\n"\
-"#define KEY2LONGHASH(x) it.unimi.dsi.fastutil.HashCommon.mix( (long)( it.unimi.dsi.fastutil.HashCommon.float2int(x) ) )\n"\
+"#define KEY2JAVAHASH_NOT_NULL(x) Float.hashCode(x)\n"\
+"#define KEY2INTHASH(x) it.unimi.dsi.fastutil.HashCommon.mix( Float.hashCode(x) )\n"\
+"#define KEY2LONGHASH(x) it.unimi.dsi.fastutil.HashCommon.mix( (long)( Float.hashCode(x) ) )\n"\
 "#define INT(x) (x)\n"\
 "#elif KEY_CLASS_Double\n"\
-"#define KEY2JAVAHASH_NOT_NULL(x) it.unimi.dsi.fastutil.HashCommon.double2int(x)\n"\
-"#define KEY2INTHASH(x) (int)it.unimi.dsi.fastutil.HashCommon.mix( Double.doubleToRawLongBits(x) )\n"\
-"#define KEY2LONGHASH(x) it.unimi.dsi.fastutil.HashCommon.mix( Double.doubleToRawLongBits(x) )\n"\
+"#define KEY2JAVAHASH_NOT_NULL(x) Double.hashCode(x)\n"\
+"#define KEY2INTHASH(x) (int)it.unimi.dsi.fastutil.HashCommon.mix( Double.doubleToLongBits(x) )\n"\
+"#define KEY2LONGHASH(x) it.unimi.dsi.fastutil.HashCommon.mix( Double.doubleToLongBits(x) )\n"\
 "#define INT(x) (int)(x)\n"\
 "#elif KEY_CLASS_Long\n"\
-"#define KEY2JAVAHASH_NOT_NULL(x) it.unimi.dsi.fastutil.HashCommon.long2int(x)\n"\
+"#define KEY2JAVAHASH_NOT_NULL(x) Long.hashCode(x)\n"\
 "#define KEY2INTHASH(x) (int)it.unimi.dsi.fastutil.HashCommon.mix( (x) )\n"\
 "#define KEY2LONGHASH(x) it.unimi.dsi.fastutil.HashCommon.mix( (x) )\n"\
 "#define INT(x) (int)(x)\n"\
@@ -936,7 +936,7 @@ $(if [[ "${CLASS[$k]}" != "" && "${CLASS[$v]}" != "" ]]; then\
 \
 "#if VALUE_CLASS_Float || VALUE_CLASS_Double || VALUE_CLASS_Long\n"\
 "#define VALUE_NULL (0)\n"\
-"#define VALUE2JAVAHASH(x) it.unimi.dsi.fastutil.HashCommon.${TYPE[$v]}2int(x)\n"\
+"#define VALUE2JAVAHASH(x) ${TYPE_CAP[$v]}.hashCode(x)\n"\
 "#elif VALUE_CLASS_Boolean\n"\
 "#define VALUE_NULL (false)\n"\
 "#define VALUE2JAVAHASH(x) (x ? 1231 : 1237)\n"\

--- a/src/it/unimi/dsi/fastutil/HashCommon.java
+++ b/src/it/unimi/dsi/fastutil/HashCommon.java
@@ -123,30 +123,33 @@ public class HashCommon {
 	 *
 	 * @param f a float.
 	 * @return the same code as {@link Float#hashCode() new Float(f).hashCode()}.
+	 * @deprecated Use {@link Float#hashCode(float)} instead.
 	 */
-
+        @Deprecated
 	public static int float2int(final float f) {
-		return Float.floatToRawIntBits(f);
+		return Float.hashCode(f);
 	}
 
 	/** Returns the hash code that would be returned by {@link Double#hashCode()}.
 	 *
 	 * @param d a double.
 	 * @return the same code as {@link Double#hashCode() new Double(f).hashCode()}.
+	 * @deprecated Use {@link Double#hashCode(double)} instead.
 	 */
-
+        @Deprecated
 	public static int double2int(final double d) {
-		final long l = Double.doubleToRawLongBits(d);
-		return (int)(l ^ (l >>> 32));
+		return Double.hashCode(d);
 	}
 
 	/** Returns the hash code that would be returned by {@link Long#hashCode()}.
 	 *
 	 * @param l a long.
 	 * @return the same code as {@link Long#hashCode() new Long(f).hashCode()}.
+	 * @deprecated Use {@link Long#hashCode(long)} instead.
 	 */
+        @Deprecated
 	public static int long2int(final long l) {
-		return (int)(l ^ (l >>> 32));
+		return Long.hashCode(l);
 	}
 
 	/** Returns the least power of two greater than or equal to the specified value.


### PR DESCRIPTION
Java 8 added static hashCode() methods like Double.hashCode(double).

https://docs.oracle.com/javase/8/docs/api/java/lang/Double.html#hashCode-double-

These are equivalent to what HashCommon.double2int(double) claims to do

https://javadoc.io/doc/it.unimi.dsi/fastutil/latest/it/unimi/dsi/fastutil/HashCommon.html#double2int(double)

but double2int() uses Double.doubleToRawLongBits(), whereas Double.HashCode() uses Double.doubleToLongBits().  Therefore, also update KEY2INTHASH() and KEY2LONGHASH() to use doubleToLongBits().

Since HashCommon is a public class, I didn't delete the old HashCommon.double2int(), float2int(), and long2int() functions.