### PR TITLE
Fix null handling in putIfAbsent and computeIfAbsent

### DIFF
--- a/drv/OpenHashMap.drv
+++ b/drv/OpenHashMap.drv
@@ -1110,7 +1110,15 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 	@Override
 	public VALUE_GENERIC_TYPE putIfAbsent(final KEY_GENERIC_TYPE k, final VALUE_GENERIC_TYPE v) {
 		final int pos = find(k);
-		if (pos >= 0) return value[pos];
+		if (pos >= 0) {
+	#if VALUES_REFERENCE
+            if (value[pos] == null) {
+                value[pos] = v;
+                return null;
+            }
+    #endif
+		    return value[pos];
+		}
 		insert(-pos - 1, k, v);
 		return defRetValue;
 	}
@@ -1186,7 +1194,15 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 	public VALUE_GENERIC_TYPE computeIfAbsent(final KEY_GENERIC_TYPE key, final FUNCTION KEY_SUPER_GENERIC_VALUE_EXTENDS_GENERIC mappingFunction) {
 		java.util.Objects.requireNonNull(mappingFunction);
 		final int pos = find(key);
-		if (pos >= 0) return value[pos];
+		if (pos >= 0) {
+    #if VALUES_REFERENCE
+        	 if (value[pos] == null) {
+        		 if (!mappingFunction.containsKey(key)) return defRetValue;
+        		 return value[pos] = mappingFunction.GET_VALUE(key);
+        	 }
+    #endif
+        	 return value[pos];
+        }
 
 		if (!mappingFunction.containsKey(key)) return defRetValue;
 		final VALUE_GENERIC_TYPE newValue = mappingFunction.GET_VALUE(key);

--- a/test/it/unimi/dsi/fastutil/objects/Object2ObjectOpenHashMapTest.java
+++ b/test/it/unimi/dsi/fastutil/objects/Object2ObjectOpenHashMapTest.java
@@ -59,4 +59,22 @@ public class Object2ObjectOpenHashMapTest {
 		assertNull(map.computeIfPresent("def", (a, b) -> "four"));
 		assertFalse(map.containsKey("def"));
 	}
+
+    @Test
+    public void testPutIfAbsentReplacesNullValue() {
+        final Object2ObjectOpenHashMap<String, String> map = new Object2ObjectOpenHashMap<>();
+        map.put("a", null);
+
+        assertNull(map.putIfAbsent("a", "b"));
+        assertEquals("b", map.get("a"));
+    }
+
+    @Test
+    public void testComputeIfAbsentReplacesNullValue() {
+        final Object2ObjectOpenHashMap<String, String> map = new Object2ObjectOpenHashMap<>();
+        map.put("a", null);
+
+        assertEquals("b", map.computeIfAbsent("a", key -> "b"));
+        assertEquals("b", map.get("a"));
+    }
 }


### PR DESCRIPTION
## Summary

Handle existing null-valued mappings in `putIfAbsent` and
`computeIfAbsent` for reference-valued open hash maps.

Previously, when a key was already mapped to `null`, both methods
returned the existing null value without applying the behavior expected
for a null mapping.

This change:

- makes `putIfAbsent` replace an existing null value with the supplied value
- makes `computeIfAbsent` compute a value when the existing mapping is null

## Tests

Added regression tests to `Object2ObjectOpenHashMapTest` covering:

- `putIfAbsent` replacing an existing null value
- `computeIfAbsent` computing a value for an existing null mapping

Addresses #280