### PR TITLE
HeapPriorityQueue.drv + capacity, toArray, toString

### DIFF
--- a/drv/HeapPriorityQueue.drv
+++ b/drv/HeapPriorityQueue.drv
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2003-2024 Paolo Boldi and Sebastiano Vigna
+ * Copyright (C) 2003-2025 Paolo Boldi and Sebastiano Vigna
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 
 package PACKAGE;
 
@@ -29,13 +28,11 @@ import java.util.Iterator;
 import java.util.Collection;
 import java.util.NoSuchElementException;
 
-
 /** A type-specific heap-based priority queue.
  *
  * <p>Instances of this class represent a priority queue using a heap. The heap is enlarged as needed, but
  * it is never shrunk. Use the {@link #trim()} method to reduce its size, if necessary.
  */
-
 public class HEAP_PRIORITY_QUEUE KEY_GENERIC implements PRIORITY_QUEUE KEY_GENERIC, java.io.Serializable {
 	private static final long serialVersionUID = 1L;
 
@@ -278,6 +275,29 @@ public class HEAP_PRIORITY_QUEUE KEY_GENERIC implements PRIORITY_QUEUE KEY_GENER
 		for(int i = 0; i < size; i++) heap[i] = KEY_GENERIC_CAST s.READ_KEY();
 	}
 
+	/** Returns the physical capacity of the queue (internal array). */
+	public int capacity() {
+		return heap.length;
+	}
+
+	/** @see java.util.Collection#toArray() */
+	public KEY_GENERIC_TYPE[] toArray() {
+		return ARRAYS.copy(heap, 0, size());
+	}
+
+	@Override
+	public String toString() {
+		int iMax = size() - 1;
+		if (iMax == -1) return "[]";
+		StringBuilder sb = new StringBuilder(iMax*9+9).append('[');
+		for (int i = 0; ; i++){
+			sb.append(heap[i]);
+			if (i == iMax){
+				return sb.append(']').toString();
+			}
+			sb.append(", ");
+		}
+	}
 
 #ifdef TEST
 


### PR DESCRIPTION
For consistency between FIFO and Heap queues: 

I have added the same methods (capacity, toArray, toString) also for Heap Priority Queues.

Results of toArray, toString are not sorted (for implementation simplicity and performance)